### PR TITLE
all-your-base: update to v1.1.0 of tests

### DIFF
--- a/exercises/all-your-base/src/test/java/BaseConverterTest.java
+++ b/exercises/all-your-base/src/test/java/BaseConverterTest.java
@@ -7,6 +7,9 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertArrayEquals;
 
+/*
+ * version: 1.1.0
+ */
 public class BaseConverterTest {
 
     /*
@@ -197,6 +200,33 @@ public class BaseConverterTest {
 
     @Ignore("Remove to run test")
     @Test
+    public void testFirstBaseIsOne() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Bases must be at least 2.");
+
+        new BaseConverter(1, new int[]{});
+    }
+
+    @Ignore("Remove to run test")
+    @Test
+    public void testFirstBaseIsZero() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Bases must be at least 2.");
+
+        new BaseConverter(0, new int[]{});
+    }
+
+    @Ignore("Remove to run test")
+    @Test
+    public void testFirstBaseIsNegative() {
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Bases must be at least 2.");
+
+        new BaseConverter(-2, new int[]{});
+    }
+
+    @Ignore("Remove to run test")
+    @Test
     public void testNegativeDigit() {
         expectedException.expect(IllegalArgumentException.class);
         expectedException.expectMessage("Digits may not be negative.");
@@ -215,15 +245,6 @@ public class BaseConverterTest {
 
     @Ignore("Remove to run test")
     @Test
-    public void testFirstBaseIsOne() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Bases must be at least 2.");
-
-        new BaseConverter(1, new int[]{});
-    }
-
-    @Ignore("Remove to run test")
-    @Test
     public void testSecondBaseIsOne() {
         final BaseConverter baseConverter = new BaseConverter(2, new int[]{1, 0, 1, 0, 1, 0});
 
@@ -235,15 +256,6 @@ public class BaseConverterTest {
 
     @Ignore("Remove to run test")
     @Test
-    public void testFirstBaseIsZero() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Bases must be at least 2.");
-
-        new BaseConverter(0, new int[]{});
-    }
-
-    @Ignore("Remove to run test")
-    @Test
     public void testSecondBaseIsZero() {
         final BaseConverter baseConverter = new BaseConverter(2, new int[]{1, 0, 1, 0, 1, 0});
 
@@ -251,15 +263,6 @@ public class BaseConverterTest {
         expectedException.expectMessage("Bases must be at least 2.");
 
         baseConverter.convertToBase(0);
-    }
-
-    @Ignore("Remove to run test")
-    @Test
-    public void testFirstBaseIsNegative() {
-        expectedException.expect(IllegalArgumentException.class);
-        expectedException.expectMessage("Bases must be at least 2.");
-
-        new BaseConverter(-2, new int[]{});
     }
 
     @Ignore("Remove to run test")


### PR DESCRIPTION
<!-- Your content goes here: -->

Closes #519.

[v1.1.0 of the tests](https://github.com/exercism/x-common/blob/c4d8d95bf53112d0dc39f6d66956b1c983d5fea3/exercises/all-your-base/canonical-data.json).

I chose to skip the x-common test case "both bases are negative" since
the xjava implementation of this exercise forces the first base to be
validated before a second base can be supplied. This test would
therefore be redundant since we already have tests that validate the
first base.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
