### PR TITLE
difference-of-squares: return doubles

### DIFF
--- a/exercises/difference-of-squares/src/example/java/DifferenceOfSquaresCalculator.java
+++ b/exercises/difference-of-squares/src/example/java/DifferenceOfSquaresCalculator.java
@@ -2,18 +2,19 @@ import java.util.stream.IntStream;
 
 final class DifferenceOfSquaresCalculator {
 
-    int computeSquareOfSumTo(final int input) {
-        final int sum = input * (input + 1) / 2;
-        return (int) Math.pow(sum, 2);
+    double computeSquareOfSumTo(final int input) {
+        final double sum = input * (input + 1) / 2;
+        return Math.pow(sum, 2);
     }
 
-    int computeSumOfSquaresTo(final int input) {
+    double computeSumOfSquaresTo(final int input) {
         return IntStream.rangeClosed(1, input)
-                .map(i -> (int) Math.pow(i, 2))
+                .mapToDouble(value -> value)
+                .map(i -> Math.pow(i, 2))
                 .sum();
     }
 
-    int computeDifferenceOfSquares(final int input) {
+    double computeDifferenceOfSquares(final int input) {
         return computeSquareOfSumTo(input) - computeSumOfSquaresTo(input);
     }
 

--- a/exercises/difference-of-squares/src/test/java/DifferenceOfSquaresCalculatorTest.java
+++ b/exercises/difference-of-squares/src/test/java/DifferenceOfSquaresCalculatorTest.java
@@ -5,9 +5,12 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 /*
- * version: 1.1.0
+ * version: 1.1.0, plus tests that exercise double return values
  */
 public class DifferenceOfSquaresCalculatorTest {
+
+    // This is sufficient accuracy since we're expecting doubles that represent integer values.
+    private static final double EQUALITY_TOLERANCE = 0.1;
 
     private DifferenceOfSquaresCalculator calculator;
 
@@ -18,73 +21,89 @@ public class DifferenceOfSquaresCalculatorTest {
 
     @Test
     public void testSquareOfSum1() {
-        final int expected = 1;
-        final int actual = calculator.computeSquareOfSumTo(1);
-        assertEquals(expected, actual);
+        final double expected = 1;
+        final double actual = calculator.computeSquareOfSumTo(1);
+        assertEquals(expected, actual, EQUALITY_TOLERANCE);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSquareOfSum5() {
-        final int expected = 225;
-        final int actual = calculator.computeSquareOfSumTo(5);
-        assertEquals(expected, actual);
+        final double expected = 225;
+        final double actual = calculator.computeSquareOfSumTo(5);
+        assertEquals(expected, actual, EQUALITY_TOLERANCE);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSquareOfSum100() {
-        final int expected = 25502500;
-        final int actual = calculator.computeSquareOfSumTo(100);
-        assertEquals(expected, actual);
+        final double expected = 25502500;
+        final double actual = calculator.computeSquareOfSumTo(100);
+        assertEquals(expected, actual, EQUALITY_TOLERANCE);
+    }
+
+    @Ignore("Remove to run test")
+    @Test
+    public void testSquareOfSum2000() {
+        final double expected = 4004001000000d;
+        final double actual = calculator.computeSquareOfSumTo(2000);
+        assertEquals(expected, actual, EQUALITY_TOLERANCE);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSumOfSquares1() {
-        final int expected = 1;
-        final int actual = calculator.computeSumOfSquaresTo(1);
-        assertEquals(expected, actual);
+        final double expected = 1;
+        final double actual = calculator.computeSumOfSquaresTo(1);
+        assertEquals(expected, actual, EQUALITY_TOLERANCE);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSumOfSquares5() {
-        final int expected = 55;
-        final int actual = calculator.computeSumOfSquaresTo(5);
-        assertEquals(expected, actual);
+        final double expected = 55;
+        final double actual = calculator.computeSumOfSquaresTo(5);
+        assertEquals(expected, actual, EQUALITY_TOLERANCE);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSumOfSquares100() {
-        final int expected = 338350;
-        final int actual = calculator.computeSumOfSquaresTo(100);
-        assertEquals(expected, actual);
+        final double expected = 338350;
+        final double actual = calculator.computeSumOfSquaresTo(100);
+        assertEquals(expected, actual, EQUALITY_TOLERANCE);
+    }
+
+    @Ignore("Remove to run test")
+    @Test
+    public void testSumOfSquares2000() {
+        final double expected = 2668667000d;
+        final double actual = calculator.computeSumOfSquaresTo(2000);
+        assertEquals(expected, actual, EQUALITY_TOLERANCE);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testDifferenceOfSquares1() {
-        final int expected = 0;
-        final int actual = calculator.computeDifferenceOfSquares(1);
-        assertEquals(expected, actual);
+        final double expected = 0;
+        final double actual = calculator.computeDifferenceOfSquares(1);
+        assertEquals(expected, actual, EQUALITY_TOLERANCE);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testDifferenceOfSquares5() {
-        final int expected = 170;
-        final int actual = calculator.computeDifferenceOfSquares(5);
-        assertEquals(expected, actual);
+        final double expected = 170;
+        final double actual = calculator.computeDifferenceOfSquares(5);
+        assertEquals(expected, actual, EQUALITY_TOLERANCE);
     }
 
     @Ignore("Remove to run test")
     @Test
-    public void testDifferenceOfSquares100() {
-        final int expected = 25164150;
-        final int actual = calculator.computeDifferenceOfSquares(100);
-        assertEquals(expected, actual);
+    public void testDifferenceOfSquares2000() {
+        final double expected = 4001332333000d;
+        final double actual = calculator.computeDifferenceOfSquares(2000);
+        assertEquals(expected, actual, EQUALITY_TOLERANCE);
     }
 
 }


### PR DESCRIPTION
<!-- Your content goes here: -->

Closes #331.

Matches [v1.1.0 of the canonical tests](https://github.com/exercism/x-common/blob/7a1108b24e06142495e135a15317a3b76769026e/exercises/difference-of-squares/canonical-data.json), and adds test cases with input 2000 (which exercises the `double` return type of the adjusted methods).

I will suggest this change upstream, but since it exercises something that may be type system specific, I wouldn't be surprised if it isn't accepted there.

I think this is a valuable change since it follows the pattern established by other Java math functions.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
