### PR TITLE
Fix link to contributing guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Source for Exercism Exercises in Java.
 
 ## Contributing Guide
 
-For general information about how to contribute to Exercism, please refer to the [Contributing Guide](https://github.com/exercism/x-api/blob/master/CONTRIBUTING.md#the-exercise-data).
+For general information about how to contribute to Exercism, please refer to the [Contributing Guide](https://github.com/exercism/docs/blob/master/contributing-to-language-tracks).
 
 ## Table of Contents
 


### PR DESCRIPTION
The link was pointing to a not very helpful page in the x-api repo.
It's now pointing to the contributing guide in the docs repo.

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
