### PR TITLE
Standardize order of test annotations

### DIFF
--- a/POLICIES.md
+++ b/POLICIES.md
@@ -48,7 +48,7 @@ References: [[1](https://github.com/exercism/java/issues/178)]
 
 ### Ignore noninitial tests
 
-> All but the first test in an exercise test suite should be annotated `@Ignore("Remove to run test")` (single test) or `@Ignore("Remove to run tests")` (parametrized test).
+> All but the first test in an exercise test suite should add `@Ignore("Remove to run test")` (single test) or `@Ignore("Remove to run tests")` (parametrized test) on the line before the corresponding `@Test` annotation.
 
 References: [[1](https://github.com/exercism/java/issues/101#issuecomment-249349204)]
 

--- a/exercises/binary-search-tree/src/test/java/BSTTest.java
+++ b/exercises/binary-search-tree/src/test/java/BSTTest.java
@@ -20,8 +20,8 @@ public class BSTTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void insertsLess() {
         BST<Integer> bst = new BST();
         final int expectedRoot = 4;
@@ -41,8 +41,8 @@ public class BSTTest {
         assertEquals(expectedRoot, actualRoot);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void insertsSame() {
         BST<Integer> bst = new BST();
         final int expectedRoot = 4;
@@ -62,8 +62,8 @@ public class BSTTest {
         assertEquals(expectedRoot, actualRoot);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void insertsRight() {
         BST<Integer> bst = new BST();
         final int expectedRoot = 4;
@@ -83,8 +83,8 @@ public class BSTTest {
         assertEquals(expectedRoot, actualRoot);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void createsComplexTree() {
         BST<Integer> bst = new BST<>();
         List<Integer> expected = Collections.unmodifiableList(
@@ -100,8 +100,8 @@ public class BSTTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void sortsSingleElement() {
         BST<Integer> bst = new BST<>();
         List<Integer> expected = Collections.unmodifiableList(
@@ -114,8 +114,8 @@ public class BSTTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void sortsCollectionOfTwoIfSecondInsertedIsSmallerThanFirst() {
         BST<Integer> bst = new BST<>();
         List<Integer> expected = Collections.unmodifiableList(
@@ -129,8 +129,8 @@ public class BSTTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void sortsCollectionOfTwoIfSecondInsertedIsBiggerThanFirst() {
         BST<Integer> bst = new BST<>();
         List<Integer> expected = Collections.unmodifiableList(
@@ -144,8 +144,8 @@ public class BSTTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void iteratesOverComplexTree() {
         BST<Integer> bst = new BST<>();
         List<Integer> expected = Collections.unmodifiableList(

--- a/exercises/custom-set/src/test/java/CustomSetTest.java
+++ b/exercises/custom-set/src/test/java/CustomSetTest.java
@@ -17,8 +17,8 @@ public class CustomSetTest {
         assertTrue(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void setsWithElementsAreNotEmpty() {
         final boolean actual
                 = new CustomSet<>(Arrays.asList(1))
@@ -27,8 +27,8 @@ public class CustomSetTest {
         assertFalse(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void nothingIsContainedInAnEmptySet() {
         final boolean actual
                 = new CustomSet<>(Collections.EMPTY_LIST)
@@ -37,8 +37,8 @@ public class CustomSetTest {
         assertFalse(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void whenTheElementIsInTheSet() {
         final boolean actual
                 = new CustomSet<>(Arrays.asList(1, 2, 3))
@@ -47,8 +47,8 @@ public class CustomSetTest {
         assertTrue(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void whenTheElementIsNotInTheSet() {
         final boolean actual
                 = new CustomSet<>(Arrays.asList(1, 2, 3))
@@ -57,8 +57,8 @@ public class CustomSetTest {
         assertFalse(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void emptySetIsASubsetOfAnotherEmptySet() {
         final boolean actual
                 = new CustomSet<>(Collections.EMPTY_LIST)
@@ -69,8 +69,8 @@ public class CustomSetTest {
         assertTrue(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void emptySetIsASubsetOfNonEemptySet() {
         final boolean actual
                 = new CustomSet<>(Arrays.asList(1))
@@ -81,8 +81,8 @@ public class CustomSetTest {
         assertTrue(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void nonEmptySetIsNotASubsetOfEmptySet() {
         final boolean actual
                 = new CustomSet<>(Collections.EMPTY_LIST)
@@ -93,8 +93,8 @@ public class CustomSetTest {
         assertFalse(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void setIsASubsetOfSetWithExactSameElements() {
         final boolean actual
                 = new CustomSet<>(Arrays.asList(1, 2, 3))
@@ -105,8 +105,8 @@ public class CustomSetTest {
         assertTrue(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void setIsASubsetOfLargerSetWithSameElements() {
         final boolean actual
                 = new CustomSet<>(Arrays.asList(4, 1, 2, 3))
@@ -117,8 +117,8 @@ public class CustomSetTest {
         assertTrue(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void setIsNotASubsetOfSetThatDoesNotContainItsElements() {
         final boolean actual
                 = new CustomSet<>(Arrays.asList(4, 1, 3))
@@ -129,8 +129,8 @@ public class CustomSetTest {
         assertFalse(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void theEmptySetIsDisjointWithItself() {
         final boolean actual
                 = new CustomSet<>(Collections.EMPTY_LIST)
@@ -141,8 +141,8 @@ public class CustomSetTest {
         assertTrue(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void emptySetIsDisjointWithNonEmptySet() {
         final boolean actual
                 = new CustomSet<>(Collections.EMPTY_LIST)
@@ -153,8 +153,8 @@ public class CustomSetTest {
         assertTrue(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void nonEmptySetIsDisjointWithEmptySet() {
         final boolean actual
                 = new CustomSet<>(Arrays.asList(1))
@@ -165,8 +165,8 @@ public class CustomSetTest {
         assertTrue(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void setsAreNotDisjointIfTheyShareAnElement() {
         final boolean actual
                 = new CustomSet<>(Arrays.asList(1, 2))
@@ -177,8 +177,8 @@ public class CustomSetTest {
         assertFalse(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void setsAreDisjointIfTheyShareNoElements() {
         final boolean actual
                 = new CustomSet<>(Arrays.asList(1, 2))
@@ -189,8 +189,8 @@ public class CustomSetTest {
         assertTrue(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void emptySetsAreEqual() {
         final boolean actual
                 = new CustomSet<>(Collections.EMPTY_LIST)
@@ -201,8 +201,8 @@ public class CustomSetTest {
         assertTrue(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void emptySetIsNotEqualToNonEmptySet() {
         final boolean actual
                 = new CustomSet<>(Collections.EMPTY_LIST)
@@ -213,8 +213,8 @@ public class CustomSetTest {
         assertFalse(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void nonEmptySetIsNotEqualToEmptySet() {
         final boolean actual
                 = new CustomSet<>(Arrays.asList(1, 2, 3))
@@ -225,8 +225,8 @@ public class CustomSetTest {
         assertFalse(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void setsWithTheSameElementsAreEqual() {
         final boolean actual
                 = new CustomSet<>(Arrays.asList(1, 2))
@@ -237,8 +237,8 @@ public class CustomSetTest {
         assertTrue(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void setsWithDifferentElementsAreNotEqual() {
         final boolean actual
                 = new CustomSet<>(Arrays.asList(1, 2, 3))
@@ -249,8 +249,8 @@ public class CustomSetTest {
         assertFalse(actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void addToEmptySet() {
         final int element = 3;
         final CustomSet<Integer> expected
@@ -267,8 +267,8 @@ public class CustomSetTest {
         assertTrue(expected.equals(actual));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void addToNonEmptySet() {
         final int element = 3;
         final CustomSet<Integer> expected
@@ -285,8 +285,8 @@ public class CustomSetTest {
         assertTrue(expected.equals(actual));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void addingAnExistingElementDoesNotChangeTheSet() {
         final int element = 3;
         final CustomSet<Integer> expected
@@ -302,8 +302,8 @@ public class CustomSetTest {
         assertTrue(expected.equals(actual));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void intersectionOfTwoEmptySetsIsAnEmptySet() {
         final CustomSet<Integer> actual
                 = new CustomSet<>(Collections.EMPTY_LIST)
@@ -315,8 +315,8 @@ public class CustomSetTest {
         assertTrue(actual.isEmpty());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void intersectionOfAnEmptySetAndNonEmptySetIsAnEmptySet() {
         final CustomSet<Integer> actual
                 = new CustomSet<>(Collections.EMPTY_LIST)
@@ -328,8 +328,8 @@ public class CustomSetTest {
         assertTrue(actual.isEmpty());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void intersectionOfANonEmptySetAndAnEmptySetIsAnEmptySet() {
         final CustomSet<Integer> actual
                 = new CustomSet<>(Arrays.asList(1, 2, 3, 4))
@@ -342,8 +342,8 @@ public class CustomSetTest {
 
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void intersectionOfTwoSetsWithNoSharedElementsIsAnEmptySet() {
         final CustomSet<Integer> actual
                 = new CustomSet<>(Arrays.asList(1, 2, 3))
@@ -355,8 +355,8 @@ public class CustomSetTest {
         assertTrue(actual.isEmpty());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void intersectionOfTwoSetsWithSharedElementsIsASetOfTheSharedElements() {
         final CustomSet<Integer> expected
                 = new CustomSet<>(
@@ -373,8 +373,8 @@ public class CustomSetTest {
         assertTrue(expected.equals(actual));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void differenceOfTwoEmptySetsIsAnEmptySet() {
         final CustomSet<Integer> actual
                 = new CustomSet<>(Collections.EMPTY_LIST)
@@ -386,8 +386,8 @@ public class CustomSetTest {
         assertTrue(actual.isEmpty());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void differenceOfAnEmptySetAndNonEmptySetIsAnEmptySet() {
         final CustomSet<Integer> actual
                 = new CustomSet<>(Collections.EMPTY_LIST)
@@ -399,8 +399,8 @@ public class CustomSetTest {
         assertTrue(actual.isEmpty());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void differenceOfANonEmptySetAndAnEmptySetIsTheNonEmptySet() {
         final CustomSet<Integer> expected
                 = new CustomSet<>(
@@ -417,8 +417,8 @@ public class CustomSetTest {
         assertTrue(expected.equals(actual));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void differenceOfTwoNonEmptySetsIsASetOfElementsThatAreOnlyInTheFirstSet() {
         final CustomSet<Integer> expected
                 = new CustomSet<>(
@@ -435,8 +435,8 @@ public class CustomSetTest {
         assertTrue(expected.equals(actual));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void unionOfTwoEmptySetsIsAnEmptySet() {
         final CustomSet<Integer> actual
                 = new CustomSet<>(Collections.EMPTY_LIST)
@@ -448,8 +448,8 @@ public class CustomSetTest {
         assertTrue(actual.isEmpty());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void unionOfAnEmptySetAndNonEmptySetIsTheNonEmptySet() {
         final CustomSet<Integer> expected
                 = new CustomSet<>(
@@ -466,8 +466,8 @@ public class CustomSetTest {
         assertTrue(expected.equals(actual));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void unionOfANonEmptySetAndAnEmptySetIsTheNonEmptySet() {
         final CustomSet<Integer> expected
                 = new CustomSet<>(
@@ -484,8 +484,8 @@ public class CustomSetTest {
         assertTrue(expected.equals(actual));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void unionOfTwoNonEmptySetsContainsAllUniqueElements() {
         final CustomSet<Integer> expected
                 = new CustomSet<>(

--- a/exercises/palindrome-products/src/test/java/PalindromeCalculatorTest.java
+++ b/exercises/palindrome-products/src/test/java/PalindromeCalculatorTest.java
@@ -35,8 +35,8 @@ public class PalindromeCalculatorTest {
         checkPalindromeWithFactorsMatchesExpected(expected, expectedValue, palindromes, palindromes.lastKey());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void largestPalindromeFromDoubleDigitFactors() {
         final List<List<Integer>> expected = Collections.unmodifiableList(
                 Arrays.asList(
@@ -50,8 +50,8 @@ public class PalindromeCalculatorTest {
         checkPalindromeWithFactorsMatchesExpected(expected, expectedValue, palindromes, palindromes.lastKey());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void smallestPalindromeFromDoubleDigitFactors() {
         final List<List<Integer>> expected = Collections.unmodifiableList(
                 Arrays.asList(
@@ -65,8 +65,8 @@ public class PalindromeCalculatorTest {
         checkPalindromeWithFactorsMatchesExpected(expected, expectedValue, palindromes, palindromes.firstKey());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void largestPalindromeFromTripleDigitFactors() {
         final List<List<Integer>> expected = Collections.unmodifiableList(
                 Arrays.asList(
@@ -80,8 +80,8 @@ public class PalindromeCalculatorTest {
         checkPalindromeWithFactorsMatchesExpected(expected, expectedValue, palindromes, palindromes.lastKey());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void smallestPalindromeFromTripleDigitFactors() {
         final List<List<Integer>> expected = Collections.unmodifiableList(
                 Arrays.asList(

--- a/exercises/poker/src/test/java/PokerTest.java
+++ b/exercises/poker/src/test/java/PokerTest.java
@@ -13,64 +13,64 @@ public class PokerTest {
         assertEquals(Arrays.asList(hand),new Poker(Arrays.asList(hand)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void nothingVsOnePair() {
         final String nothing = "4S 5H 6S 8D JH";
         final String pairOf4 = "2S 4H 6S 4D JH";
         assertEquals(Arrays.asList(pairOf4),new Poker(Arrays.asList(nothing, pairOf4)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void twoPairs() {
         final String pairOf2 = "4S 2H 6S 2D JH";
         final String pairOf4 = "2S 4H 6S 4D JH";
         assertEquals(Arrays.asList(pairOf4), new Poker(Arrays.asList(pairOf2,pairOf4)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void onePairVsDoublePair() {
         final String pairOf8 = "2S 8H 6S 8D JH";
         final String doublePair = "4S 5H 4S 8D 5H";
         assertEquals(Arrays.asList(doublePair),  new Poker(Arrays.asList(pairOf8, doublePair)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void twoDoublePairs() {
         final String doublePair2And8 = "2S 8H 2S 8D JH";
         final String doublePair4And5 = "4S 5H 4S 8D 5H";
         assertEquals(Arrays.asList(doublePair2And8), new Poker(Arrays.asList(doublePair2And8, doublePair4And5)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void doublePairVsThree() {
         final String doublePair2And8 = "2S 8H 2S 8D JH";
         final String threeOf4 = "4S 5H 4S 8D 4H";
         assertEquals(Arrays.asList(threeOf4 ), new Poker(Arrays.asList(doublePair2And8, threeOf4)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void twoThrees() {
         final String threeOf2 = "2S 2H 2S 8D JH";
         final String threeOf1 = "4S AH AS 8D AH";
         assertEquals(Arrays.asList(threeOf1), new Poker(Arrays.asList(threeOf2, threeOf1)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void threeVsStraight() {
         final String threeOf4 = "4S 5H 4S 8D 4H";
         final String straight = "3S 4H 2S 6D 5H";
         assertEquals(Arrays.asList(straight), new Poker(Arrays.asList(threeOf4, straight)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void twoStraights() {
         final String straightTo8 = "4S 6H 7S 8D 5H";
         final String straightTo9 = "5S 7H 8S 9D 6H";
@@ -81,72 +81,72 @@ public class PokerTest {
         assertEquals(Arrays.asList(straightTo1), new Poker(Arrays.asList(straightTo1, straightTo5)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void straightVsFlush() {
         final String straightTo8 = "4S 6H 7S 8D 5H";
         final String flushTo7 = "2S 4S 5S 6S 7S";
         assertEquals(Arrays.asList(flushTo7 ), new Poker(Arrays.asList(straightTo8, flushTo7)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void twoFlushes() {
         final String flushTo8 = "3H 6H 7H 8H 5H";
         final String flushTo7 = "2S 4S 5S 6S 7S";
         assertEquals(Arrays.asList(flushTo8), new Poker(Arrays.asList(flushTo8, flushTo7)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void flushVsFull() {
         final String flushTo8 = "3H 6H 7H 8H 5H";
         final String full = "4S 5H 4S 5D 4H";
         assertEquals(Arrays.asList(full ), new Poker(Arrays.asList(full, flushTo8)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void twoFulls() {
         final String fullOf4By9 = "4H 4S 4D 9S 9D";
         final String fullOf5By8 = "5H 5S 5D 8S 8D";
         assertEquals(Arrays.asList(fullOf5By8 ), new Poker(Arrays.asList(fullOf4By9, fullOf5By8)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void fullVsSquare() {
         final String full = "4S 5H 4S 5D 4H";
         final String squareOf3 = "3S 3H 2S 3D 3H";
         assertEquals(Arrays.asList(squareOf3 ), new Poker(Arrays.asList(full, squareOf3)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void twoSquares() {
         final String squareOf2 = "2S 2H 2S 8D 2H";
         final String squareOf5 = "4S 5H 5S 5D 5H";
         assertEquals(Arrays.asList(squareOf5), new Poker(Arrays.asList(squareOf2, squareOf5)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void squareVsStraightFlush() {
         final String squareOf5 = "4S 5H 5S 5D 5H";
         final String straightFlushTo9 = "5S 7S 8S 9S 6S";
         assertEquals(Arrays.asList(straightFlushTo9 ), new Poker(Arrays.asList(squareOf5, straightFlushTo9)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void twoStraightFlushes() {
         final String straightFlushTo8 = "4H 6H 7H 8H 5H";
         final String straightFlushTo9 = "5S 7S 8S 9S 6S";
         assertEquals(Arrays.asList(straightFlushTo9 ), new Poker(Arrays.asList(straightFlushTo8, straightFlushTo9)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void threeHandWithTie() {
         final String spadeStraightTo9 = "9S 8S 7S 6S 5S";
         final String diamondStraightTo9 = "9D 8D 7D 6D 5D";
@@ -154,8 +154,8 @@ public class PokerTest {
         assertEquals(Arrays.asList(spadeStraightTo9, diamondStraightTo9), new Poker(Arrays.asList(spadeStraightTo9, diamondStraightTo9, threeOf4)).getBestHands());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void straightTo5AgainstAPairOfJacks() {
         final String straightTo5 = "2S 4D 5C 3S AS";
         final String twoJacks = "JD 8D 7D JC 5D";

--- a/exercises/pythagorean-triplet/src/test/java/PythagoreanTripletTest.java
+++ b/exercises/pythagorean-triplet/src/test/java/PythagoreanTripletTest.java
@@ -20,8 +20,8 @@ public class PythagoreanTripletTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void shouldCalculateProduct() {
         PythagoreanTriplet triplet = new PythagoreanTriplet(3, 4, 5);
         final long expected = 60l;
@@ -29,22 +29,22 @@ public class PythagoreanTripletTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void testIsPythagoreanOK() {
         PythagoreanTriplet triplet = new PythagoreanTriplet(3, 4, 5);
         assertTrue(triplet.isPythagorean());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void testIsPythagoreanFail() {
         PythagoreanTriplet triplet = new PythagoreanTriplet(5, 6, 7);
         assertFalse(triplet.isPythagorean());
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void shouldMakeTripletsUpToTen() {
         final List<Long> actual
                 = PythagoreanTriplet
@@ -59,8 +59,8 @@ public class PythagoreanTripletTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void shouldMakeTripletsElevenToTwenty() {
         final List<Long> actual
                 = PythagoreanTriplet
@@ -76,8 +76,8 @@ public class PythagoreanTripletTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void shouldMakeTripletsAndFilterOnSum() {
         final List<Long> actual
                 = PythagoreanTriplet

--- a/exercises/series/src/test/java/SeriesTest.java
+++ b/exercises/series/src/test/java/SeriesTest.java
@@ -25,8 +25,8 @@ public class SeriesTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void hasDigitsLong() {
         Series series = new Series("0123456789");
         List<Integer> expected = Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
@@ -36,8 +36,8 @@ public class SeriesTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void keepsTheDigitOrderIfReversed() {
         Series series = new Series("9876543210");
         List<Integer> expected = Arrays.asList(9, 8, 7, 6, 5, 4, 3, 2, 1, 0);
@@ -47,8 +47,8 @@ public class SeriesTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void keepsArbitraryDigitOrder() {
         Series series = new Series("936923468");
         List<Integer> expected = Arrays.asList(9, 3, 6, 9, 2, 3, 4, 6, 8);
@@ -58,8 +58,8 @@ public class SeriesTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void canSliceByOne() {
         Series series = new Series("01234");
         List<List<Integer>> expected = Arrays.asList(
@@ -75,8 +75,8 @@ public class SeriesTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void canSliceByTwo() {
         Series series = new Series("98273463");
         List<List<Integer>> expected = Arrays.asList(
@@ -94,8 +94,8 @@ public class SeriesTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void canSliceByThree() {
         Series series = new Series("01234");
         List<List<Integer>> expected = Arrays.asList(
@@ -109,8 +109,8 @@ public class SeriesTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void canSliceByThreeWithDuplicateDigits() {
         Series series = new Series("31001");
         List<List<Integer>> expected = Arrays.asList(
@@ -124,8 +124,8 @@ public class SeriesTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void canSliceByFour() {
         Series series = new Series("91274");
         List<List<Integer>> expected = Arrays.asList(
@@ -138,8 +138,8 @@ public class SeriesTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void canSliceByFive() {
         Series series = new Series("81228");
         List<List<Integer>> expected = Arrays.asList(
@@ -151,8 +151,8 @@ public class SeriesTest {
         assertEquals(expected, actual);
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void throwsAnErrorIfNotEnoughDigitsToSlice() {
         expectedException.expect(IllegalArgumentException.class);
         new Series("01032987583").slices(12);

--- a/exercises/sum-of-multiples/src/test/java/SumOfMultiplesTest.java
+++ b/exercises/sum-of-multiples/src/test/java/SumOfMultiplesTest.java
@@ -17,8 +17,8 @@ public class SumOfMultiplesTest {
 
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void testSumOfMultiplesOf3and5UpToFour() {
 
         int[] set = {
@@ -30,8 +30,8 @@ public class SumOfMultiplesTest {
 
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void testSumOfMultiplesOf3and5UpToTen() {
 
         int[] set = {
@@ -43,8 +43,8 @@ public class SumOfMultiplesTest {
 
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void testSumOfMultiplesOf3and5UpToOneHundred() {
 
         int[] set = {
@@ -56,8 +56,8 @@ public class SumOfMultiplesTest {
 
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void testSumOfMultiplesOf3and5UpToOneThousand() {
 
         int[] set = {
@@ -69,8 +69,8 @@ public class SumOfMultiplesTest {
 
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void testSumOfMultiplesOf7and13and17UpToTwenty() {
 
         int[] set = {
@@ -83,8 +83,8 @@ public class SumOfMultiplesTest {
 
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void testSumOfMultiplesOf4and6UpToFifteen() {
 
         int[] set = {
@@ -96,8 +96,8 @@ public class SumOfMultiplesTest {
 
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void testSumOfMultiplesOf5and6and8UpToOneHundredFifty() {
 
         int[] set = {
@@ -110,8 +110,8 @@ public class SumOfMultiplesTest {
 
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void testSumOfMultiplesOf5and25UpToTwoHundredSeventyFive() {
 
         int[] set = {
@@ -123,8 +123,8 @@ public class SumOfMultiplesTest {
 
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void testSumOfMultiplesOf43and47UpToTenThousand() {
 
         int[] set = {
@@ -136,8 +136,8 @@ public class SumOfMultiplesTest {
 
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void testSumOfMultiplesOfOneUpToOneHundred() {
 
         int[] set = {
@@ -148,8 +148,8 @@ public class SumOfMultiplesTest {
 
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void testSumOfMultiplesOfNoneUpToTenThousand() {
 
         int[] set = {};

--- a/exercises/transpose/src/test/java/TransposeTest.java
+++ b/exercises/transpose/src/test/java/TransposeTest.java
@@ -21,8 +21,8 @@ public class TransposeTest {
         assertEquals(expected, transpose.transpose(input));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void twoCharsInARow() {
         String input = "A1";
 
@@ -32,8 +32,8 @@ public class TransposeTest {
         assertEquals(expected, transpose.transpose(input));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void twoCharsInAColumn() {
         String input = "A\n" +
                        "1";
@@ -43,8 +43,8 @@ public class TransposeTest {
         assertEquals(expected, transpose.transpose(input));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void simpleMatrix() {
         String input = "ABC\n" +
                        "123";
@@ -56,8 +56,8 @@ public class TransposeTest {
         assertEquals(expected, transpose.transpose(input));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void singleLine() {
         String input = "Single line.";
 
@@ -77,8 +77,8 @@ public class TransposeTest {
         assertEquals(expected, transpose.transpose(input));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void firstLineLongerThanSecond() {
         String input = "The fourth line.\n" +
                        "The fifth line.";
@@ -103,8 +103,8 @@ public class TransposeTest {
         assertEquals(expected, transpose.transpose(input));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void secondLineLongerThanFirst() {
         String input = "The first line.\n" +
                        "The second line.";
@@ -129,8 +129,8 @@ public class TransposeTest {
         assertEquals(expected, transpose.transpose(input));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void square() {
         String input = "HEART\n" +
                        "EMBER\n" +
@@ -147,8 +147,8 @@ public class TransposeTest {
         assertEquals(expected, transpose.transpose(input));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void rectangle() {
         String input = "FRACTURE\n" +
                        "OUTLINED\n" +
@@ -167,8 +167,8 @@ public class TransposeTest {
         assertEquals(expected, transpose.transpose(input));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void triangle() {
         String input = "T\n" +
                        "EE\n" +
@@ -187,8 +187,8 @@ public class TransposeTest {
         assertEquals(expected, transpose.transpose(input));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void manyLines() {
         String input = "Chor. Two households, both alike in dignity,\n" +
                        "In fair Verona, where we lay our scene,\n" +

--- a/exercises/two-fer/src/test/java/TwoferTest.java
+++ b/exercises/two-fer/src/test/java/TwoferTest.java
@@ -21,8 +21,8 @@ public class TwoferTest {
         assertEquals(expected, twofer.twofer(input));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void aNameGiven() {
         String input = "Alice";
         String expected = "One for Alice, one for me.";
@@ -30,8 +30,8 @@ public class TwoferTest {
         assertEquals(expected, twofer.twofer(input));
     }
 
-    @Test
     @Ignore("Remove to run test")
+    @Test
     public void anotherNameGiven() {
         String input = "Bob";
         String expected = "One for Bob, one for me.";


### PR DESCRIPTION
<!-- Your content goes here: -->

A user accidentally deleted the `@Test` annotation in an exercise where that annotation appeared first. This PR standardizes the order of annotations so that any `@Ignore` annotation appears before any `@Test` annotation.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
