### PR TITLE
Optimize CI Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@
 language: java
 jdk:
   - oraclejdk8
+env:
+  - SCRIPT=bin/unit-tests.sh
+  - SCRIPT=bin/journey-test.sh
 
 # http://docs.travis-ci.com/user/migrating-from-legacy
 sudo: false
@@ -23,8 +26,7 @@ before_script:
   - export PATH=$TRAVIS_BUILD_DIR/bin:$PATH  # ensure our tools are prefered over included ones.
 
 script:
-  - bin/unit-tests.sh
-  - bin/journey-test.sh
+  - $SCRIPT
 
 # configure caching (https://docs.travis-ci.com/user/languages/java/#Caching)
 before_cache:

--- a/bin/journey-test.sh
+++ b/bin/journey-test.sh
@@ -164,7 +164,7 @@ make_local_trackler() {
   cp -r ${track_root}/exercises tracks/${TRACK}
 
   gem install bundler
-  bundle install
+  bundle install -j4
   gem build trackler.gemspec
 
   # Make *this* the gem that x-api uses when we build x-api.
@@ -181,7 +181,7 @@ start_x_api() {
   pushd $xapi_home
 
   gem install bundler
-  bundle install
+  bundle install -j4
   RACK_ENV=development rackup &
   xapi_pid=$!
   sleep 5
@@ -233,7 +233,7 @@ solve_all_exercises() {
 
     pushd ${exercism_exercises_dir}/${TRACK}/${exercise}
     # Check that tests compile before we strip @Ignore annotations
-    "$EXECPATH"/gradlew compileTestJava
+    "$EXECPATH"/gradlew compileTestJava --configure-on-demand --parallel
     # Ensure we run all the tests (as delivered, all but the first is @Ignore'd)
     for testfile in `find . -name "*Test.${TRACK_SRC_EXT}"`; do
       # Strip @Ignore annotations to ensure we run the tests (as delivered, all but the first is @Ignore'd).
@@ -241,7 +241,7 @@ solve_all_exercises() {
       # The stripping implementations here and in copyTestsFilteringIgnores should be kept consistent.
       sed 's/@Ignore\(\(.*\)\)\{0,1\}//' ${testfile} > "${tempfile}" && mv "${tempfile}" "${testfile}"
     done
-    "$EXECPATH"/gradlew test
+    "$EXECPATH"/gradlew test --configure-on-demand --parallel
     popd
 
     current_exercise_number=$((current_exercise_number + 1))

--- a/bin/journey-test.sh
+++ b/bin/journey-test.sh
@@ -164,7 +164,7 @@ make_local_trackler() {
   cp -r ${track_root}/exercises tracks/${TRACK}
 
   gem install bundler
-  bundle install -j4
+  bundle install --jobs $((`nproc --all`-1))
   gem build trackler.gemspec
 
   # Make *this* the gem that x-api uses when we build x-api.
@@ -181,7 +181,7 @@ start_x_api() {
   pushd $xapi_home
 
   gem install bundler
-  bundle install -j4
+  bundle install --jobs $((`nproc --all`-1))
   RACK_ENV=development rackup &
   xapi_pid=$!
   sleep 5
@@ -233,7 +233,7 @@ solve_all_exercises() {
 
     pushd ${exercism_exercises_dir}/${TRACK}/${exercise}
     # Check that tests compile before we strip @Ignore annotations
-    "$EXECPATH"/gradlew compileTestJava --configure-on-demand --parallel
+    "$EXECPATH"/gradlew compileTestJava
     # Ensure we run all the tests (as delivered, all but the first is @Ignore'd)
     for testfile in `find . -name "*Test.${TRACK_SRC_EXT}"`; do
       # Strip @Ignore annotations to ensure we run the tests (as delivered, all but the first is @Ignore'd).
@@ -241,7 +241,7 @@ solve_all_exercises() {
       # The stripping implementations here and in copyTestsFilteringIgnores should be kept consistent.
       sed 's/@Ignore\(\(.*\)\)\{0,1\}//' ${testfile} > "${tempfile}" && mv "${tempfile}" "${testfile}"
     done
-    "$EXECPATH"/gradlew test --configure-on-demand --parallel &
+    "$EXECPATH"/gradlew test
     popd
 
     current_exercise_number=$((current_exercise_number + 1))

--- a/bin/unit-tests.sh
+++ b/bin/unit-tests.sh
@@ -10,6 +10,6 @@ bin/configlet .
 pushd exercises
 echo ""
 echo ">>> Running tests..."
-TERM=dumb ../gradlew check compileStarterSourceJava --parallel --continue
+TERM=dumb ../gradlew check compileStarterSourceJava --parallel --configure-on-demand --continue
 popd
 

--- a/bin/unit-tests.sh
+++ b/bin/unit-tests.sh
@@ -10,6 +10,5 @@ bin/configlet .
 pushd exercises
 echo ""
 echo ">>> Running tests..."
-TERM=dumb ../gradlew check compileStarterSourceJava --parallel --configure-on-demand --continue
+TERM=dumb ../gradlew check compileStarterSourceJava --parallel --continue
 popd
-


### PR DESCRIPTION
<!-- Your content goes here: -->
Reference #410 

This pull request attempts to optimize the speed of the travis build's some more.  Unit tests and journey tests are run on separate build nodes, this trims a few minutes.  In the journey test it now downloads everything in parallel to save some time. And then `gradle` builds now use `--configure-on-demand` and `bundle install` uses the `-j4` tag.

After this get's reviewed and it all looks good, I'll make a pull request to mirror the changes in the kotlin track.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
