### PR TITLE
Support a subcommand on configlet in CI

### DIFF
--- a/bin/unit-tests.sh
+++ b/bin/unit-tests.sh
@@ -5,7 +5,7 @@ set -e
 echo ""
 echo ">>> Running configlet..."
 bin/fetch-configlet
-bin/configlet .
+bin/configlet lint .
 
 pushd exercises
 echo ""


### PR DESCRIPTION
We will be adding subcommands to configlet.

For now, we've released a version of configlet which handles both the
old command:

    configlet path/to/track

as well as the new command:

    configlet lint path/to/track

This will let us update all the travis files to include the
subcommand before we release the version of configlet that requires
the subcommand.


https://github.com/exercism/configlet/pull/23