### PR TITLE
Add configuration defaults for nextercism

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,448 +5,640 @@
   "active": true,
   "exercises": [
     {
+      "uuid": "f77dc7e3-35a8-4300-a7c8-2c1765e9644d",
       "slug": "hello-world",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "74515d45-565b-4be2-96c4-77e58efa9257",
       "slug": "two-fer",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
     },
     {
+      "uuid": "8e983ed2-62f7-439a-a144-fb8fdbdf4d30",
       "slug": "rna-transcription",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
 
       ]
     },
     {
+      "uuid": "133b0f84-bdc7-4508-a0a1-5732a7db81ef",
       "slug": "pangram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "ce899ca6-9cc7-47ba-b76f-1bbcf2630b76",
       "slug": "hamming",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "bf1641c8-dc0d-4d38-9cfe-b4c132ea3553",
       "slug": "gigasecond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "e5b524cd-3a1c-468a-8981-13e8eeccb29d",
       "slug": "space-age",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "c31bbc6d-bdcf-44f7-bf35-5f98752e38d0",
       "slug": "acronym",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "afae9f2d-8baf-4bd7-8d7c-d486337f7c97",
       "slug": "scrabble-score",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d916e4f8-fda1-41c0-ab24-79e8fc3f1272",
       "slug": "raindrops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "b0da59c6-1b55-405c-b163-007ebf09f5e8",
       "slug": "difference-of-squares",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "71c7c174-7e2c-43c2-bdd6-7515fcb12a91",
       "slug": "secret-handshake",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d0dcc898-ec38-4822-9e3c-1a1829c9b2d9",
       "slug": "perfect-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
 
       ]
     },
     {
+      "uuid": "2f244afc-3e7b-4f89-92af-e2b427f4ef35",
       "slug": "sum-of-multiples",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
 
       ]
     },
     {
+      "uuid": "5227a76c-8ecb-4e5f-b023-6af65a057c41",
       "slug": "luhn",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
 
       ]
     },
     {
+      "uuid": "c1d4e0b4-6a0f-4be9-8222-345966621f53",
       "slug": "matrix",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
 
       ]
     },
     {
+      "uuid": "ec268d8e-997b-4553-8c67-8bdfa1ecb888",
       "slug": "triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
 
       ]
     },
     {
+      "uuid": "b7310b6e-435c-4d5f-b2bd-31e586d0f238",
       "slug": "largest-series-product",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
 
       ]
     },
     {
+      "uuid": "6791d01f-bae4-4b63-ae76-86529ac49e36",
       "slug": "sieve",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
 
       ]
     },
     {
+      "uuid": "581afdbb-dfb6-4dc5-9554-a025b5469a3c",
       "slug": "twelve-days",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
 
       ]
     },
     {
+      "uuid": "0b92ffee-c092-4ab1-ad78-76c8cf80e1b5",
       "slug": "kindergarten-garden",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
 
       ]
     },
     {
+      "uuid": "1500d39a-c9d9-4d3a-9e77-fdc1837fc6ad",
       "slug": "collatz-conjecture",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
 
       ]
     },
     {
+      "uuid": "2c69db99-648d-4bd7-8012-1fbdeff6ca0a",
       "slug": "nth-prime",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
 
       ]
     },
     {
+      "uuid": "8dfc2f0d-1141-46e9-95e2-6f35ccf6f160",
       "slug": "saddle-points",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
 
       ]
     },
     {
+      "uuid": "ecbd997b-86f4-4e11-9ff0-706ac2899415",
       "slug": "diamond",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
 
       ]
     },
     {
+      "uuid": "c3e89c7c-3a8a-4ddc-b653-9b0ff9e1d7d8",
       "slug": "isogram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a732a838-8170-458a-a85e-d6b4c46f97a1",
       "slug": "flatten-array",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "38bc80ae-d842-4c04-a797-48edf322504d",
       "slug": "pig-latin",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "5f9139e7-9fbb-496a-a0d7-a946283033de",
       "slug": "phone-number",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "2d80fdfc-5bd7-4b67-9fbe-8ab820d89051",
       "slug": "nucleotide-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "3603b770-87a5-4758-91f3-b4d1f9075bc1",
       "slug": "word-count",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "4499a3f9-73a7-48bf-8753-d5b6abf588c9",
       "slug": "run-length-encoding",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d7c2eed9-64c7-4c4a-b45d-c787d460337f",
       "slug": "robot-name",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "599c08ec-7338-46ed-99f8-a76f78f724e6",
       "slug": "prime-factors",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "6a617ddb-04e3-451c-bb30-27ccd0be9125",
       "slug": "allergies",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "34cd328c-cd96-492b-abd4-2b8716cdcd9a",
       "slug": "bob",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d2a76905-1c8c-4b03-b4f7-4fbff19329f3",
       "slug": "pascals-triangle",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "85aa50ac-0141-49eb-bc6f-62f3f7a97647",
       "slug": "bracket-push",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "af80d7f4-c7d0-4d0b-9c30-09da120f6bb9",
       "slug": "series",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d36ce010-210f-4e9a-9d6c-cb933e0a59af",
       "slug": "atbash-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
 
       ]
     },
     {
+      "uuid": "163fcc6b-c054-4232-a88b-0aded846a6eb",
       "slug": "spiral-matrix",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "3e728cd4-5e5f-4c69-8a53-bc36d020fcdb",
       "slug": "roman-numerals",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "57b76837-4610-466f-9373-d5c2697625f1",
       "slug": "transpose",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "dd3e6fd6-5359-4978-acd7-c39374cead4d",
       "slug": "food-chain",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "56943095-de76-40bf-b42b-fa3e70f8df5e",
       "slug": "beer-song",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "5404109e-3ed9-4691-8eaf-af8b36024a44",
       "slug": "queen-attack",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "76d28d97-75d3-47eb-bb77-3d347b76f1b6",
       "slug": "etl",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "7ba5084d-3b75-4406-a0d7-87c26387f9c0",
       "slug": "linked-list",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "b4af5da1-601f-4b0f-bfb8-4a381851090c",
       "slug": "grade-school",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "993bde9d-7774-4e7a-a381-9eee75f28ecb",
       "slug": "robot-simulator",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "50136dc3-caf7-4fa1-b7bd-0cba1bea9176",
       "slug": "binary-search",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "416a1489-12af-4593-8540-0f55285c96b4",
       "slug": "minesweeper",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "3310a3cd-c0cb-45fa-8c51-600178be904a",
       "slug": "wordy",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
+      "uuid": "f7c2e4b5-1995-4dfe-b827-c9aff8ac5332",
       "slug": "all-your-base",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 6,
       "topics": [
 
       ]
     },
     {
-    	"slug": "bank-account",
-    	"difficulty": 6,
-    	"topics": [
+      "uuid": "a242efc5-159d-492b-861d-12a1459fb334",
+      "slug": "bank-account",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
+      "topics": [
 
-    	]
+      ]
     },
     {
-    	"slug": "bowling",
-    	"difficulty": 6,
-    	"topics": [
+      "uuid": "4b3f7771-c642-4278-a3d9-2fb958f26361",
+      "slug": "bowling",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 6,
+      "topics": [
 
-    	]
+      ]
     },
     {
+      "uuid": "fb10dc2f-0ba1-44b6-8365-5e48e86d1283",
       "slug": "anagram",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
 
       ]
     },
     {
+      "uuid": "d2aedbd7-092a-43d0-8a5e-ae3ebd5b9c7f",
       "slug": "sublist",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
 
       ]
     },
     {
+      "uuid": "b53bde52-cb5f-4d43-86ec-18aa509d62f9",
       "slug": "word-search",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
 
       ]
     },
     {
+      "uuid": "e3e5ffe5-cfc1-467e-a28a-da0302130144",
       "slug": "simple-linked-list",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
 
       ]
     },
     {
+      "uuid": "0a2d18aa-7b5e-4401-a952-b93d2060694f",
       "slug": "binary-search-tree",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
 
       ]
     },
     {
+      "uuid": "602511d5-7e89-4def-b072-4dd311816810",
       "slug": "meetup",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
 
       ]
     },
     {
+      "uuid": "162bebdc-9bf2-43c0-8460-a91f5fc16147",
       "slug": "crypto-square",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
 
       ]
     },
     {
+      "uuid": "57eeac00-741c-4843-907a-51f0ac5ea4cb",
       "slug": "poker",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
         "Parsing",
@@ -455,21 +647,30 @@
       ]
     },
     {
+      "uuid": "97c8fcd4-85b6-41cb-9de2-b4e1b4951222",
       "slug": "clock",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 7,
       "topics": [
 
       ]
     },
     {
+      "uuid": "5cbc6a67-3a53-4aad-ae68-ff469525437f",
       "slug": "ocr-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
 
       ]
     },
     {
+      "uuid": "626dc25a-062c-4053-a8c1-788e4dc44ca0",
       "slug": "circular-buffer",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
         "Queues",
@@ -478,83 +679,135 @@
       ]
     },
     {
+      "uuid": "64cda115-919a-4eef-9a45-9ec5d1af98cc",
       "slug": "rectangles",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
 
       ]
     },
     {
+      "uuid": "e5f05d00-fe5b-4d78-b2fa-934c1c9afb32",
       "slug": "book-store",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
 
       ]
     },
     {
+      "uuid": "f654831f-c34b-44f5-9dd5-054efbb486f2",
       "slug": "simple-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
 
       ]
     },
     {
+      "uuid": "52d11278-0d65-4b5b-b387-1374fced3243",
       "slug": "complex-numbers",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
 
       ]
     },
     {
+      "uuid": "a9836565-5c39-4285-b83a-53408be36ccc",
       "slug": "list-ops",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
-      
+
       ]
     },
     {
+      "uuid": "bac1f4bc-eea9-43c1-8e95-097347f5925e",
       "slug": "change",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
 
       ]
     },
     {
+      "uuid": "873c05de-b5f5-4c5b-97f0-d1ede8a82832",
       "slug": "palindrome-products",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 8,
       "topics": [
 
       ]
     },
     {
+      "uuid": "88505f95-89e5-4a08-8ed2-208eb818cdf1",
       "slug": "pythagorean-triplet",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 9,
       "topics": [
 
       ]
     },
     {
+      "uuid": "377fe38b-08ad-4f3a-8118-a43c10f7b9b2",
       "slug": "custom-set",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 10,
       "topics": [
 
       ]
     },
     {
+      "uuid": "9eb41883-55ef-4681-b5ac-5c2259302772",
       "slug": "rotational-cipher",
+      "core": false,
+      "unlocked_by": null,
       "difficulty": 1,
       "topics": [
 
       ]
+    },
+    {
+      "uuid": "e58c29d2-80a7-40ef-bed0-4a184ae35f34",
+      "slug": "accumulate",
+      "deprecated": true
+    },
+    {
+      "uuid": "9ea6e0fa-b91d-4d17-ac8f-6d2dc30fdd44",
+      "slug": "binary",
+      "deprecated": true
+    },
+    {
+      "uuid": "6fe53a08-c123-465d-864a-ef18217203c4",
+      "slug": "hexadecimal",
+      "deprecated": true
+    },
+    {
+      "uuid": "14a29e82-f9b1-4662-b678-06992e306c01",
+      "slug": "octal",
+      "deprecated": true
+    },
+    {
+      "uuid": "2d195cd9-1814-490a-8dd6-a2c676f1d4cd",
+      "slug": "strain",
+      "deprecated": true
+    },
+    {
+      "uuid": "ee3a8abe-6b19-4b47-9cf6-4d39ae915fb7",
+      "slug": "trinary",
+      "deprecated": true
     }
-  ],
-  "deprecated": [
-    "accumulate",
-    "binary",
-    "hexadecimal",
-    "octal",
-    "strain",
-    "trinary"
   ],
   "foregone": [
     "leap",


### PR DESCRIPTION
We will be moving to a tree-shaped track rather than a linear one, as described in the [progression & learning in Exercism](https://github.com/exercism/docs/blob/master/about/conception/progression.md) design document.

In order to support this, we need to expand the metadata that exercises are configured with.

Note that 'core' exercises are never unlocked by any other exercises. Core exercises appear in the track in the order that they are listed in the array.

Non-core exercises depend on only one exercise (unlocked_by: ). At the moment we are assuming that this is a core exercise, but there is no reason that it needs to be.

Until now we have operated with a separate deprecated array. These are now being moved into the exercises array with a deprecated field.

With these defaults the track in nextercism will have no core exercises, and all the exercises will be available as 'extras' from the start.

If you haven't already, now would be a good time to do the following:

* add a rough estimate of difficulty to each exercise (scale: 1-10)
* add topics to each exercise
* choose *at most 20 exercises* to be core exercises (set core: true, and delete the unlocked_by key)
* for each exercise that is not core, decide which exercise is the prerequisite (max 1)

If possible, leave 3 or 4 simple exercises as (core: false, unlocked_by: null), as this will provide new participants with some exercises that they can tackle even if they have not finished the first core exercise.


See https://github.com/exercism/meta/issues/16