### PR TITLE
Fixes #716 remove redundant type params

### DIFF
--- a/exercises/word-count/src/example/java/WordCount.java
+++ b/exercises/word-count/src/example/java/WordCount.java
@@ -6,7 +6,7 @@ import java.util.Map;
 public class WordCount {
 
     public Map<String, Integer> phrase( String input ) {
-        Map<String, Integer> countMap = new HashMap<String, Integer>();
+        Map<String, Integer> countMap = new HashMap<>();
         input = input.trim().toLowerCase().replaceAll("[\\W]", " ");
         final String[] tokenizedInput = input.split("\\s+");
         for( String aWord : tokenizedInput ) {

--- a/exercises/word-count/src/test/java/WordCountTest.java
+++ b/exercises/word-count/src/test/java/WordCountTest.java
@@ -18,7 +18,7 @@ public class WordCountTest {
     @Before
     public void setup() {
         wordCount = new WordCount();
-        expectedWordCount = new HashMap<String, Integer>();
+        expectedWordCount = new HashMap<>();
     }
 
 


### PR DESCRIPTION
Remove redundant generic type params in map initialization in WordCount and WordCountTest



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
