### PR TITLE
Add echo's to run-journey-test-from-ci for debug info

### DIFF
--- a/bin/run-journey-test-from-ci.sh
+++ b/bin/run-journey-test-from-ci.sh
@@ -5,6 +5,9 @@ bin/build-jq.sh
 
 pr_files_json=`curl -s https://api.github.com/repos/exercism/java/pulls/${TRAVIS_PULL_REQUEST}/files`
 
+echo "Pull request number: ${TRAVIS_PULL_REQUEST}"
+echo "Changes in pr json: ${pr_files_json}"
+
 # if jq fails to get the required data, then that means TRAVIS_PULL_REQUEST was not set (not run in travis-ci),
 # or was false (not a pull request). In that case, we should fall back with testing every exercise
 


### PR DESCRIPTION
<!-- Your content goes here: -->
So I noticed that when trying to get files modified when running the journey-tests, the builds are not able to get the required information, so it continues and runs the entire journey-test suite. This pr is to figure out where the problem is, and fix it


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
