### PR TITLE
Adding the prerequisites to the CONTRIBUTING.md file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,15 @@ Each problem/submodule has three source sets:
 
 ## Advanced: Complete Local Setup
 
+### Prerequisites
+Before you proceed, please ensure that you have `jq` (library that parses JSON) & `ruby` installed on your machine.
+
+##### Debian Linux
+`sudo apt-get install jq ruby-full`
+
+##### Mac OSX
+`brew install jq ruby`
+
 If you are going to make significant contribution(s) to the track, you might find it handy to have a complete local install of exercism on your computer.  This way, you can run the full suite of tests without having to create/update a PR.
 
 The easiest way to achieve this is simply use the `bin/journey-test.sh` script.  However, you may want to perform other tests, depending on what you are doing.  You can do so by duplicating the setup performed by the `bin/journey-test.sh` script.


### PR DESCRIPTION
<!-- Your content goes here: -->
Fixes #769 
The local setup requires jq & ruby to be installed. This should be mentioned in the CONTRIBUTING.md file to make it easier for folks to contribute in the future

Happy Hacktoberfest! 

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
