### PR TITLE
saddle-points: make MatrixCoordinate implement Comparable

### DIFF
--- a/exercises/saddle-points/.meta/src/reference/java/MatrixCoordinate.java
+++ b/exercises/saddle-points/.meta/src/reference/java/MatrixCoordinate.java
@@ -1,4 +1,4 @@
-class MatrixCoordinate {
+class MatrixCoordinate implements Comparable<MatrixCoordinate> {
     private final int row;
     private final int col;
 
@@ -29,5 +29,11 @@ class MatrixCoordinate {
         int result = row;
         result = 31 * result + col;
         return result;
+    }
+
+    @Override
+    public int compareTo(MatrixCoordinate o) {
+        int rowComparison = Integer.compare(row, o.row);
+        return (rowComparison == 0) ? Integer.compare(col, o.col) : rowComparison;
     }
 }

--- a/exercises/saddle-points/src/main/java/MatrixCoordinate.java
+++ b/exercises/saddle-points/src/main/java/MatrixCoordinate.java
@@ -1,4 +1,4 @@
-class MatrixCoordinate {
+class MatrixCoordinate implements Comparable<MatrixCoordinate> {
     private final int row;
     private final int col;
 
@@ -29,5 +29,11 @@ class MatrixCoordinate {
         int result = row;
         result = 31 * result + col;
         return result;
+    }
+
+    @Override
+    public int compareTo(MatrixCoordinate o) {
+        int rowComparison = Integer.compare(row, o.row);
+        return (rowComparison == 0) ? Integer.compare(col, o.col) : rowComparison;
     }
 }


### PR DESCRIPTION
The saddle-points tests make it seem like you can use any kind of set for your output. However, if you use `TreeSet` then the tests will fail because `MatrixCoordinate` doesn't implement `Comparable`.

`MatrixCoordinate` does now implement `Comparable` to prevent this failure.

Another solution would be to make the tests enforce use of `HashSet` instead of `TreeSet`. I'd be happy to change to that solution if anyone thinks that's preferable :)

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
