### PR TITLE
binary-search-tree: use generics

### DIFF
--- a/exercises/binary-search-tree/.meta/src/reference/java/BinarySearchTree.java
+++ b/exercises/binary-search-tree/.meta/src/reference/java/BinarySearchTree.java
@@ -1,49 +1,11 @@
+import java.util.*;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Queue;
-
-public class BinarySearchTree<T extends Comparable<T>> {
-
-    public static class Node<T> {
-
-        private T data;
-        private Node<T> left = null;
-        private Node<T> right = null;
-
-        public Node(T data) {
-            this.data = data;
-        }
-
-        public Node<T> getLeft() {
-            return left;
-        }
-
-        public void setLeft(Node<T> left) {
-            this.left = left;
-        }
-
-        public Node<T> getRight() {
-            return right;
-        }
-
-        public void setRight(Node<T> right) {
-            this.right = right;
-        }
-
-        public T getData() {
-            return data;
-        }
-
-    }
+class BinarySearchTree<T extends Comparable<T>> {
 
     private Node<T> root;
-
     private int nodeCount = 0;
 
-    public void insert(T value) {
+    void insert(T value) {
         if (root == null) {
             root = new Node<>(value);
         } else {
@@ -52,19 +14,19 @@ public class BinarySearchTree<T extends Comparable<T>> {
         this.nodeCount++;
     }
 
-    public List<T> getAsSortedList() {
+    List<T> getAsSortedList() {
         List<T> result = new ArrayList<>(this.nodeCount);
         this.putInSortedOrderToList(this.root, result);
         return Collections.unmodifiableList(result);
     }
 
-    public List<T> getAsLevelOrderList() {
+    List<T> getAsLevelOrderList() {
         List<T> result = new ArrayList<>(this.nodeCount);
         this.putInLevelOrderToList(this.root, result);
         return Collections.unmodifiableList(result);
     }
 
-    public Node<T> getRoot() {
+    Node<T> getRoot() {
         return root;
     }
 
@@ -118,5 +80,37 @@ public class BinarySearchTree<T extends Comparable<T>> {
                 queue.add(right);
             }
         }
+    }
+
+    static class Node<T> {
+
+        private T data;
+        private Node<T> left = null;
+        private Node<T> right = null;
+
+        Node(T data) {
+            this.data = data;
+        }
+
+        Node<T> getLeft() {
+            return left;
+        }
+
+        void setLeft(Node<T> left) {
+            this.left = left;
+        }
+
+        Node<T> getRight() {
+            return right;
+        }
+
+        void setRight(Node<T> right) {
+            this.right = right;
+        }
+
+        T getData() {
+            return data;
+        }
+
     }
 }

--- a/exercises/binary-search-tree/src/main/java/BinarySearchTree.java
+++ b/exercises/binary-search-tree/src/main/java/BinarySearchTree.java
@@ -1,0 +1,35 @@
+import java.util.List;
+
+class BinarySearchTree<T extends Comparable<T>> {
+    void insert(T value) {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    List<T> getAsSortedList() {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    List<T> getAsLevelOrderList() {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    Node<T> getRoot() {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    static class Node<T> {
+
+        Node<T> getLeft() {
+            throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+        }
+
+        Node<T> getRight() {
+            throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+        }
+
+        T getData() {
+            throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+        }
+
+    }
+}

--- a/exercises/binary-search-tree/src/test/java/BinarySearchTreeTest.java
+++ b/exercises/binary-search-tree/src/test/java/BinarySearchTreeTest.java
@@ -90,44 +90,29 @@ public class BinarySearchTreeTest {
     @Ignore("Remove to run test")
     @Test
     public void createsComplexTree() {
-        BinarySearchTree<Integer> binarySearchTree = new BinarySearchTree<>();
-        List<Integer> expected = Collections.unmodifiableList(
-                Arrays.asList(4, 2, 6, 1, 3, 5, 7)
+        BinarySearchTree<Character> binarySearchTree = new BinarySearchTree<>();
+        List<Character> expected = Collections.unmodifiableList(
+                Arrays.asList('4', '2', '6', '1', '3', '5', '7')
         );
 
-        List<Integer> treeData = Collections.unmodifiableList(
-                Arrays.asList(4, 2, 6, 1, 3, 7, 5)
+        List<Character> treeData = Collections.unmodifiableList(
+                Arrays.asList('4', '2', '6', '1', '3', '7', '5')
         );
         treeData.forEach(binarySearchTree::insert);
 
-        List<Integer> actual = binarySearchTree.getAsLevelOrderList();
+        List<Character> actual = binarySearchTree.getAsLevelOrderList();
         assertEquals(expected, actual);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void sortsSingleElement() {
-        BinarySearchTree<Character> binarySearchTree = new BinarySearchTree<>();
-        List<Character> expected = Collections.unmodifiableList(
-                Collections.singletonList('4')
-        );
-
-        binarySearchTree.insert('4');
-
-        List<Character> actual = binarySearchTree.getAsSortedList();
-        assertEquals(expected, actual);
-    }
-
-    @Ignore("Remove to run test")
-    @Test
-    public void sortsCollectionOfTwoIfSecondInsertedIsSmallerThanFirst() {
         BinarySearchTree<String> binarySearchTree = new BinarySearchTree<>();
         List<String> expected = Collections.unmodifiableList(
-                Arrays.asList("2", "4")
+                Collections.singletonList("4")
         );
 
         binarySearchTree.insert("4");
-        binarySearchTree.insert("2");
 
         List<String> actual = binarySearchTree.getAsSortedList();
         assertEquals(expected, actual);
@@ -135,14 +120,14 @@ public class BinarySearchTreeTest {
 
     @Ignore("Remove to run test")
     @Test
-    public void sortsCollectionOfTwoIfSecondInsertedIsBiggerThanFirst() {
+    public void sortsCollectionOfTwoIfSecondInsertedIsSmallerThanFirst() {
         BinarySearchTree<Integer> binarySearchTree = new BinarySearchTree<>();
         List<Integer> expected = Collections.unmodifiableList(
-                Arrays.asList(4, 5)
+                Arrays.asList(2, 4)
         );
 
         binarySearchTree.insert(4);
-        binarySearchTree.insert(5);
+        binarySearchTree.insert(2);
 
         List<Integer> actual = binarySearchTree.getAsSortedList();
         assertEquals(expected, actual);
@@ -150,18 +135,33 @@ public class BinarySearchTreeTest {
 
     @Ignore("Remove to run test")
     @Test
-    public void iteratesOverComplexTree() {
-        BinarySearchTree<Integer> binarySearchTree = new BinarySearchTree<>();
-        List<Integer> expected = Collections.unmodifiableList(
-                Arrays.asList(1, 2, 3, 4, 5, 6, 7)
+    public void sortsCollectionOfTwoIfSecondInsertedIsBiggerThanFirst() {
+        BinarySearchTree<Character> binarySearchTree = new BinarySearchTree<>();
+        List<Character> expected = Collections.unmodifiableList(
+                Arrays.asList('4', '5')
         );
 
-        List<Integer> treeData = Collections.unmodifiableList(
-                Arrays.asList(4, 2, 1, 3, 6, 7, 5)
+        binarySearchTree.insert('4');
+        binarySearchTree.insert('5');
+
+        List<Character> actual = binarySearchTree.getAsSortedList();
+        assertEquals(expected, actual);
+    }
+
+    @Ignore("Remove to run test")
+    @Test
+    public void iteratesOverComplexTree() {
+        BinarySearchTree<String> binarySearchTree = new BinarySearchTree<>();
+        List<String> expected = Collections.unmodifiableList(
+                Arrays.asList("1", "2", "3", "4", "5", "6", "7")
+        );
+
+        List<String> treeData = Collections.unmodifiableList(
+                Arrays.asList("4", "2", "1", "3", "6", "7", "5")
         );
         treeData.forEach(binarySearchTree::insert);
 
-        List<Integer> actual = binarySearchTree.getAsSortedList();
+        List<String> actual = binarySearchTree.getAsSortedList();
         assertEquals(expected, actual);
     }
 }

--- a/exercises/binary-search-tree/src/test/java/BinarySearchTreeTest.java
+++ b/exercises/binary-search-tree/src/test/java/BinarySearchTreeTest.java
@@ -9,39 +9,38 @@ import org.junit.Test;
 import org.junit.Before;
 
 public class BinarySearchTreeTest {
-    private BinarySearchTree<Integer> binarySearchTree;
-
-    @Before
-    public void setUp() {
-        binarySearchTree = new BinarySearchTree<>();
-    }
 
     @Test
     public void dataIsRetained() {
-        final int actual = 4;
-        binarySearchTree.insert(actual);
+        BinarySearchTree<Integer> binarySearchTree = new BinarySearchTree<>();
+
+        final int expected = 4;
+        binarySearchTree.insert(expected);
+
         final BinarySearchTree.Node<Integer> root = binarySearchTree.getRoot();
         assertNotNull(root);
-        final int expected = root.getData();
+
+        final int actual = root.getData();
         assertEquals(expected, actual);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void insertsLess() {
-        final int expectedRoot = 4;
-        final int expectedLeft = 2;
+        BinarySearchTree<Character> binarySearchTree = new BinarySearchTree<>();
+        final char expectedRoot = '4';
+        final char expectedLeft = '2';
 
         binarySearchTree.insert(expectedRoot);
         binarySearchTree.insert(expectedLeft);
 
-        final BinarySearchTree.Node<Integer> root = binarySearchTree.getRoot();
+        final BinarySearchTree.Node<Character> root = binarySearchTree.getRoot();
         assertNotNull(root);
-        final BinarySearchTree.Node<Integer> left = root.getLeft();
+        final BinarySearchTree.Node<Character> left = root.getLeft();
         assertNotNull(left);
 
-        final int actualRoot = root.getData();
-        final int actualLeft = left.getData();
+        final char actualRoot = root.getData();
+        final char actualLeft = left.getData();
         assertEquals(expectedLeft, actualLeft);
         assertEquals(expectedRoot, actualRoot);
     }
@@ -49,19 +48,20 @@ public class BinarySearchTreeTest {
     @Ignore("Remove to run test")
     @Test
     public void insertsSame() {
-        final int expectedRoot = 4;
-        final int expectedLeft = 4;
+        BinarySearchTree<String> binarySearchTree = new BinarySearchTree<>();
+        final String expectedRoot = "4";
+        final String expectedLeft = "4";
 
         binarySearchTree.insert(expectedRoot);
         binarySearchTree.insert(expectedLeft);
 
-        final BinarySearchTree.Node<Integer> root = binarySearchTree.getRoot();
+        final BinarySearchTree.Node<String> root = binarySearchTree.getRoot();
         assertNotNull(root);
-        final BinarySearchTree.Node<Integer> left = root.getLeft();
+        final BinarySearchTree.Node<String> left = root.getLeft();
         assertNotNull(left);
 
-        final int actualRoot = root.getData();
-        final int actualLeft = left.getData();
+        final String actualRoot = root.getData();
+        final String actualLeft = left.getData();
         assertEquals(expectedLeft, actualLeft);
         assertEquals(expectedRoot, actualRoot);
     }
@@ -69,6 +69,7 @@ public class BinarySearchTreeTest {
     @Ignore("Remove to run test")
     @Test
     public void insertsRight() {
+        BinarySearchTree<Integer> binarySearchTree = new BinarySearchTree<>();
         final int expectedRoot = 4;
         final int expectedRight = 5;
 
@@ -89,6 +90,7 @@ public class BinarySearchTreeTest {
     @Ignore("Remove to run test")
     @Test
     public void createsComplexTree() {
+        BinarySearchTree<Integer> binarySearchTree = new BinarySearchTree<>();
         List<Integer> expected = Collections.unmodifiableList(
                 Arrays.asList(4, 2, 6, 1, 3, 5, 7)
         );
@@ -105,33 +107,36 @@ public class BinarySearchTreeTest {
     @Ignore("Remove to run test")
     @Test
     public void sortsSingleElement() {
-        List<Integer> expected = Collections.unmodifiableList(
-                Collections.singletonList(4)
+        BinarySearchTree<Character> binarySearchTree = new BinarySearchTree<>();
+        List<Character> expected = Collections.unmodifiableList(
+                Collections.singletonList('4')
         );
 
-        binarySearchTree.insert(4);
+        binarySearchTree.insert('4');
 
-        List<Integer> actual = binarySearchTree.getAsSortedList();
+        List<Character> actual = binarySearchTree.getAsSortedList();
         assertEquals(expected, actual);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void sortsCollectionOfTwoIfSecondInsertedIsSmallerThanFirst() {
-        List<Integer> expected = Collections.unmodifiableList(
-                Arrays.asList(2, 4)
+        BinarySearchTree<String> binarySearchTree = new BinarySearchTree<>();
+        List<String> expected = Collections.unmodifiableList(
+                Arrays.asList("2", "4")
         );
 
-        binarySearchTree.insert(4);
-        binarySearchTree.insert(2);
+        binarySearchTree.insert("4");
+        binarySearchTree.insert("2");
 
-        List<Integer> actual = binarySearchTree.getAsSortedList();
+        List<String> actual = binarySearchTree.getAsSortedList();
         assertEquals(expected, actual);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void sortsCollectionOfTwoIfSecondInsertedIsBiggerThanFirst() {
+        BinarySearchTree<Integer> binarySearchTree = new BinarySearchTree<>();
         List<Integer> expected = Collections.unmodifiableList(
                 Arrays.asList(4, 5)
         );
@@ -146,6 +151,7 @@ public class BinarySearchTreeTest {
     @Ignore("Remove to run test")
     @Test
     public void iteratesOverComplexTree() {
+        BinarySearchTree<Integer> binarySearchTree = new BinarySearchTree<>();
         List<Integer> expected = Collections.unmodifiableList(
                 Arrays.asList(1, 2, 3, 4, 5, 6, 7)
         );


### PR DESCRIPTION
<!-- Your content goes here: -->

Should hopefully fix the `binary-search-tree` part of issue #230.

Also swaps `expected` and `actual` around in the first test as they were, as far as I can tell, the wrong way around.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
