### PR TITLE
Add script for checking for exercise updates

### DIFF
--- a/scripts/canonical_data_check.sh
+++ b/scripts/canonical_data_check.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+print_usage() {
+    echo "Usage: ./canonical_data_check.sh -t path/to/track -s path/to/problem/specifications"
+}
+
+# Execution begins
+
+command -v jq >/dev/null 2>&1 || {
+    echo >&2 "This script requires jq but it's not installed. Aborting."
+    exit 1
+}
+
+num_args=$#
+
+if [ $num_args -eq 0 ]
+then
+    print_usage
+    exit 0
+fi
+
+path_to_track=
+path_to_problem_specifications=
+
+while getopts ":t:s:" option
+do
+    case "$option" in
+        "t")
+            path_to_track="$OPTARG"
+            ;;
+        "s")
+            path_to_problem_specifications="$OPTARG"
+            ;;
+        *)
+            echo "Unrecognized option. Aborting."
+            print_usage
+            exit 1
+            ;;
+    esac
+done
+
+if [ -z "$path_to_track" ]
+then
+    echo "Path to track missing."
+    print_usage
+    exit 1
+fi
+
+if [ -z "$path_to_problem_specifications" ]
+then
+    echo "Path to problem specifications missing."
+    print_usage
+    exit 1
+fi
+
+config_file_path="$path_to_track/config.json"
+
+if ! [ -f "$config_file_path" ]
+then
+    echo "Config file not found at $config_file_path."
+    exit 1
+fi
+
+track_exercise_slugs=$(jq '.exercises[] | select(has("deprecated") | not) | .slug' $config_file_path | tr -d "\"")
+
+for slug in $track_exercise_slugs
+do
+    canonical_data_folder_path="$path_to_problem_specifications/exercises/$slug"
+
+    if ! [ -d "$canonical_data_folder_path" ]
+    then
+        echo "Canonical data folder $canonical_data_folder_path not found. Aborting."
+        exit 1
+    fi
+
+    canonical_data_file_path="$canonical_data_folder_path/canonical-data.json"
+
+    if ! [ -f "$canonical_data_file_path" ]
+    then
+        # echo "$slug: no canonical data found."
+        continue
+    fi
+
+    canonical_data_version=$(jq '.version' $canonical_data_file_path | tr -d "\"")
+
+    track_exercise_version_file_path="$path_to_track/exercises/$slug/.meta/version"
+
+    if ! [ -f "$track_exercise_version_file_path" ]
+    then
+        echo "$slug: needs update or version file (v$canonical_data_version)."
+        continue
+    fi
+
+    track_data_version=$(cat $track_exercise_version_file_path)
+
+    if [ "$track_data_version" = "$canonical_data_version" ]
+    then
+        # echo "$slug: up-to-date."
+        continue
+    else
+        echo "$slug: needs update (v$track_data_version -> v$canonical_data_version)."
+    fi
+
+done


### PR DESCRIPTION
<!-- Your content goes here: -->

Sample output:

```text
$ ./canonical_data_check.sh  -t .. -s ../../problem-specifications/
hello-world: needs update or version file (v1.0.0).
two-fer: needs update or version file (v1.1.0).
pangram: needs update (v1.1.0 -> v1.3.0).
hamming: needs update (v1.1.0 -> v2.0.1).
gigasecond: needs update or version file (v1.0.0).
space-age: needs update or version file (v1.0.0).
raindrops: needs update or version file (v1.0.0).
secret-handshake: needs update (v1.0.0 -> v1.1.0).
perfect-numbers: needs update (v1.0.0 -> v1.0.1).
sum-of-multiples: needs update or version file (v1.1.0).
luhn: needs update or version file (v1.0.0).
largest-series-product: needs update or version file (v1.0.0).
sieve: needs update or version file (v1.0.0).
rotational-cipher: needs update or version file (v1.1.0).
kindergarten-garden: needs update or version file (v1.0.0).
collatz-conjecture: needs update (v1.1.0 -> v1.1.1).
nth-prime: needs update or version file (v1.0.0).
isogram: needs update or version file (v1.2.0).
pig-latin: needs update or version file (v1.1.0).
phone-number: needs update or version file (v1.2.0).
nucleotide-count: needs update or version file (v1.2.0).
word-count: needs update or version file (v1.0.0).
run-length-encoding: needs update or version file (v1.0.0).
prime-factors: needs update or version file (v1.0.0).
allergies: needs update or version file (v1.0.0).
bob: needs update or version file (v1.0.0).
pascals-triangle: needs update (v1.0.0 -> v1.1.0).
bracket-push: needs update (v1.0.0 -> v1.1.0).
atbash-cipher: needs update or version file (v1.0.0).
roman-numerals: needs update or version file (v1.0.0).
transpose: needs update or version file (v1.0.0).
house: needs update or version file (v1.0.0).
food-chain: needs update or version file (v1.0.0).
beer-song: needs update or version file (v1.0.0).
queen-attack: needs update (v1.0.0 -> v2.0.0).
etl: needs update or version file (v1.0.0).
robot-simulator: needs update (v1.0.0 -> v2.0.0).
binary-search: needs update or version file (v1.0.0).
wordy: needs update or version file (v1.0.0).
bowling: needs update or version file (v1.0.1).
tournament: needs update or version file (v1.3.0).
anagram: needs update or version file (v1.0.1).
word-search: needs update (v1.0.0 -> v1.1.0).
meetup: needs update or version file (v1.0.0).
crypto-square: needs update or version file (v3.1.0).
poker: needs update or version file (v1.0.0).
circular-buffer: needs update or version file (v1.0.1).
book-store: needs update or version file (v1.0.1).
list-ops: needs update (v1.0.0 -> v2.0.0).
palindrome-products: needs update or version file (v1.0.0).
```

Missing slugs either (1) don't have canonical data, or (2) are up-to-date with canonical data.

Thoughts?

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
