### PR TITLE
clock: make classes and methods package private in reference solution

### DIFF
--- a/exercises/clock/.meta/src/reference/java/Clock.java
+++ b/exercises/clock/.meta/src/reference/java/Clock.java
@@ -1,17 +1,17 @@
-public class Clock {
+class Clock {
     private static final int MINUTES_IN_AN_HOUR = 60;
     private static final int HOURS_IN_A_DAY = 24;
 
     private int hours;
     private int minutes;
 
-    public Clock(int hours, int minutes) {
+    Clock(int hours, int minutes) {
         this.hours = hours;
         this.minutes = minutes;
         sanitiseTime();
     }
 
-    public void add(int minutes) {
+    void add(int minutes) {
         this.minutes += minutes;
         sanitiseTime();
     }


### PR DESCRIPTION
<!-- Your content goes here: -->
Fixes #1043. I couldn't remove the public access modifiers on toString() or equals() because they were overridden methods. 


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
