### PR TITLE
Ignore build.gradle when CI runs tests against changeset

### DIFF
--- a/bin/run-journey-test-from-ci.sh
+++ b/bin/run-journey-test-from-ci.sh
@@ -17,7 +17,7 @@ for file in $modded_files
   do if [[ $file == exercises* ]] || [[ $file == config.json ]]
     then
     for file2 in $modded_files
-      do if [[ $file2 == exercises* ]] && [[ $file2 != exercises/settings.gradle ]]
+      do if [[ $file2 == exercises* ]] && [[ $file2 != exercises/settings.gradle ]] && [[ $file2 != exercises/build.gradle ]]
         then modded_exercise=${file2#exercises/}
         modded_exercise=${modded_exercise%%/*}
         if [[ $last_modded_exercise != $modded_exercise ]]

--- a/exercises/build.gradle
+++ b/exercises/build.gradle
@@ -56,7 +56,6 @@ subprojects {
     // When running the standard test task, make sure we prepopulate the test source set with the
     // @Ignore-stripped tests.
     // Insert comment to force change in CI
-    // Another comment because CI hit Github API limit
     test.dependsOn(copyTestsFilteringIgnores)
   }
 

--- a/exercises/build.gradle
+++ b/exercises/build.gradle
@@ -55,6 +55,7 @@ subprojects {
 
     // When running the standard test task, make sure we prepopulate the test source set with the
     // @Ignore-stripped tests.
+    // Insert comment to force change in CI
     test.dependsOn(copyTestsFilteringIgnores)
   }
 

--- a/exercises/build.gradle
+++ b/exercises/build.gradle
@@ -55,7 +55,6 @@ subprojects {
 
     // When running the standard test task, make sure we prepopulate the test source set with the
     // @Ignore-stripped tests.
-    // Insert comment to force change in CI
     test.dependsOn(copyTestsFilteringIgnores)
   }
 

--- a/exercises/build.gradle
+++ b/exercises/build.gradle
@@ -56,6 +56,7 @@ subprojects {
     // When running the standard test task, make sure we prepopulate the test source set with the
     // @Ignore-stripped tests.
     // Insert comment to force change in CI
+    // Another comment because CI hit Github API limit
     test.dependsOn(copyTestsFilteringIgnores)
   }
 


### PR DESCRIPTION
<!-- Your content goes here: -->

I was curious if the CI also tried to run tests against build.gradle similar to how settings.gradle was having tests run against it if it was in the change set. It was fixed in #1064 for settings.gradle as a reference.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
