### PR TITLE
Extend linked list tests

### DIFF
--- a/exercises/linked-list/.meta/src/reference/java/DoublyLinkedList.java
+++ b/exercises/linked-list/.meta/src/reference/java/DoublyLinkedList.java
@@ -1,57 +1,177 @@
-final class DoublyLinkedList<T> {
-    private Element<T> head;
+public class DoublyLinkedList<T> {
+    private Node<T> initialNode;
+    private int count;
 
-    void push(T value) {
-        if (head == null) {
-            head = new Element<>(value, null, null);
-            head.next = head;
-            head.prev = head;
-            return;
-        }
-
-        Element<T> oldTail = head.prev;
-        Element<T> tail = new Element<>(value, oldTail, head);
-        oldTail.next = tail;
-        head.prev = tail;
+    public DoublyLinkedList(T... initData) {
+        this.count = 0;
+        for(T data : initData) { push(data); }
     }
 
-    T pop() {
-        head = head.prev;
-        return shift();
+    public void push(T data) {
+        Node<T> newNode = new Node<>(data);
+        if (this.count == 0) {
+            this.initialNode = newNode;
+        } else {
+            Node<T> lastNode = getLastNode(this.initialNode);
+            makeConnection(lastNode, newNode);
+        }
+        this.count++;
     }
 
-    void unshift(T value) {
-        push(value);
-        head = head.prev;
+    public T pop() {
+        Node<T> lastNode = getLastNode(this.initialNode);
+        T data = lastNode.getData();
+        if (this.count == 1) {
+            this.initialNode = null;
+        } else {
+            lastNode.getPrev().assignNext(null);
+        }
+        lastNode.assignPrev(null);
+        this.count--;
+        return data;
     }
 
-    T shift() {
-        T value = head.value;
-
-        Element<T> newHead = head.next;
-        Element<T> newTail = head.prev;
-
-        if (newHead == head) {
-            head = null;
+    public T shift() {
+        T data = this.initialNode.getData();
+        if (this.count > 1) {
+            this.initialNode = this.initialNode.getNext();
+            this.initialNode.assignPrev(null);
+        } else {
+            this.initialNode = null;
         }
-        else {
-            newHead.prev = newTail;
-            newTail.next = newHead;
-            head = newHead;
-        }
-
-        return value;
+        this.count--;
+        return data;
     }
 
-    private static final class Element<T> {
-        private final T value;
-        private Element<T> prev;
-        private Element<T> next;
+    public void unshift(T data) {
+        Node<T> newNode  = new Node<>(data),
+                initNode = this.initialNode;
+        if (this.count > 0) makeConnection(newNode, initNode);
+        this.initialNode = newNode;
+        this.count++;
+    }
 
-        Element(T value, Element<T> prev, Element<T> next) {
-            this.value = value;
-            this.prev = prev;
-            this.next = next;
+    public void insert(T data, int index) {
+        if (index < 0) throw new RuntimeException("Index must be above zero");
+        if (index >= this.count && this.count != 0) {
+            extendedPush(data, index);
+        } else {
+            insertWithinScope(data, index);
         }
+    }
+
+    public void replace(int index, T data) {
+      if (index >= this.count || this.initialNode == null) throw new RuntimeException("Index out of range of array");
+      Node<T> selectedNode = getNodeAt(this.initialNode, index, 0);
+      selectedNode.assignData(data);
+    }
+
+    public T getValueAtIndex(int index) {
+        final String errMsg = "Index outside of range of LinkedList";
+        if (index >= this.count) throw new RuntimeException(errMsg);
+        Node<T> requestedNode = getNodeAt(this.initialNode, index, 0);
+        return requestedNode.getData();
+    }
+
+    public Integer find(T data) {
+      if (this.count == 0) return null;
+      Node<T> currentNode = this.initialNode;
+      for (int i = 0; i < this.count; i++) {
+        if (currentNode.getData() == data) {
+          return i;
+        } else {
+          currentNode = currentNode.getNext();
+        }
+      }
+      return null;
+    }
+
+    public int count() {
+        return this.count;
+    }
+
+    private void extendedPush(T data, int index) {
+        Node<T> lastNode = getLastNode(this.initialNode);
+        for (int i = this.count; i < index; i++) {
+            push(null);
+        }
+        push(data);
+    }
+
+    private void insertWithinScope(T data, int index) {
+        Node<T> requestedNode = getNodeAt(this.initialNode, index, 0),
+                prevNode      = (requestedNode == null) ? null : requestedNode.getPrev(),
+                newNode       = new Node<>(data);
+        if (this.count > 0) makeConnection(newNode, requestedNode);
+        if (prevNode != null) makeConnection(prevNode, newNode);
+        if (requestedNode == null || newNode.getPrev() == null) {
+            this.initialNode = newNode;
+        }
+        this.count++;
+    }
+
+    private void makeConnection(Node<T> firstNode, Node<T> secondNode) {
+        firstNode.assignNext(secondNode);
+        secondNode.assignPrev(firstNode);
+    }
+
+    private Node<T> getNodeAt(Node<T> currentNode, int index, int counter) {
+        if (currentNode.hasNext() && index != counter) {
+            counter++;
+            return getNodeAt(currentNode.getNext(), index, counter);
+        } else if (index == counter) {
+            return currentNode;
+        } else {
+            return null;
+        }
+    }
+
+    private Node<T> getLastNode(Node<T> currentNode) {
+        if (currentNode.hasNext()) {
+            return getLastNode(currentNode.getNext());
+        } else {
+            return currentNode;
+        }
+    }
+}
+
+class Node<T> {
+    private T data;
+    private Node<T> nextNode, prevNode;
+
+    public Node(T data) {
+        this.data = data;
+    }
+
+    public void assignData(T data) {
+      this.data = data;
+    }
+
+    public void assignNext(Node<T> nextNode) {
+        this.nextNode = nextNode;
+    }
+
+    public void assignPrev(Node<T> prevNode) {
+        this.prevNode = prevNode;
+    }
+
+    public T getData() {
+        return this.data;
+    }
+
+    public Node<T> getNext() {
+        return this.nextNode;
+    }
+
+    public Node<T> getPrev() {
+        return this.prevNode;
+    }
+
+    public boolean hasNext() {
+        return this.nextNode != null;
+    }
+
+    public boolean hasPrev() {
+        return this.prevNode != null;
     }
 }

--- a/exercises/linked-list/src/test/java/DoublyLinkedListTest.java
+++ b/exercises/linked-list/src/test/java/DoublyLinkedListTest.java
@@ -40,6 +40,7 @@ public class DoublyLinkedListTest {
 
         assertThat(list.shift(), is("10"));
         assertThat(list.shift(), is("20"));
+        assertThat(list.count(), is(0));
     }
 
     @Ignore("Remove to run test")
@@ -51,6 +52,7 @@ public class DoublyLinkedListTest {
         list.unshift('2');
 
         assertThat(list.shift(), is('2'));
+        assertThat(list.count(), is(1));
         assertThat(list.shift(), is('1'));
     }
 
@@ -64,6 +66,26 @@ public class DoublyLinkedListTest {
 
         assertThat(list.pop(), is(10));
         assertThat(list.pop(), is(20));
+    }
+
+    @Ignore("Remove to run test")
+    @Test
+    public void testInsert() {
+      DoublyLinkedList<String> list = new DoublyLinkedList<>("Foo", "Bar");
+
+      list.insert("Hello", 1);
+      list.insert("World", 3);
+      list.insert("FooBar", 5);
+      list.insert("BarFoo", 0);
+
+      assertThat(list.getValueAtIndex(0), is("BarFoo"));
+      assertThat(list.getValueAtIndex(1), is("Foo"));
+      assertThat(list.getValueAtIndex(2), is("Hello"));
+      assertThat(list.getValueAtIndex(3), is("Bar"));
+      assertThat(list.getValueAtIndex(4), is("World"));
+      assertNull(list.getValueAtIndex(5));
+      assertThat(list.getValueAtIndex(6), is("FooBar"));
+      assertThat(list.count(), is(7));
     }
 
     @Ignore("Remove to run test")

--- a/exercises/linked-list/src/test/java/DoublyLinkedListTest.java
+++ b/exercises/linked-list/src/test/java/DoublyLinkedListTest.java
@@ -3,6 +3,7 @@ import org.junit.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNull;
 
 public class DoublyLinkedListTest {
 

--- a/exercises/linked-list/src/test/java/DoublyLinkedListTest.java
+++ b/exercises/linked-list/src/test/java/DoublyLinkedListTest.java
@@ -101,6 +101,18 @@ public class DoublyLinkedListTest {
 
     @Ignore("Remove to run test")
     @Test
+    public void testReplace() {
+      DoublyLinkedList<String> list = new DoublyLinkedList<>();
+
+      list.push("Goodbye");
+      list.push("World");
+      list.replace(0, "Hello");
+
+      assertThat(list.getValueAtIndex(0), is("Hello"));
+      assertThat(list.getValueAtIndex(1), is("World"));
+    }
+
+    @Test
     public void testExample() {
         DoublyLinkedList<String> list = new DoublyLinkedList<>();
 
@@ -108,17 +120,28 @@ public class DoublyLinkedListTest {
         list.push("twenty");
 
         assertThat(list.pop(), is("twenty"));
+        assertThat(list.count(), is(1));
 
+        list.insert("zero", 0);
         list.push("thirty");
 
-        assertThat(list.shift(), is("ten"));
+        assertThat(list.shift(), is("zero"));
+        assertThat(list.getValueAtIndex(0), is("ten"));
+        assertThat(list.count(), is(2));
 
         list.unshift("forty");
         list.push("fifty");
+        list.insert("seventy", 5);
+
+        assertNull(list.getValueAtIndex(4));
+        assertThat(list.find("thirty"), is(2));
+
+        list.replace(4, "sixty");
 
         assertThat(list.shift(), is("forty"));
-        assertThat(list.pop(), is("fifty"));
-        assertThat(list.shift(), is("thirty"));
+        assertThat(list.pop(), is("seventy"));
+        assertThat(list.pop(), is("sixty"));
+        assertThat(list.shift(), is("ten"));
     }
 
 }

--- a/exercises/linked-list/src/test/java/DoublyLinkedListTest.java
+++ b/exercises/linked-list/src/test/java/DoublyLinkedListTest.java
@@ -22,6 +22,16 @@ public class DoublyLinkedListTest {
 
     @Ignore("Remove to run test")
     @Test
+    public void testInitializeWithValues() {
+      DoublyLinkedList<Character> list = new DoublyLinkedList<>('a', 'b', 'c');
+
+      assertThat(list.getValueAtIndex(0), is('a'));
+      assertThat(list.getValueAtIndex(1), is('b'));
+      assertThat(list.getValueAtIndex(2), is('c'));
+    }
+
+    @Ignore("Remove to run test")
+    @Test
     public void testPushShift() {
         DoublyLinkedList<String> list = new DoublyLinkedList<>();
 

--- a/exercises/linked-list/src/test/java/DoublyLinkedListTest.java
+++ b/exercises/linked-list/src/test/java/DoublyLinkedListTest.java
@@ -90,6 +90,17 @@ public class DoublyLinkedListTest {
 
     @Ignore("Remove to run test")
     @Test
+    public void testFind() {
+      DoublyLinkedList<Character> list = new DoublyLinkedList<>('h', 'e', 'l', 'l', 'o');
+
+      assertThat(list.find('e'), is(1));
+      assertThat(list.find('o'), is(4));
+      assertThat(list.find('l'), is(2)); // Returns first index if multiple elements exist
+      assertNull(list.find('r'));
+    }
+
+    @Ignore("Remove to run test")
+    @Test
     public void testExample() {
         DoublyLinkedList<String> list = new DoublyLinkedList<>();
 

--- a/exercises/linked-list/src/test/java/DoublyLinkedListTest.java
+++ b/exercises/linked-list/src/test/java/DoublyLinkedListTest.java
@@ -13,8 +13,11 @@ public class DoublyLinkedListTest {
         list.push(10);
         list.push(20);
 
+        assertThat(list.count(), is(2));
         assertThat(list.pop(), is(20));
+        assertThat(list.count(), is(1));
         assertThat(list.pop(), is(10));
+        assertThat(list.count(), is(0));
     }
 
     @Ignore("Remove to run test")


### PR DESCRIPTION
<!-- Your content goes here: -->
Increase DoublyLinkedList functionality to be more verbose and versatile.
Updated the test suite with the following new methods:
- `count()` - returns an `int` with the number of nodes in the list
- `getValueAtIndex(int index)` - returns the data stored in the node at the given index
- Initialize list with data - functionality to initialize the list with an initial set of data; ex: `new DoublyLinkedList<String>("Hello", "World");` will create a new linked list with two linked nodes containing "Hello" and "World" respectively.
- `insert(T data, int index)` - Inserts a new node with the given data at the given index shifting all prior nodes back and other nodes forward.
- `find(T data)` - returns the index number of the given data. If multiple results, it returns the index of the first index. If it is not found, it returns `null`.
- `replace(int index, T data)` - replaces the node's data at the given index with the given data

Furthermore, I updated the final `testExample` with all the new functionality.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
