### PR TITLE
Change reverse method signature to follow test requirements

### DIFF
--- a/exercises/reverse-string/src/main/java/ReverseString.java
+++ b/exercises/reverse-string/src/main/java/ReverseString.java
@@ -1,6 +1,6 @@
 class ReverseString {
   
-    String reverse() {
+    String reverse(String stringToReverse) {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
     }
   


### PR DESCRIPTION
[Tests](https://github.com/exercism/java/blob/master/exercises/reverse-string/src/test/java/ReverseStringTest.java) in `reverse-string` exercise require that the method `ReverseString#reverse` should have the following signature - `reserse(String)`

This PR modifies the exercise placeholder to fix this inconsistency


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
