### PR TITLE
parallel-letter-frequency: remove characters with accents / diacritics

### DIFF
--- a/exercises/parallel-letter-frequency/.meta/HINTS.md
+++ b/exercises/parallel-letter-frequency/.meta/HINTS.md
@@ -2,4 +2,4 @@ Single-threaded (non-concurrent) solutions can pass all tests [but the last.](ht
 
 Java documentation on [parallel streams](https://docs.oracle.com/javase/tutorial/collections/streams/parallelism.html) may provide some help.
 
-As a stretch goal, consider if your implementation will work for characters with [diacritics or accents](https://en.wikipedia.org/wiki/Diacritic). For example, a good solution should not consider e and ë the same character. An example text for this case is [Wilhelmus](https://en.wikipedia.org/wiki/Wilhelmus), the dutch national anthem.
+As a stretch goal, consider if your implementation will work for characters with [diacritics or accents](https://en.wikipedia.org/wiki/Diacritic). For example, such solutions should not consider e and ë the same character. An example text for this case is [Wilhelmus](https://en.wikipedia.org/wiki/Wilhelmus), the Dutch national anthem.

--- a/exercises/parallel-letter-frequency/.meta/HINTS.md
+++ b/exercises/parallel-letter-frequency/.meta/HINTS.md
@@ -1,3 +1,5 @@
 Single-threaded (non-concurrent) solutions can pass all tests [but the last.](https://www.youtube.com/watch?v=mJZZNHekEQw)  Your solution will be tested for concurrency by submitting it as a [Runnable](https://docs.oracle.com/javase/7/docs/api/java/lang/Runnable.html) to an [ExecutorService.](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ExecutorService.html) Your solution must leverage multiple [Threads](https://docs.oracle.com/javase/7/docs/api/java/lang/Thread.html) to pass the final test.
 
 Java documentation on [parallel streams](https://docs.oracle.com/javase/tutorial/collections/streams/parallelism.html) may provide some help.
+
+As a stretch goal, consider if your implementation will work for characters with [diacritics or accents](https://en.wikipedia.org/wiki/Diacritic). For example, a good solution should not consider e and ë the same character. An example text for this case is [Wilhelmus](https://en.wikipedia.org/wiki/Wilhelmus), the dutch national anthem.

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -13,7 +13,7 @@ Single-threaded (non-concurrent) solutions can pass all tests [but the last.](ht
 
 Java documentation on [parallel streams](https://docs.oracle.com/javase/tutorial/collections/streams/parallelism.html) may provide some help.
 
-As a stretch goal, consider if your implementation will work for characters with [diacritics or accents](https://en.wikipedia.org/wiki/Diacritic). For example, a good solution should not consider e and ë the same character. An example text for this case is [Wilhelmus](https://en.wikipedia.org/wiki/Wilhelmus), the dutch national anthem.
+As a stretch goal, consider if your implementation will work for characters with [diacritics or accents](https://en.wikipedia.org/wiki/Diacritic). For example, such solutions should not consider e and ë the same character. An example text for this case is [Wilhelmus](https://en.wikipedia.org/wiki/Wilhelmus), the Dutch national anthem.
 
 # Running the tests
 

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -13,6 +13,7 @@ Single-threaded (non-concurrent) solutions can pass all tests [but the last.](ht
 
 Java documentation on [parallel streams](https://docs.oracle.com/javase/tutorial/collections/streams/parallelism.html) may provide some help.
 
+As a stretch goal, consider if your implementation will work for characters with [diacritics or accents](https://en.wikipedia.org/wiki/Diacritic). For example, a good solution should not consider e and ë the same character. An example text for this case is [Wilhelmus](https://en.wikipedia.org/wiki/Wilhelmus), the dutch national anthem.
 
 # Running the tests
 

--- a/exercises/parallel-letter-frequency/src/test/java/ParallelLetterFrequencyTest.java
+++ b/exercises/parallel-letter-frequency/src/test/java/ParallelLetterFrequencyTest.java
@@ -8,28 +8,6 @@ import java.util.*;
 
 public class ParallelLetterFrequencyTest {
 
-    // Poem by Friedrich Schiller. The corresponding music is the European Anthem.
-    private String OdeAnDieFreude =
-            "Freude schöner Götterfunken\n" +
-                    "Tochter aus Elysium,\n" +
-                    "Wir betreten feuertrunken,\n" +
-                    "Himmlische, dein Heiligtum!\n" +
-                    "Deine Zauber binden wieder\n" +
-                    "Was die Mode streng geteilt;\n" +
-                    "Alle Menschen werden Brüder,\n" +
-                    "Wo dein sanfter Flügel weilt.";
-
-    // Dutch national anthem
-    private String Wilhelmus =
-            "Wilhelmus van Nassouwe\n" +
-                    "ben ik, van Duitsen bloed,\n" +
-                    "den vaderland getrouwe\n" +
-                    "blijf ik tot in den dood.\n" +
-                    "Een Prinse van Oranje\n" +
-                    "ben ik, vrij, onverveerd,\n" +
-                    "den Koning van Hispanje\n" +
-                    "heb ik altijd geëerd.";
-
     // American national anthem
     private String StarSpangledBanner =
             "O say can you see by the dawn's early light,\n" +
@@ -118,7 +96,7 @@ public class ParallelLetterFrequencyTest {
     @Ignore("Remove to run test")
     @Test
     public void punctuationDoesntCount() {
-        ParallelLetterFrequency p = new ParallelLetterFrequency(OdeAnDieFreude);
+        ParallelLetterFrequency p = new ParallelLetterFrequency(StarSpangledBanner);
 
         assertFalse(p.letterCounts().containsKey((int) ','));
     }
@@ -129,21 +107,6 @@ public class ParallelLetterFrequencyTest {
         ParallelLetterFrequency p = new ParallelLetterFrequency("Testing, 1, 2, 3");
 
         assertFalse(p.letterCounts().containsKey((int) '1'));
-    }
-
-    @Ignore("Remove to run test")
-    @Test
-    public void allThreeAnthemsTogetherProduceCorrectCounts() {
-        StringBuilder b = new StringBuilder();
-        b.append(OdeAnDieFreude);
-        b.append(Wilhelmus);
-        b.append(StarSpangledBanner);
-
-        ParallelLetterFrequency p = new ParallelLetterFrequency(b.toString());
-
-        assertEquals(new Integer(49), p.letterCounts().get((int) 'a'));
-        assertEquals(new Integer(56), p.letterCounts().get((int) 't'));
-        assertEquals(new Integer(2), p.letterCounts().get((int) 'ü'));
     }
 
     @Ignore("Remove to run test")


### PR DESCRIPTION
<!-- Your content goes here: -->
Fixes #1104.

I have removed the two Strings called 'OdeAnDieFreude' and Wilhelmus. The test case for appending all three anthems has been removed, and in the comma test case, I have substituted 'StarSpangledBannner'.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
