### PR TITLE
two-fer: make classes and methods package private

### DIFF
--- a/exercises/two-fer/.meta/src/reference/java/Twofer.java
+++ b/exercises/two-fer/.meta/src/reference/java/Twofer.java
@@ -1,5 +1,5 @@
-public class Twofer {
-    public String twofer(String name) {
+class Twofer {
+    String twofer(String name) {
         return "One for " + (name != null ? name : "you") + ", one for me.";
     }
 }

--- a/exercises/two-fer/src/main/java/Twofer.java
+++ b/exercises/two-fer/src/main/java/Twofer.java
@@ -1,5 +1,5 @@
-public class Twofer {
-    public String twofer(String name) {
+class Twofer {
+    String twofer(String name) {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
     }
 }


### PR DESCRIPTION
<!-- Your content goes here: -->
Classes and methods in reference and starter implementation are now package private as described in the policies doc.

Fix for issue #1108 

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
