### PR TITLE
Update TESTS.md

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -69,7 +69,7 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 3. Run the tests:
 
     ```
-    $ gradle test
+    $ ./gradlew test
     ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
@@ -104,7 +104,7 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 3. Run the tests:
 
     ```
-    $ gradle test
+    $ ./gradlew test
     ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 


### PR DESCRIPTION
On Mac OS X the command "$ gradle test" (row 72 in this doc) won't work. I propose to change it to "$ ./gradlew test" to execute the gradle wrapper with the 'test' argument. Linux should be the same.

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
