### PR TITLE
add travis_retry param to rvm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ addons:
       - tree
 
 before_install:
-  - rvm install 2.2.5
+  - travis_retry rvm install 2.2.5
   - rvm use 2.2.5
 
 # https://docs.travis-ci.com/user/customizing-the-build#Skipping-the-Installation-Step


### PR DESCRIPTION
<!-- Your content goes here: -->
As mentioned in #1199, build as failing intermittently.

This PR adds a retry parameter to the `rvm install` line, which seems to be where about half the build failures come from. The others seem to come from a mix of timeouts from installing caching utils and broken connections.

I wasn't too sure if the retry parameter could be added to caching utils, and I wasn't too sure where this would go. Let me know about improving this PR if we think more problems can be fixed here, as I don't have much experience with Travis :slightly_smiling_face: 


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
