### PR TITLE
run-length-encoding: added hints about no starter implementation

### DIFF
--- a/exercises/run-length-encoding/.meta/hints.md
+++ b/exercises/run-length-encoding/.meta/hints.md
@@ -1,30 +1,3 @@
-# Run Length Encoding
-
-Implement run-length encoding and decoding.
-
-Run-length encoding (RLE) is a simple form of data compression, where runs
-(consecutive data elements) are replaced by just one data value and count.
-
-For example we can represent the original 53 characters with only 13.
-
-```text
-"WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"  ->  "12WB12W3B24WB"
-```
-
-RLE allows the original data to be perfectly reconstructed from
-the compressed data, which makes it a lossless data compression.
-
-```text
-"AABCCCDEEEE"  ->  "2AB3CD4E"  ->  "AABCCCDEEEE"
-```
-
-For simplicity, you can assume that the unencoded string will only contain
-the letters A through Z (either lower or upper case) and whitespace. This way
-data to be encoded will never contain any numbers and numbers inside data to
-be decoded always represent the count for the following character.
-
-# Java Tips
-
 Since this exercise has difficulty 5 it doesn't come with any starter implementation.
 This is so that you get to practice creating classes and methods which is an important part of programming in Java.
 It does mean that when you first try to run the tests, they won't compile.
@@ -83,22 +56,3 @@ Or you could set your method to return some random type (e.g. `void`), and run t
 The new error should tell you which type it's expecting.
 
 After having resolved these errors you should be ready to start making the tests pass!
-
-
-# Running the tests
-
-You can run all the tests for an exercise by entering
-
-```sh
-$ gradle test
-```
-
-in your terminal.
-
-## Source
-
-Wikipedia [https://en.wikipedia.org/wiki/Run-length_encoding](https://en.wikipedia.org/wiki/Run-length_encoding)
-
-## Submitting Incomplete Solutions
-
-It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
Added new hints.md file copied from exercises/flatten-array/.meta/hints.md
and regenerated the README.md file using configlet. Fixes #1089

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
