### PR TITLE
Inline the exercise README insert

### DIFF
--- a/config/exercise-readme-insert.md
+++ b/config/exercise-readme-insert.md
@@ -1,9 +1,0 @@
-# Running the tests
-
-You can run all the tests for an exercise by entering
-
-```sh
-$ gradle test
-```
-
-in your terminal.

--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -6,10 +6,16 @@
 
 {{ . }}
 {{ end }}
-{{- with .TrackInsert }}
-{{ . }}
-{{ end }}
-{{- with .Spec.Credits -}}
+# Running the tests
+
+You can run all the tests for an exercise by entering
+
+```sh
+$ gradle test
+```
+
+in your terminal.
+{{ with .Spec.Credits }}
 ## Source
 
 {{ . }}

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -41,7 +41,6 @@ $ gradle test
 
 in your terminal.
 
-
 ## Submitting Incomplete Solutions
 
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -41,7 +41,6 @@ $ gradle test
 
 in your terminal.
 
-
 ## Submitting Incomplete Solutions
 
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -50,7 +50,6 @@ $ gradle test
 
 in your terminal.
 
-
 ## Submitting Incomplete Solutions
 
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -17,7 +17,6 @@ $ gradle test
 
 in your terminal.
 
-
 ## Submitting Incomplete Solutions
 
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -25,17 +25,6 @@ enough.)
 
 Words are case-insensitive.
 
-# Running the tests
-
-You can run all the tests for an exercise by entering
-
-```sh
-$ gradle test
-```
-
-in your terminal.
-
-
 ## Submitting Incomplete Solutions
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.
 

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -27,7 +27,6 @@ $ gradle test
 
 in your terminal.
 
-
 ## Submitting Incomplete Solutions
 
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/markdown/README.md
+++ b/exercises/markdown/README.md
@@ -24,7 +24,6 @@ $ gradle test
 
 in your terminal.
 
-
 ## Submitting Incomplete Solutions
 
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -36,7 +36,6 @@ $ gradle test
 
 in your terminal.
 
-
 ## Submitting Incomplete Solutions
 
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -26,7 +26,6 @@ $ gradle test
 
 in your terminal.
 
-
 ## Submitting Incomplete Solutions
 
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -73,7 +73,6 @@ $ gradle test
 
 in your terminal.
 
-
 ## Submitting Incomplete Solutions
 
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -27,7 +27,6 @@ $ gradle test
 
 in your terminal.
 
-
 ## Submitting Incomplete Solutions
 
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -74,7 +74,6 @@ $ gradle test
 
 in your terminal.
 
-
 ## Submitting Incomplete Solutions
 
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -66,7 +66,7 @@ in your terminal.
 
 ## Source
 
-This is an exercise to introduce users to basic programming constructs, just after Hello World. [https://en.wikipedia.org/wiki/Two-fer](https://en.wikipedia.org/wiki/Two-fer)
+[https://en.wikipedia.org/wiki/Two-fer](https://en.wikipedia.org/wiki/Two-fer)
 
 ## Submitting Incomplete Solutions
 

--- a/exercises/word-search/README.md
+++ b/exercises/word-search/README.md
@@ -36,7 +36,6 @@ $ gradle test
 
 in your terminal.
 
-
 ## Submitting Incomplete Solutions
 
 It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
Now that we're operating with a track-wide template for generating exercise
READMEs we no longer need a separate markdown document to use for hints
and instructions that apply to all the exercises in a track. These instructions
can be defined directly in the template.

The first commit regenerates the exercise READMEs to pick up tweaks to problem descriptions, which have been updated with various formatting changes, whitespace changes, and clarifications to the description.

That gives us a clean diff when inlining the template and regenerating.

Ref: https://github.com/exercism/meta/issues/94