### PR TITLE
remove reference to xjava

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,4 @@
 
 Reviewer Resources:
 
-[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
+[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)


### PR DESCRIPTION
<!-- Your content goes here: -->
Just noticed that in the PR template we still reference 'xjava' instead of 'java'.

I've swapped it to use the newer term, so first-time users aren't confused :slightly_smiling_face: 


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/xjava/blob/master/POLICIES.md#event-checklist)
