### PR TITLE
protein-translation: update unlocked by

### DIFF
--- a/config.json
+++ b/config.json
@@ -197,7 +197,7 @@
         "loops",
         "strings"
       ],
-      "unlocked_by": "rna-transcription",
+      "unlocked_by": "two-fer",
       "uuid": "331073b3-bd1a-4868-b767-a64ce9fd9d97"
     },
     {


### PR DESCRIPTION
It was previously unlocked by rna-transcription which is not a core exercise.
Exercises must be unlocked by core exercises.

<!-- Your content goes here: -->

Fixes #1366.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
