### PR TITLE
Fix canonical data check script

### DIFF
--- a/scripts/canonical_data_check.sh
+++ b/scripts/canonical_data_check.sh
@@ -93,7 +93,7 @@ do
         continue
     fi
 
-    track_data_version=$(cat $track_exercise_version_file_path)
+    track_data_version=$(cat $track_exercise_version_file_path | sed 's/\r$//')
 
     if [ "$track_data_version" = "$canonical_data_version" ]
     then


### PR DESCRIPTION
The script was reporting versions as different because of line endings. These line endings are now being removed before the version comparison.

I've tested it in WSL on windows. There's a chance it could cause problems on mac or linux (I don't think it would but you never know) so if anyone wants to try it to check then feel free 🙂

Fixes #1261. 

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
