### PR TITLE
hello-world: set auto-approve to true

### DIFF
--- a/config.json
+++ b/config.json
@@ -17,7 +17,8 @@
       "difficulty": 1,
       "topics": [
         "strings"
-      ]
+      ],
+      "auto-approve": true
     },
     {
       "slug": "two-fer",


### PR DESCRIPTION
The first core exercise on the track should be auto-approved. This means that mentor approval isn't needed in order to move forward when the exercise has been completed.

Currently any hello-world exercises are auto-approved in the backend of v2 but this special handling might be removed later which is why this also needs to be set in config.json.

This fixes the last point in issue #1481.

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
