### PR TITLE
amend auto_approve for hello-world

### DIFF
--- a/config.json
+++ b/config.json
@@ -18,7 +18,7 @@
       "topics": [
         "strings"
       ],
-      "auto-approve": true
+      "auto_approve": true
     },
     {
       "slug": "two-fer",


### PR DESCRIPTION
<!-- Your content goes here: -->
Completely missed this in my review! From the look of #1481, it seems like the `config.json` should use `auto_approve` not `auto-approve` 🙂 


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
