### PR TITLE
Make journey-test up to date with exercism cli updates

### DIFF
--- a/bin/journey-test.sh
+++ b/bin/journey-test.sh
@@ -3,341 +3,141 @@
 TRACK=java
 TRACK_REPO="$TRACK"
 TRACK_SRC_EXT="java"
-CPU_CORES=`getconf NPROCESSORS_ONLN 2>/dev/null || getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1`
 EXERCISES_TO_SOLVE=$@
 
 on_exit() {
-  echo ">>> on_exit()"
-  if [[ "$xapi_pid" != "" ]] ; then
-    kill $xapi_pid
-    echo "stopped x-api (pid=${xapi_pid})"
-  fi
-  cd $EXECPATH
-  echo "<<< on_exit()"
+    echo ">>> on_exit()"
+    cd $EXECPATH
+    echo "<<< on_exit()"
 }
 
 assert_installed() {
-  local binary=$1
-  echo ">>> assert_installed(binary=\"${binary}\")"
-
-  if [[ "`which $binary`" == "" ]]; then
-    echo "${binary} not found; it is required to perform this test."
-    echo -e "Have you completed the setup instructions at https://github.com/exercism/${TRACK_REPO} ?\n"
-    echo "PATH=${PATH}"
-    echo "aborting."
-    exit 1
-  fi
-  echo "<<< assert_installed()"
-}
-
-assert_ruby_installed() {
-  local ruby_app_home="$1"
-  echo ">>> assert_ruby_installed(ruby_app_home=\"${ruby_app_home}\")"
-
-  pushd "${ruby_app_home}"
-  local current_ruby_ver=`ruby --version | egrep --only-matching "[0-9]+\.[0-9]+\.[0-9]+"`
-  local expected_ruby_ver=`cat Gemfile | awk -F\' '/ruby /{print $2}'`
-  popd
-  if [[ "${expected_ruby_ver}" != "" && "${current_ruby_ver}" != "${expected_ruby_ver}" ]]; then
-    echo "${ruby_app_home} requires Ruby ${expected_ruby_ver}; current Ruby version is ${current_ruby_ver}."
-    echo -e "Ruby used: `which ruby`.\n"
-    echo -e "Have you completed the setup instructions at https://github.com/exercism/${TRACK_REPO} ?\n"
-    echo "PATH=${PATH}"
-    echo "aborting."
-    exit 1
-  fi
-  echo "<<< assert_ruby_installed()"
+    local binary=$1
+    echo ">>> assert_installed(binary=\"${binary}\")"
+    
+    if [[ "`which $binary`" == "" ]]; then
+        echo "${binary} not found; it is required to perform this test."
+        echo -e "Have you completed the setup instructions at https://github.com/exercism/${TRACK_REPO} ?\n"
+        echo "PATH=${PATH}"
+        echo "aborting."
+        exit 1
+    fi
+    echo "<<< assert_installed()"
 }
 
 clean() {
-  local build_dir="$1"
-  echo ">>> clean(build_dir=\"${build_dir}\")"
-
-  # empty, absolute path, or parent reference are considered dangerous to rm -rf against.
-  if [[ "${build_dir}" == "" || ${build_dir} =~ ^/ || ${build_dir} =~ \.\. ]] ; then
-    echo "Value for build_dir looks dangerous.  Aborting."
-    exit 1
-  fi
-
-  local build_path=$( pwd )/${build_dir}
-  if [[ -d "${build_path}" ]] ; then
-    echo "Cleaning journey script build output directory (${build_path})."
-    rm -rf "${build_path}"
-  fi
-  cd exercises
-  "$EXECPATH"/gradlew clean
-  cd ..
-  echo "<<< clean()"
+    local build_dir="$1"
+    echo ">>> clean(build_dir=\"${build_dir}\")"
+    
+    # empty, absolute path, or parent reference are considered dangerous to rm -rf against.
+    if [[ "${build_dir}" == "" || ${build_dir} =~ ^/ || ${build_dir} =~ \.\. ]] ; then
+        echo "Value for build_dir looks dangerous.  Aborting."
+        exit 1
+    fi
+    
+    local build_path=$( pwd )/${build_dir}
+    if [[ -d "${build_path}" ]] ; then
+        echo "Cleaning journey script build output directory (${build_path})."
+        rm -rf "${build_path}"
+    fi
+    cd exercises
+    "$EXECPATH"/gradlew clean
+    cd ..
+    echo "<<< clean()"
 }
 
-get_operating_system() {
-  case $(uname) in
-      (Darwin*)
-          echo "mac";;
-      (Linux*)
-          echo "linux";;
-      (Windows*)
-          echo "windows";;
-      (MINGW*)
-          echo "windows";;
-      (*)
-          echo "linux";;
-  esac
-}
+solve_exercise() {
+    local exercise="$1"
 
-get_cpu_architecture() {
-  case $(uname -m) in
-      (*64*)
-          echo 64bit;;
-      (*686*)
-          echo 32bit;;
-      (*386*)
-          echo 32bit;;
-      (*)
-          echo 64bit;;
-  esac
-}
-
-get_optimal_amount_of_jobs() {
-  if [ "$CPU_CORES" -gt "1" ]; then 
-    echo $((CPU_CORES-1))
-  else 
-    echo 1 
-  fi
-}
-
-download_exercism_cli() {
-  local os="$1"
-  local arch="$2"
-  local exercism_home="$3"
-  echo ">>> download_exercism_cli(os=\"${os}\", arch=\"${arch}\", exercism_home=\"${exercism_home}\")"
-
-  local CLI_RELEASES=https://github.com/exercism/cli/releases
-
-  local latest=${CLI_RELEASES}/latest
-  # "curl..." :: HTTP 302 headers, including "Location" -- URL to redirect to.
-  # "awk..." :: pluck last path segment from "Location" (i.e. the version number)
-  local version="$(curl --head --silent ${latest} | awk -v FS=/ '/Location:/{print $NF}' | tr -d '\r')"
-
-  local download_url_suffix
-  local unzip_command
-  local unzip_from_file_option
-  if [[ ${os} == "windows" ]] ; then
-    download_url_suffix="zip"
-    unzip_command="unzip -d"
-    unzip_from_file_option=""
-  else
-    download_url_suffix="tgz"
-    unzip_command="tar xz -C"
-    unzip_from_file_option="-f"
-  fi
-  local download_url=${CLI_RELEASES}/download/${version}/exercism-${os}-${arch}.${download_url_suffix}
-
-  mkdir -p ${exercism_home}
-  local temp=`mktemp`
-  curl -s --location ${download_url} > ${temp}
-  ${unzip_command} ${exercism_home} ${unzip_from_file_option} ${temp}
-  echo "<<< download_exercism_cli()"
-}
-
-git_clone() {
-  local repo_name="$1"
-  local dest_path="$2"
-  echo ">>> git_clone(repo_name=\"${repo_name}\", dest_path=\"${dest_path}\")"
-
-  git clone https://github.com/exercism/${repo_name} ${dest_path}
-
-  echo "<<< git_clone()"
-}
-
-make_local_trackler() {
-  local trackler="$1"
-  local xapi_home="$2"
-  echo ">>> make_local_trackler(trackler=\"${trackler}\", xapi_home=\"${xapi_home}\")"
-
-  local track_root=$( pwd )
-  pushd ${trackler}
-
-  # Get the version of Trackler x-api is currently using
-  local version=$( grep -m 1 'trackler' ${xapi_home}/Gemfile.lock | sed 's/.*(//' | sed 's/)//' )
-
-  git checkout v${version}
-  git submodule init -- problem-specifications
-  git submodule update
-
-  # Bake in local copy of this track; this is what we are testing.
-  rmdir tracks/${TRACK}
-  mkdir -p tracks/${TRACK}/exercises
-  cp ${track_root}/config.json tracks/${TRACK}
-  cp -r ${track_root}/exercises tracks/${TRACK}
-
-  gem install bundler
-  bundle install --jobs $(get_optimal_amount_of_jobs)
-  gem build trackler.gemspec
-
-  # Make *this* the gem that x-api uses when we build x-api.
-  gem install --local trackler-*.gem
-
-  popd > /dev/null
-  echo "<<< make_local_trackler()"
-}
-
-start_x_api() {
-  local xapi_home="$1"
-  echo ">>> start_x_api(xapi_home=\"${xapi_home}\")"
-
-  pushd $xapi_home
-
-  gem install bundler
-  bundle install --jobs $(get_optimal_amount_of_jobs) 
-  RACK_ENV=development rackup &
-  xapi_pid=$!
-  sleep 5
-
-  echo "x-api is running (pid=${xapi_pid})."
-
-  popd > /dev/null
-  echo "<<< start_x_api()"
-}
-
-configure_exercism_cli() {
-  local exercism_home="$1"
-  local xapi_port=$2
-  local exercism_cli="./exercism"
-  echo ">>> configure_exercism_cli(exercism_home=\"${exercism_home}\", xapi_port=${xapi_port})"
-
-  mkdir -p "${exercism_home}"
-  pushd "${exercism_home}"
-  ${exercism_cli} configure --token="49b1ceef-a89d-4a13-a5d7-e90a4b694769" --workspace="${exercism_home}" --api http://localhost:${xapi_port}
-  popd
-
-  echo "<<< configure_exercism_cli()"
-}
-
-solve_all_exercises() {
-  local exercism_exercises_dir="$1"
-  echo ">>> solve_all_exercises(exercism_exercises_dir=\"${exercism_exercises_dir}\")"
-
-  local track_root=$( pwd )
-  local exercism_cli="./exercism"
-  local exercises=`cat config.json | jq -c '.exercises[]'`
-  local total_exercises=`cat config.json | jq '.exercises | length'`
-  local current_exercise_number=1
-  local tempfile="${TMPDIR:-/tmp}/journey-test.sh-unignore_all_tests.txt"
-
-  pushd ${exercism_exercises_dir}
-  for exercise in $exercises; do
-    local exercise_uuid=$exercise | jq '.uuid'
-    local exercise_name=$exercise | jq '.slug'
     echo -e "\n\n"
     echo "=================================================="
-    echo "${current_exercise_number} of ${total_exercises} -- ${exercise_name}"
+    echo "Solving ${exercise}"
     echo "=================================================="
 
-    ${exercism_cli} download -t ${TRACK} -u ${exercise_uuid}
-    cp -R -H ${track_root}/exercises/${exercise_name}/.meta/src/reference/${TRACK}/* ${exercism_exercises_dir}/${TRACK}/${exercise_name}/src/main/${TRACK}/
-
-    pushd ${exercism_exercises_dir}/${TRACK}/${exercise_name}
+    mkdir -p ${exercism_exercises_dir}/${TRACK}/${exercise}/src/main/java/
+    mkdir -p ${exercism_exercises_dir}/${TRACK}/${exercise}/src/test/java/
+    cp ${track_root}/exercises/${exercise}/build.gradle ${exercism_exercises_dir}/${TRACK}/${exercise}/build.gradle
+    cp -R -H ${track_root}/exercises/${exercise}/.meta/src/reference/${TRACK}/* ${exercism_exercises_dir}/${TRACK}/${exercise}/src/main/${TRACK}/
+    cp -R -H ${track_root}/exercises/${exercise}/src/test/${TRACK}/* ${exercism_exercises_dir}/${TRACK}/${exercise}/src/test/${TRACK}/
+    
+    pushd ${exercism_exercises_dir}/${TRACK}/${exercise}
     # Check that tests compile before we strip @Ignore annotations
     "$EXECPATH"/gradlew compileTestJava
     # Ensure we run all the tests (as delivered, all but the first is @Ignore'd)
     for testfile in `find . -name "*Test.${TRACK_SRC_EXT}"`; do
-      # Strip @Ignore annotations to ensure we run the tests (as delivered, all but the first is @Ignore'd).
-      # Note that unit-test.sh also strips @Ignore annotations via the Gradle task copyTestsFilteringIgnores.
-      # The stripping implementations here and in copyTestsFilteringIgnores should be kept consistent.
-      sed 's/@Ignore\(\(.*\)\)\{0,1\}//' ${testfile} > "${tempfile}" && mv "${tempfile}" "${testfile}"
+        # Strip @Ignore annotations to ensure we run the tests (as delivered, all but the first is @Ignore'd).
+        # Note that unit-test.sh also strips @Ignore annotations via the Gradle task copyTestsFilteringIgnores.
+        # The stripping implementations here and in copyTestsFilteringIgnores should be kept consistent.
+        sed 's/@Ignore\(\(.*\)\)\{0,1\}//' ${testfile} > "${tempfile}" && mv "${tempfile}" "${testfile}"
     done
     "$EXECPATH"/gradlew test
     popd
+}
 
-    current_exercise_number=$((current_exercise_number + 1))
-  done
-  popd
+solve_all_exercises() {
+    local exercism_exercises_dir="$1"
+    echo ">>> solve_all_exercises(exercism_exercises_dir=\"${exercism_exercises_dir}\")"
+    
+    local track_root=$( pwd )
+    local exercises=`cat config.json | jq '.exercises[].slug + " "' --join-output`
+    local total_exercises=`cat config.json | jq '.exercises | length'`
+    local current_exercise_number=1
+    local tempfile="${TMPDIR:-/tmp}/journey-test.sh-unignore_all_tests.txt"
+
+    mkdir -p ${exercism_exercises_dir}
+    pushd ${exercism_exercises_dir}
+
+    for exercise in $exercises; do
+        echo -e "\n\n"
+        echo "=================================================="
+        echo "${current_exercise_number} of ${total_exercises} -- ${exercise}"
+        echo "=================================================="
+        
+        solve_exercise "${exercise}"
+        
+        current_exercise_number=$((current_exercise_number + 1))
+    done
+    popd
 }
 
 solve_single_exercise() {
-  local exercism_exercises_dir="$1"
-  local exercise_to_solve="$2"
-  echo ">>> solve_single_exercises(exercism_exercises_dir=\"${exercism_exercises_dir}\", exercise_to_solve=\"$exercise_to_solve\")"
-
-  local track_root=$( pwd )
-  local exercism_cli="./exercism"
-  local tempfile="${TMPDIR:-/tmp}/journey-test.sh-unignore_all_tests.txt"
-
-  pushd ${exercism_exercises_dir}
-
-  echo -e "\n\n"
-  echo "=================================================="
-  echo "Solving ${exercise_to_solve}"
-  echo "=================================================="
-
-  local exercise_config_object=`cat config.json | jq -c '.exercises[] | select(.slug | contains("hello-world"))'`
-  local exercise_uuid = ${exercise_config_object} | jq '.uuid'
-  ${exercism_cli} download -t ${TRACK} -u ${exercise_uuid}
-  cp -R -H ${track_root}/exercises/${exercise_to_solve}/.meta/src/reference/${TRACK}/* ${exercism_exercises_dir}/${TRACK}/${exercise_to_solve}/src/main/${TRACK}/
-
-  pushd ${exercism_exercises_dir}/${TRACK}/${exercise_to_solve}
-  # Check that tests compile before we strip @Ignore annotations
-  "$EXECPATH"/gradlew compileTestJava
-  # Ensure we run all the tests (as delivered, all but the first is @Ignore'd)
-  for testfile in `find . -name "*Test.${TRACK_SRC_EXT}"`; do
-    # Strip @Ignore annotations to ensure we run the tests (as delivered, all but the first is @Ignore'd).
-    # Note that unit-test.sh also strips @Ignore annotations via the Gradle task copyTestsFilteringIgnores.
-    # The stripping implementations here and in copyTestsFilteringIgnores should be kept consistent.
-    sed 's/@Ignore\(\(.*\)\)\{0,1\}//' ${testfile} > "${tempfile}" && mv "${tempfile}" "${testfile}"
-  done
-  "$EXECPATH"/gradlew test
-  popd
-
-  popd
+    local exercism_exercises_dir="$1"
+    local exercise_to_solve="$2"
+    echo ">>> solve_single_exercises(exercism_exercises_dir=\"${exercism_exercises_dir}\", exercise_to_solve=\"$exercise_to_solve\")"
+    
+    local track_root=$( pwd )
+    local tempfile="${TMPDIR:-/tmp}/journey-test.sh-unignore_all_tests.txt"
+    
+    mkdir -p ${exercism_exercises_dir}
+    pushd ${exercism_exercises_dir}
+    
+    solve_exercise "${exercise_to_solve}"
+    
+    popd
 }
 
 main() {
-  # all functions assume current working directory is repository root.
-  cd "${SCRIPTPATH}/.."
-
-  local track_root=$( pwd )
-  local build_dir="build"
-  local build_path="${track_root}/${build_dir}"
-
-  local xapi_home="${build_path}/x-api"
-  local trackler_home="${build_path}/trackler"
-  local exercism_home="${build_path}/exercism"
-
-  local xapi_port=9292
-
-  # fail fast if required binaries are not installed.
-  assert_installed "jq"
-
-  clean "${build_dir}"
-
-  # Download everything we need in parallel
-  git_clone "x-api" "${xapi_home}" &
-  git_clone "trackler" "${trackler_home}" &
-  download_exercism_cli $(get_operating_system) $(get_cpu_architecture) "${exercism_home}" &
-  wait
-
-  # Check and install the ruby stuff we need in parallel
-  assert_ruby_installed "${trackler_home}" &
-  assert_ruby_installed "${xapi_home}" &
-  wait
-
-  # Make a local version of trackler
-  make_local_trackler "${trackler_home}" "${xapi_home}"
-
-  # Start-up a local instance of x-api so we can fetch the exercises through it.
-  start_x_api "${xapi_home}"
-
-  # Create a CLI install and config just for this build; this script does not use your CLI install.
-  configure_exercism_cli "${exercism_home}" "${xapi_port}"
-
-  if [[ $EXERCISES_TO_SOLVE == "" ]]; then
-    solve_all_exercises "${exercism_home}"
-  else
-    for exercise in $EXERCISES_TO_SOLVE
-      do solve_single_exercise "${exercism_home}" "${exercise}"
-    done
-  fi
+    # all functions assume current working directory is repository root.
+    cd "${SCRIPTPATH}/.."
+    
+    local track_root=$( pwd )
+    local build_dir="build"
+    local build_path="${track_root}/${build_dir}"
+    
+    local exercism_home="${build_path}/exercism"
+    
+    # fail fast if required binaries are not installed.
+    assert_installed "jq"
+    
+    clean "${build_dir}"
+    
+    if [[ $EXERCISES_TO_SOLVE == "" ]]; then
+        solve_all_exercises "${exercism_home}"
+    else
+        for exercise in $EXERCISES_TO_SOLVE
+        do solve_single_exercise "${exercism_home}" "${exercise}"
+        done
+    fi
 }
 
 ##########################################################################
@@ -350,7 +150,6 @@ EXECPATH=$( pwd )
 # Make output easier to read in CI
 TERM=dumb
 
-xapi_pid=""
 trap on_exit EXIT
 main
 

--- a/bin/run-journey-test-from-ci.sh
+++ b/bin/run-journey-test-from-ci.sh
@@ -1,32 +1,82 @@
 #!/bin/bash
 
-trap 'exit 1' ERR
-bin/build-jq.sh
+contains_setup_file() {
+  local files=$1
+  for file in $files; do
+    if [[ $file == *.gradle || $file == *.sh || $file == config.json ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
-pr_files_json=`curl -s https://api.github.com/repos/exercism/java/pulls/${TRAVIS_PULL_REQUEST}/files`
+contains_exercise() {
+  local files=$1
+  for file in $files; do
+    if [[ $file == exercises* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
-echo "Pull request number: ${TRAVIS_PULL_REQUEST}"
-echo "Changes in pr json: ${pr_files_json}"
+run_journey_test_with_modified_exercises() {
+  local modded_files=$1
+  local last_modded_exercise=""
+  local modded_exercises=""
 
-# if jq fails to get the required data, then that means TRAVIS_PULL_REQUEST was not set (not run in travis-ci),
-# or was false (not a pull request). In that case, we should fall back with testing every exercise
-
-modded_files=`echo $pr_files_json | bin/jq -r '.[].filename'` || bin/journey-test.sh
-
-for file in $modded_files
-  do if [[ $file == exercises* ]] || [[ $file == config.json ]]
-    then
-    for file2 in $modded_files
-      do if [[ $file2 == exercises* ]] && [[ $file2 != exercises/settings.gradle ]] && [[ $file2 != exercises/build.gradle ]]
-        then modded_exercise=${file2#exercises/}
-        modded_exercise=${modded_exercise%%/*}
-        if [[ $last_modded_exercise != $modded_exercise ]]
-          then modded_exercises=$modded_exercises$modded_exercise$'\n'
-        fi
-        last_modded_exercise=$modded_exercise
+  for file in $modded_files; do
+    if [[ $file == exercises* ]] && [[ $file != exercises/settings.gradle ]] && [[ $file != exercises/build.gradle ]]; then
+      local modded_exercise=${file#exercises/}
+      modded_exercise=${modded_exercise%%/*}
+      if [[ $last_modded_exercise != $modded_exercise ]]; then
+        modded_exercises=$modded_exercises$modded_exercise$'\n'
       fi
-    done
-    bin/journey-test.sh $modded_exercises
-    break
+      last_modded_exercise=$modded_exercise
+    fi
+  done
+
+  echo "Running journey test with modified exercise(s): ${modded_exercises}"
+  bin/journey-test.sh $modded_exercises
+}
+
+run_journey_test_with_all_exercises() {
+  echo "Running journey test with all exercises"
+  bin/journey-test.sh
+}
+
+main() {
+  bin/build-jq.sh
+
+  local pr_files_json=`curl -s https://api.github.com/repos/exercism/java/pulls/${TRAVIS_PULL_REQUEST}/files`
+
+  echo "Pull request number: ${TRAVIS_PULL_REQUEST}"
+  echo "Changes in pr json: ${pr_files_json}"
+
+  # if jq fails to get the required data, then that means TRAVIS_PULL_REQUEST was not set (not run in travis-ci),
+  # or was false (not a pull request), or the api limit was reached, or some other error occurred.
+  # In that case, we should fall back with testing every exercise
+  local pr_files_json_type=`echo $pr_files_json | bin/jq -r 'type'`
+  if [[ $pr_files_json_type != "array" ]]; then
+    echo "Didn't get pr changes from travis"
+    run_journey_test_with_all_exercises
+    return
   fi
-done
+
+  local modded_files=`echo $pr_files_json | bin/jq -r '.[].filename'`
+
+  # If the changed files contain a .sh file or .gradle file or config.json then we should run all the exercises
+  if contains_setup_file "${modded_files}"; then
+    echo "Pr changes contain setup file(s): ${modded_files}"
+    run_journey_test_with_all_exercises
+    return
+  fi
+
+  if contains_exercise "${modded_files}"; then
+    echo "Pr changes contain modified exercise file(s)"
+    run_journey_test_with_modified_exercises "${modded_files}"
+  fi
+}
+
+trap 'exit 1' ERR
+main

--- a/bin/run-journey-test-from-ci.sh
+++ b/bin/run-journey-test-from-ci.sh
@@ -1,81 +1,81 @@
 #!/bin/bash
 
 contains_setup_file() {
-  local files=$1
-  for file in $files; do
-    if [[ $file == *.gradle || $file == *.sh || $file == config.json ]]; then
-      return 0
-    fi
-  done
-  return 1
+    local files=$1
+    for file in $files; do
+        if [[ $file == *.gradle || $file == *.sh || $file == config.json ]]; then
+            return 0
+        fi
+    done
+    return 1
 }
 
 contains_exercise() {
-  local files=$1
-  for file in $files; do
-    if [[ $file == exercises* ]]; then
-      return 0
-    fi
-  done
-  return 1
+    local files=$1
+    for file in $files; do
+        if [[ $file == exercises* ]]; then
+            return 0
+        fi
+    done
+    return 1
 }
 
 run_journey_test_with_modified_exercises() {
-  local modded_files=$1
-  local last_modded_exercise=""
-  local modded_exercises=""
-
-  for file in $modded_files; do
-    if [[ $file == exercises* ]] && [[ $file != exercises/settings.gradle ]] && [[ $file != exercises/build.gradle ]]; then
-      local modded_exercise=${file#exercises/}
-      modded_exercise=${modded_exercise%%/*}
-      if [[ $last_modded_exercise != $modded_exercise ]]; then
-        modded_exercises=$modded_exercises$modded_exercise$'\n'
-      fi
-      last_modded_exercise=$modded_exercise
-    fi
-  done
-
-  echo "Running journey test with modified exercise(s): ${modded_exercises}"
-  bin/journey-test.sh $modded_exercises
+    local modded_files=$1
+    local last_modded_exercise=""
+    local modded_exercises=""
+    
+    for file in $modded_files; do
+        if [[ $file == exercises* ]] && [[ $file != exercises/settings.gradle ]] && [[ $file != exercises/build.gradle ]]; then
+            local modded_exercise=${file#exercises/}
+            modded_exercise=${modded_exercise%%/*}
+            if [[ $last_modded_exercise != $modded_exercise ]]; then
+                modded_exercises=$modded_exercises$modded_exercise$'\n'
+            fi
+            last_modded_exercise=$modded_exercise
+        fi
+    done
+    
+    echo "Running journey test with modified exercise(s): ${modded_exercises}"
+    bin/journey-test.sh $modded_exercises
 }
 
 run_journey_test_with_all_exercises() {
-  echo "Running journey test with all exercises"
-  bin/journey-test.sh
+    echo "Running journey test with all exercises"
+    bin/journey-test.sh
 }
 
 main() {
-  bin/build-jq.sh
-
-  local pr_files_json=`curl -s https://api.github.com/repos/exercism/java/pulls/${TRAVIS_PULL_REQUEST}/files`
-
-  echo "Pull request number: ${TRAVIS_PULL_REQUEST}"
-  echo "Changes in pr json: ${pr_files_json}"
-
-  # if jq fails to get the required data, then that means TRAVIS_PULL_REQUEST was not set (not run in travis-ci),
-  # or was false (not a pull request), or the api limit was reached, or some other error occurred.
-  # In that case, we should fall back with testing every exercise
-  local pr_files_json_type=`echo $pr_files_json | bin/jq -r 'type'`
-  if [[ $pr_files_json_type != "array" ]]; then
-    echo "Didn't get pr changes from travis"
-    run_journey_test_with_all_exercises
-    return
-  fi
-
-  local modded_files=`echo $pr_files_json | bin/jq -r '.[].filename'`
-
-  # If the changed files contain a .sh file or .gradle file or config.json then we should run all the exercises
-  if contains_setup_file "${modded_files}"; then
-    echo "Pr changes contain setup file(s): ${modded_files}"
-    run_journey_test_with_all_exercises
-    return
-  fi
-
-  if contains_exercise "${modded_files}"; then
-    echo "Pr changes contain modified exercise file(s)"
-    run_journey_test_with_modified_exercises "${modded_files}"
-  fi
+    bin/build-jq.sh
+    
+    local pr_files_json=`curl -s https://api.github.com/repos/exercism/java/pulls/${TRAVIS_PULL_REQUEST}/files`
+    
+    echo "Pull request number: ${TRAVIS_PULL_REQUEST}"
+    echo "Changes in pr json: ${pr_files_json}"
+    
+    # if jq fails to get the required data, then that means TRAVIS_PULL_REQUEST was not set (not run in travis-ci),
+    # or was false (not a pull request), or the api limit was reached, or some other error occurred.
+    # In that case, we should fall back with testing every exercise
+    local pr_files_json_type=`echo $pr_files_json | bin/jq -r 'type'`
+    if [[ $pr_files_json_type != "array" ]]; then
+        echo "Didn't get pr changes from travis"
+        run_journey_test_with_all_exercises
+        return
+    fi
+    
+    local modded_files=`echo $pr_files_json | bin/jq -r '.[].filename'`
+    
+    # If the changed files contain a .sh file or .gradle file or config.json then we should run all the exercises
+    if contains_setup_file "${modded_files}"; then
+        echo "Pr changes contain setup file(s): ${modded_files}"
+        run_journey_test_with_all_exercises
+        return
+    fi
+    
+    if contains_exercise "${modded_files}"; then
+        echo "Pr changes contain modified exercise file(s)"
+        run_journey_test_with_modified_exercises "${modded_files}"
+    fi
 }
 
 trap 'exit 1' ERR


### PR DESCRIPTION
The exercism cli has been updated, therefore we need to change our build script so that it still works.

Problems we still need to fix:
- `exercism configure` can't be called without a token so I'm currently using my own token. We should find out what the standard procedure is for this, e.g. creating a token for the track or using some option that allows us not to use a token.

- I get the error `The base API URL 'http://localhost:9292' cannot be reached` even though xapi should be running. Apparently other tracks have had this issue as well.

- `exercism --config` doesn't appear to be a valid option anymore. I can't find the config file we were using so I'm hoping it's fine to not use it anymore?

See issue #1493 for details.

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
