### PR TITLE
matrix: Remove unused methods in starter source

### DIFF
--- a/exercises/matrix/src/main/java/Matrix.java
+++ b/exercises/matrix/src/main/java/Matrix.java
@@ -12,12 +12,4 @@ class Matrix {
     int[] getColumn(int columnNumber) {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
     }
-
-    int getRowsCount() {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
-    }
-
-    int getColumnsCount() {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
-    }
 }


### PR DESCRIPTION
Fix #1495 by removing unused methods.

`getRowsCount`/`getColumnsCount` are neither tested nor defined in the reference implementation.



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
