### PR TITLE
error-handling: remove UnsupportedOperationException from starter implementation

### DIFF
--- a/exercises/error-handling/src/main/java/ErrorHandling.java
+++ b/exercises/error-handling/src/main/java/ErrorHandling.java
@@ -19,11 +19,11 @@ class ErrorHandling {
     }
 
     void handleErrorByThrowingAnyUncheckedException() {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+        // Delete this statement and write your own implementation.
     }
 
     void handleErrorByThrowingAnyUncheckedExceptionWithDetailMessage(String message) {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+        // Delete this statement and write your own implementation.
     }
 
     void handleErrorByThrowingCustomCheckedException() {


### PR DESCRIPTION
Fix #1509   

I removed the ```UnsupportedOperationException``` from both ```handleErrorByThrowingAnyUncheckedException``` and ```handleErrorByThrowingAnyUncheckedExceptionWithDetailMessage```

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
