### PR TITLE
Renames the getDate method in the gigasecond exercise to getDateTime

### DIFF
--- a/exercises/gigasecond/.meta/src/reference/java/Gigasecond.java
+++ b/exercises/gigasecond/.meta/src/reference/java/Gigasecond.java
@@ -13,7 +13,7 @@ class Gigasecond {
         this.birthDateTime = birthDateTime;
     }
 
-    LocalDateTime getDate() {
+    LocalDateTime getDateTime() {
         return birthDateTime.plusSeconds(1000000000);
     }
 

--- a/exercises/gigasecond/src/main/java/Gigasecond.java
+++ b/exercises/gigasecond/src/main/java/Gigasecond.java
@@ -11,7 +11,7 @@ class Gigasecond {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
     }
 
-    LocalDateTime getDate() {
+    LocalDateTime getDateTime() {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
     }
 

--- a/exercises/gigasecond/src/test/java/GigasecondTest.java
+++ b/exercises/gigasecond/src/test/java/GigasecondTest.java
@@ -13,7 +13,7 @@ public class GigasecondTest {
     public void modernTime() {
         Gigasecond gigaSecond = new Gigasecond(LocalDate.of(2011, Month.APRIL, 25));
 
-        assertEquals(LocalDateTime.of(2043, Month.JANUARY, 1, 1, 46, 40), gigaSecond.getDate());
+        assertEquals(LocalDateTime.of(2043, Month.JANUARY, 1, 1, 46, 40), gigaSecond.getDateTime());
     }
 
     @Ignore("Remove to run test")
@@ -21,7 +21,7 @@ public class GigasecondTest {
     public void afterEpochTime() {
         Gigasecond gigaSecond = new Gigasecond(LocalDate.of(1977, Month.JUNE, 13));
 
-        assertEquals(LocalDateTime.of(2009, Month.FEBRUARY, 19, 1, 46, 40), gigaSecond.getDate());
+        assertEquals(LocalDateTime.of(2009, Month.FEBRUARY, 19, 1, 46, 40), gigaSecond.getDateTime());
     }
 
     @Ignore("Remove to run test")
@@ -29,7 +29,7 @@ public class GigasecondTest {
     public void beforeEpochTime() {
         Gigasecond gigaSecond = new Gigasecond(LocalDate.of(1959, Month.JULY, 19));
 
-        assertEquals(LocalDateTime.of(1991, Month.MARCH, 27, 1, 46, 40), gigaSecond.getDate());
+        assertEquals(LocalDateTime.of(1991, Month.MARCH, 27, 1, 46, 40), gigaSecond.getDateTime());
     }
 
     @Ignore("Remove to run test")
@@ -37,7 +37,7 @@ public class GigasecondTest {
     public void withFullTimeSpecified() {
         Gigasecond gigaSecond = new Gigasecond(LocalDateTime.of(2015, Month.JANUARY, 24, 22, 0, 0));
 
-        assertEquals(LocalDateTime.of(2046, Month.OCTOBER, 2, 23, 46, 40), gigaSecond.getDate());
+        assertEquals(LocalDateTime.of(2046, Month.OCTOBER, 2, 23, 46, 40), gigaSecond.getDateTime());
     }
 
     @Ignore("Remove to run test")
@@ -45,6 +45,6 @@ public class GigasecondTest {
     public void withFullTimeSpecifiedAndDayRollover() {
         Gigasecond gigaSecond = new Gigasecond(LocalDateTime.of(2015, Month.JANUARY, 24, 23, 59, 59));
 
-        assertEquals(LocalDateTime.of(2046, Month.OCTOBER, 3, 1, 46, 39), gigaSecond.getDate());
+        assertEquals(LocalDateTime.of(2046, Month.OCTOBER, 3, 1, 46, 39), gigaSecond.getDateTime());
     }
 }


### PR DESCRIPTION
Hello,

with this PR I want to resolve the issue #1513. 
I'm renaiming the `getDate()` method in the [gigasecond](https://github.com/exercism/java/tree/master/exercises/gigasecond) exercise to `getDateTime()`.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
