### PR TITLE
update gradle to the latest release (v4.10.2)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-bin.zip


### PR DESCRIPTION
<!-- Your content goes here: -->

Gradle 4.0.1 does not understand the new JDK versions (9 and beyond) well and build fails with an error (ex: Could not determine java version from '9.0.1')

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
