### PR TITLE
Fix test3000ToRomanNumberMMM

### DIFF
--- a/exercises/roman-numerals/src/test/java/RomanNumeralsTest.java
+++ b/exercises/roman-numerals/src/test/java/RomanNumeralsTest.java
@@ -68,7 +68,7 @@ public class RomanNumeralsTest {
         romanNumeral = new RomanNumeral(48);
         assertEquals("XLVIII", romanNumeral.getRomanNumeral());
     }
-    
+
     @Ignore("Remove to run test")
     @Test
     public void test49ToRomanNumberXLIX() {
@@ -135,8 +135,8 @@ public class RomanNumeralsTest {
     @Ignore("Remove to run test")
     @Test
     public void test3000ToRomanNumberMMM() {
-        romanNumeral = new RomanNumeral(1024);
-        assertEquals("MXXIV", romanNumeral.getRomanNumeral());
+        romanNumeral = new RomanNumeral(3000);
+        assertEquals("MMM", romanNumeral.getRomanNumeral());
     }
 
 }


### PR DESCRIPTION
<!-- Your content goes here: -->
This pull request is to fix the Roman Numerals exercise test case for converting 3000 to MMM.  The current test case mistakenly reuses the test for converting 1024 to MXXIV.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
