### PR TITLE
Create script for issue submission (canonical data version changes)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,7 +203,7 @@ Example generic new isse:
 
 Before you may submit a new issue, the script
   1. Checks for differences between version numbers of each exercise (in comparison with the version number of the canonical data)
-  2. Checks whether an open issue for this exercise; if there is an open issue, you will have to check by yourself if the title of the open issue might be changed to include the new version number. Here, it is important to check whether someone is already working on the issue. 
+  2. Checks whether an open issue exists for this exercise; if there is an open issue, you will have to check by yourself if the title of the open issue might be changed to include the new version number. Here, it is important to check whether someone is already working on the issue. 
   3. If a new issue may be opened for an exercise, the script will ask you if you want to submit the issue. Entering `y` will create the new issue.
 
 To run this script:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -196,9 +196,7 @@ To run this script:
   
 ## Checking tests are up to date and submit new issues
 
->>> This script may only be used by maintainers or members of exercism.
-
-There is [another script which allows you to submit new issues](https://github.com/exercism/java/blob/master/scripts/create_issues_versionchange_canonical.sh) to this Repo with generic title, description and labels if a change in version was detected.
+There is [a script which allows you to submit new issues](https://github.com/exercism/java/blob/master/scripts/create_issues_versionchange_canonical.sh) to this repo with generic title, description and labels if a change in version was detected.
 
 Example generic new isse:
 <img width="1005" alt="image" src="https://user-images.githubusercontent.com/6614867/57221803-bf1a6600-7000-11e9-93cf-b930ef24ce97.png">

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@
 * [Adding a New Exercise](#adding-a-new-exercise)
 * [Updating the READMEs](#updating-the-readmes)
 * [Checking tests are up to date](#checking-tests-are-up-to-date)
+* [Checking tests are up to date and submit new issues](#checking-tests-are-up-to-date-and-submit-new-issues)
 
 ## Overview
 
@@ -192,3 +193,34 @@ To run this script:
   1. Clone [the problem-specifications repository](https://github.com/exercism/problem-specifications).
 
   2. Run `./scripts/canonical_data_check.sh -t . -s --spec-path path_to_problem_specifications` from the root of this repository.
+  
+## Checking tests are up to date and submit new issues
+
+>>> This script may only be used by maintainers or members of exercism.
+
+There is [another script which allows you to submit new issues](https://github.com/exercism/java/blob/master/scripts/create_issues_versionchange_canonical.sh) to this Repo with generic title, description and labels if a change in version was detected.
+
+Example generic new isse:
+<img width="1005" alt="image" src="https://user-images.githubusercontent.com/6614867/57221803-bf1a6600-7000-11e9-93cf-b930ef24ce97.png">
+
+Before you may submit a new issue, the script
+  1. Checks for differences between version numbers of each exercise (in comparison with the version number of the canonical data)
+  2. Checks whether an open issue for this exercise; if there is an open issue, you will have to check by yourself if the title of the open issue might be changed to include the new version number. Here, it is important to check whether someone is already working on the issue. 
+  3. If a new issue may be opened for an exercise, the script will ask you if you want to submit the issue. Entering `y` will create the new issue.
+
+To run this script:
+
+  1. Clone [the problem-specifications repository](https://github.com/exercism/problem-specifications).
+  
+  2. Create a file `.exercism-version-update-issue-script-settings.sh` in your home directory.
+  
+  3. In this file, you have to put the following variables:
+        - `TOKEN="your_token"`
+        - `OWNER="repo_owner"` # -> `"exercism"`
+        - `REPO="repo_name"` # -> `"java"`
+        
+     For authentication, you need to create a personal token, see [this GitHub page](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line) for more information.
+
+  4. Run `./scripts/create_issues_versionchange_canonical.sh -t . -s --spec-path path_to_problem_specifications` from the root of this repository and follow the directions.
+  
+  5. If you submitted new issues, please check these submissions on the [issues page](https://github.com/exercism/java/issues).

--- a/scripts/create_issues_versionchange_canonical.sh
+++ b/scripts/create_issues_versionchange_canonical.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+
+print_usage() {
+    echo ">>>>> Usage: ./canonical_data_check_open_issue.sh -t path/to/track -s path/to/problem/specifications"
+}
+
+# Execution begins
+
+command -v jq >/dev/null 2>&1 || {
+    echo >&2 ">>>>> This script requires jq but it's not installed. Aborting."
+    exit 1
+}
+
+num_args=$#
+
+if [[ $num_args = 0 ]]; then
+    print_usage
+    exit 0
+fi
+
+path_to_track=
+path_to_problem_specifications=
+
+while getopts ":t:s:" option; do
+    case "$option" in
+        "t")
+            path_to_track="$OPTARG"
+            ;;
+        "s")
+            path_to_problem_specifications="$OPTARG"
+            ;;
+        *)
+            echo ">>>>> Unrecognized option. Aborting."
+            print_usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$path_to_track" ]]; then
+    echo ">>>>> Path to track missing."
+    print_usage
+    exit 1
+fi
+
+if [[ -z "$path_to_problem_specifications" ]]; then
+    echo ">>>>> Path to problem specifications missing."
+    print_usage
+    exit 1
+fi
+
+config_file_path="$path_to_track/config.json"
+
+if ! [[ -f "$config_file_path" ]]; then
+    echo ">>>>> Config file not found at ${config_file_path}."
+    exit 1
+fi
+
+track_exercise_slugs=$(jq '.exercises[] | select(has("deprecated") | not) | .slug' "$config_file_path" | tr -d "\"" | sort)
+update_needed_count=0
+
+
+# Create a file named ".exercism-version-update-issue-script-settings.sh"
+# with the following variables and put in in your home directory
+#
+# TOKEN="your_token"
+# OWNER="your_username"
+# REPO="repo_name"
+
+. "$HOME/.exercism-version-update-issue-script-settings.sh"
+
+# Fetch issues opened by us to avoid duplicate issues
+OPEN_ISSUES=$(curl --silent -HAuthorization:token\ ${TOKEN} https://api.github.com/repos/${OWNER}/${REPO}/issues\?state=open\&labels=exercise+version+update | jq -r '.[] |(.title | split(":")[0]) + " Issue Title: " + .title + " (" + (.comments|tostring) +" comments)" + ", URL: " + .html_url')
+
+# Check each exercise for possible difference in version and check for submission of new issue
+for slug in $track_exercise_slugs; do
+    canonical_data_folder_path="${path_to_problem_specifications}/exercises/${slug}"
+
+    if ! [[ -d "$canonical_data_folder_path" ]]; then
+        echo ">>>>> Canonical data folder ${canonical_data_folder_path} not found. Aborting."
+        exit 1
+    fi
+
+    canonical_data_file_path="${canonical_data_folder_path}/canonical-data.json"
+
+    if ! [[ -f "$canonical_data_file_path" ]]; then
+        continue
+    fi
+
+    canonical_data_version=$(jq '.version' ${canonical_data_file_path} | tr -d "\"")
+
+    track_exercise_version_file_path="${path_to_track}/exercises/${slug}/.meta/version"
+
+    if ! [[ -f "$track_exercise_version_file_path" ]]; then
+        echo ">>>>> ${slug}: needs update or version file (v${canonical_data_version})."
+        update_needed_count=$((update_needed_count + 1))
+        read -p "Press enter to continue."
+        echo
+        continue
+    fi
+
+    track_data_version=$(cat "$track_exercise_version_file_path" | sed 's/\r$//')
+
+    if [[ "$track_data_version" = "$canonical_data_version" ]]; then
+        # echo "$slug: up-to-date."
+        continue
+    elif echo "$OPEN_ISSUES" | grep --quiet "^$slug "; then
+        echo ">>>>> ${slug}: update tests and version file (v${track_data_version} -> v${canonical_data_version})"
+        echo "The following issue(s) are currently open for exercise ${slug} in ${REPO}:"
+        echo "$OPEN_ISSUES" | grep "^$slug " | cut -d' ' -f2-
+        echo "Please check manually if the title of one of this/these issue(s) might be changed to >> ${slug}: update tests and version file (v${track_data_version} -> v${canonical_data_version}) <<"
+        read -p "Press enter to continue."
+        echo
+        continue
+    else
+        update_needed_count=$((update_needed_count + 1))
+        printf ">>>>> Exercise ${slug} needs an update from v${track_data_version} -> v${canonical_data_version}\n"
+        title="${slug}: update tests and version file (v${track_data_version} -> v${canonical_data_version})"
+        body="The tests for the [${slug} exercise](https://github.com/exercism/java/tree/master/exercises/${slug}/src/test/) are not up-to-date with the [canonical data](https://github.com/exercism/problem-specifications/tree/master/exercises/${slug}/canonical-data.json).\nTo check what has changed and if new tests have been added to the canonical data, please have a look at the [commit history](https://github.com/exercism/problem-specifications/commits/master/exercises/${slug}/canonical-data.json) of the canonical data file for the exercise ${slug}.\nPlease update version and/or test file, and, if the new test(s) fail, fix the reference implementation.\nFeel free to leave a comment if you have any questions. \n\nBackground info: each exercise which has canonical data should have a version file. This file states which version of the canonical data the exercise implements. The version can be found at the top of the [canonical data file](https://github.com/exercism/problem-specifications/tree/master/exercises/${slug}/canonical-data.json) for that exercise."
+        labels='"good first issue", "help wanted", "exercise version update"'
+
+        response=""
+        while [[ $response != "y" && $response != "n" ]]; do
+          read -r -p "Do you want to publish this new issue for exercise $slug with title: $title? [y/n] " response
+        done
+        echo
+        if [[ $response == "y" ]]; then
+          printf ">>>>> Generating new issue for exercise ${slug} with title: ${title}\n"
+
+          curl --fail --silent -H 'Content-Type: application/json' -H 'Authorization: token '"$TOKEN"'' -X POST -d '{"title": "'"$title"'", "body": "'"$body"'", "labels": ['"$labels"']}' https://api.github.com/repos/${OWNER}/${REPO}/issues | jq -r '"New issue created at: " + .html_url'
+          read -p "Press enter to continue."
+          echo
+
+          if [[ "$?" != "0" ]]; then
+              echo ">>>>> Issue submission failed. Exit 1"
+              exit 1
+          fi
+        fi
+    fi
+done
+
+if [[ "$update_needed_count" = 0 ]]; then
+  echo "All exercises are up to date!"
+fi
+
+echo "All exercises have been checked. Exit"

--- a/scripts/create_issues_versionchange_canonical.sh
+++ b/scripts/create_issues_versionchange_canonical.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 print_usage() {
-    echo ">>>>> Usage: ./canonical_data_check_open_issue.sh -t path/to/track -s path/to/problem/specifications"
+    echo ">>>>> Usage: ./create_issues_versionchange_canonical.sh -t path/to/track -s path/to/problem/specifications"
 }
 
 # Execution begins
@@ -67,7 +67,27 @@ update_needed_count=0
 # OWNER="your_username"
 # REPO="repo_name"
 
+if ! [[ -f "$HOME/.exercism-version-update-issue-script-settings.sh" ]]; then
+    echo "Create a file named \".exercism-version-update-issue-script-settings.sh\""
+    echo "with the following variables and put in in your home directory"
+    echo "TOKEN=\"your_token\""
+    echo "OWNER=\"repo_owner\""
+    echo "REPO=\"repo_name\""
+fi
+
 . "$HOME/.exercism-version-update-issue-script-settings.sh"
+
+if [[ -z "$TOKEN" ]]; then
+    echo "Please insert your personal token into \".exercism-version-update-issue-script-settings.sh\"."
+    exit 1
+elif [[ -z "$OWNER" ]]; then
+    echo "Please insert the repo owner into \".exercism-version-update-issue-script-settings.sh\"."
+    exit 1
+elif [[ -z "$REPO" ]]; then
+    echo "Please insert the name of the repo into \".exercism-version-update-issue-script-settings.sh\"."
+    exit 1
+fi
+
 
 # Fetch issues opened by us to avoid duplicate issues
 OPEN_ISSUES=$(curl --silent -HAuthorization:token\ ${TOKEN} https://api.github.com/repos/${OWNER}/${REPO}/issues\?state=open\&labels=exercise+version+update | jq -r '.[] |(.title | split(":")[0]) + " Issue Title: " + .title + " (" + (.comments|tostring) +" comments)" + ", URL: " + .html_url')
@@ -116,7 +136,7 @@ for slug in $track_exercise_slugs; do
         update_needed_count=$((update_needed_count + 1))
         printf ">>>>> Exercise ${slug} needs an update from v${track_data_version} -> v${canonical_data_version}\n"
         title="${slug}: update tests and version file (v${track_data_version} -> v${canonical_data_version})"
-        body="The tests for the [${slug} exercise](https://github.com/exercism/java/tree/master/exercises/${slug}/src/test/) are not up-to-date with the [canonical data](https://github.com/exercism/problem-specifications/tree/master/exercises/${slug}/canonical-data.json).\nTo check what has changed and if new tests have been added to the canonical data, please have a look at the [commit history](https://github.com/exercism/problem-specifications/commits/master/exercises/${slug}/canonical-data.json) of the canonical data file for the exercise ${slug}.\nPlease update version and/or test file, and, if the new test(s) fail, fix the reference implementation.\nFeel free to leave a comment if you have any questions. \n\nBackground info: each exercise which has canonical data should have a version file. This file states which version of the canonical data the exercise implements. The version can be found at the top of the [canonical data file](https://github.com/exercism/problem-specifications/tree/master/exercises/${slug}/canonical-data.json) for that exercise."
+        body="The tests for the [${slug} exercise](https://github.com/exercism/java/tree/master/exercises/${slug}/src/test/java) are not up-to-date with the [canonical data](https://github.com/exercism/problem-specifications/tree/master/exercises/${slug}/canonical-data.json).\nTo check what has changed and if new tests have been added to the canonical data, please have a look at the [commit history](https://github.com/exercism/problem-specifications/commits/master/exercises/${slug}/canonical-data.json) of the canonical data file for the exercise ${slug}.\nPlease update version and/or test file, and, if the new test(s) fail, fix the reference implementation.\nFeel free to leave a comment if you have any questions. \n\nBackground info: each exercise which has canonical data should have a version file. This file states which version of the canonical data the exercise implements. The version can be found at the top of the [canonical data file](https://github.com/exercism/problem-specifications/tree/master/exercises/${slug}/canonical-data.json) for that exercise."
         labels='"good first issue", "help wanted", "exercise version update"'
 
         response=""

--- a/scripts/create_issues_versionchange_canonical.sh
+++ b/scripts/create_issues_versionchange_canonical.sh
@@ -122,7 +122,6 @@ for slug in $track_exercise_slugs; do
     track_data_version=$(cat "$track_exercise_version_file_path" | sed 's/\r$//')
 
     if [[ "$track_data_version" = "$canonical_data_version" ]]; then
-        # echo "$slug: up-to-date."
         continue
     elif echo "$OPEN_ISSUES" | grep --quiet "^$slug "; then
         echo ">>>>> ${slug}: update tests and version file (v${track_data_version} -> v${canonical_data_version})"


### PR DESCRIPTION
Closes #1670

Suggested script using GitHub API to create new issue when difference between track exercise version file number and canonical data version number is detected.

I based the script on the [canonical data check script](scripts/canonical_data_check.sh).

I introduced a new label to filter for duplicates, `exercise version update`.

The script adds a generic title, body and labels.
For example:

<img width="1005" alt="image" src="https://user-images.githubusercontent.com/6614867/57221803-bf1a6600-7000-11e9-93cf-b930ef24ce97.png">

Please have a look at the generic texts and fell free to add or remove information/wording (I'm not a native speaker of English, so I would be very glad for corrections :smile:). I tried to incorporate parts of texts that have been previously used.

The script may be tested with a private repository. For authentication you need to create a [token](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line), which should be kept in a hidden file in your `home directory`, and of course should never be committed. Further explanation on what to put into the file is described in the script.

Right now, the script only checks for changes in the test version, but not for new exercises.
I'd suggest to add this additional functionality at a later point.

Please let me know if you have further improvements or ideas for the script @exercism/java  :smile:

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
