### PR TITLE
Show standard streams in build (#1773)

### DIFF
--- a/_template/build.gradle
+++ b/_template/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/accumulate/build.gradle
+++ b/exercises/accumulate/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/acronym/build.gradle
+++ b/exercises/acronym/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/affine-cipher/build.gradle
+++ b/exercises/affine-cipher/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/all-your-base/build.gradle
+++ b/exercises/all-your-base/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/allergies/build.gradle
+++ b/exercises/allergies/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/alphametics/build.gradle
+++ b/exercises/alphametics/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/anagram/build.gradle
+++ b/exercises/anagram/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/armstrong-numbers/build.gradle
+++ b/exercises/armstrong-numbers/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/atbash-cipher/build.gradle
+++ b/exercises/atbash-cipher/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/bank-account/build.gradle
+++ b/exercises/bank-account/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/beer-song/build.gradle
+++ b/exercises/beer-song/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/binary-search-tree/build.gradle
+++ b/exercises/binary-search-tree/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/binary-search/build.gradle
+++ b/exercises/binary-search/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/binary/build.gradle
+++ b/exercises/binary/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/bob/build.gradle
+++ b/exercises/bob/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/book-store/build.gradle
+++ b/exercises/book-store/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/bowling/build.gradle
+++ b/exercises/bowling/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/change/build.gradle
+++ b/exercises/change/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/circular-buffer/build.gradle
+++ b/exercises/circular-buffer/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/clock/build.gradle
+++ b/exercises/clock/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/collatz-conjecture/build.gradle
+++ b/exercises/collatz-conjecture/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/complex-numbers/build.gradle
+++ b/exercises/complex-numbers/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/crypto-square/build.gradle
+++ b/exercises/crypto-square/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/custom-set/build.gradle
+++ b/exercises/custom-set/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/darts/build.gradle
+++ b/exercises/darts/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/diamond/build.gradle
+++ b/exercises/diamond/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/difference-of-squares/build.gradle
+++ b/exercises/difference-of-squares/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/diffie-hellman/build.gradle
+++ b/exercises/diffie-hellman/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/dnd-character/build.gradle
+++ b/exercises/dnd-character/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/dominoes/build.gradle
+++ b/exercises/dominoes/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/error-handling/build.gradle
+++ b/exercises/error-handling/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/etl/build.gradle
+++ b/exercises/etl/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/flatten-array/build.gradle
+++ b/exercises/flatten-array/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/food-chain/build.gradle
+++ b/exercises/food-chain/build.gradle
@@ -11,7 +11,8 @@ dependencies {
 }
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/forth/build.gradle
+++ b/exercises/forth/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/gigasecond/build.gradle
+++ b/exercises/gigasecond/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/go-counting/build.gradle
+++ b/exercises/go-counting/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/grade-school/build.gradle
+++ b/exercises/grade-school/build.gradle
@@ -13,7 +13,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/grains/build.gradle
+++ b/exercises/grains/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/grep/build.gradle
+++ b/exercises/grep/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/hamming/build.gradle
+++ b/exercises/hamming/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/hello-world/build.gradle
+++ b/exercises/hello-world/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/hexadecimal/build.gradle
+++ b/exercises/hexadecimal/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/house/build.gradle
+++ b/exercises/house/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/isbn-verifier/build.gradle
+++ b/exercises/isbn-verifier/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/isogram/build.gradle
+++ b/exercises/isogram/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/kindergarten-garden/build.gradle
+++ b/exercises/kindergarten-garden/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/largest-series-product/build.gradle
+++ b/exercises/largest-series-product/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/leap/build.gradle
+++ b/exercises/leap/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/linked-list/build.gradle
+++ b/exercises/linked-list/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/list-ops/build.gradle
+++ b/exercises/list-ops/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/luhn/build.gradle
+++ b/exercises/luhn/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/markdown/build.gradle
+++ b/exercises/markdown/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/matching-brackets/build.gradle
+++ b/exercises/matching-brackets/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/matrix/build.gradle
+++ b/exercises/matrix/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/meetup/build.gradle
+++ b/exercises/meetup/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/minesweeper/build.gradle
+++ b/exercises/minesweeper/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/nth-prime/build.gradle
+++ b/exercises/nth-prime/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/nucleotide-count/build.gradle
+++ b/exercises/nucleotide-count/build.gradle
@@ -13,7 +13,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/ocr-numbers/build.gradle
+++ b/exercises/ocr-numbers/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/octal/build.gradle
+++ b/exercises/octal/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/palindrome-products/build.gradle
+++ b/exercises/palindrome-products/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/pangram/build.gradle
+++ b/exercises/pangram/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/parallel-letter-frequency/build.gradle
+++ b/exercises/parallel-letter-frequency/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/pascals-triangle/build.gradle
+++ b/exercises/pascals-triangle/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/perfect-numbers/build.gradle
+++ b/exercises/perfect-numbers/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/phone-number/build.gradle
+++ b/exercises/phone-number/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/pig-latin/build.gradle
+++ b/exercises/pig-latin/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/poker/build.gradle
+++ b/exercises/poker/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/prime-factors/build.gradle
+++ b/exercises/prime-factors/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/protein-translation/build.gradle
+++ b/exercises/protein-translation/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/proverb/build.gradle
+++ b/exercises/proverb/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/pythagorean-triplet/build.gradle
+++ b/exercises/pythagorean-triplet/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/queen-attack/build.gradle
+++ b/exercises/queen-attack/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/rail-fence-cipher/build.gradle
+++ b/exercises/rail-fence-cipher/build.gradle
@@ -10,8 +10,9 @@ dependencies {
     testCompile "junit:junit:4.12"
 }
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/raindrops/build.gradle
+++ b/exercises/raindrops/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/rational-numbers/build.gradle
+++ b/exercises/rational-numbers/build.gradle
@@ -10,8 +10,9 @@ dependencies {
     testCompile "junit:junit:4.12"
 }
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/rectangles/build.gradle
+++ b/exercises/rectangles/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/resistor-color-duo/build.gradle
+++ b/exercises/resistor-color-duo/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/resistor-color/build.gradle
+++ b/exercises/resistor-color/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/reverse-string/build.gradle
+++ b/exercises/reverse-string/build.gradle
@@ -9,9 +9,11 @@ repositories {
 dependencies {
     testCompile "junit:junit:4.12"
 }
+
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/rna-transcription/build.gradle
+++ b/exercises/rna-transcription/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/robot-name/build.gradle
+++ b/exercises/robot-name/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/robot-simulator/build.gradle
+++ b/exercises/robot-simulator/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/roman-numerals/build.gradle
+++ b/exercises/roman-numerals/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/rotational-cipher/build.gradle
+++ b/exercises/rotational-cipher/build.gradle
@@ -10,8 +10,9 @@ dependencies {
     testCompile "junit:junit:4.12"
 }
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/run-length-encoding/build.gradle
+++ b/exercises/run-length-encoding/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/saddle-points/build.gradle
+++ b/exercises/saddle-points/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/scrabble-score/build.gradle
+++ b/exercises/scrabble-score/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/secret-handshake/build.gradle
+++ b/exercises/secret-handshake/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/series/build.gradle
+++ b/exercises/series/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/sieve/build.gradle
+++ b/exercises/sieve/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/simple-cipher/build.gradle
+++ b/exercises/simple-cipher/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/simple-linked-list/build.gradle
+++ b/exercises/simple-linked-list/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/space-age/build.gradle
+++ b/exercises/space-age/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/spiral-matrix/build.gradle
+++ b/exercises/spiral-matrix/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/strain/build.gradle
+++ b/exercises/strain/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/sublist/build.gradle
+++ b/exercises/sublist/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/sum-of-multiples/build.gradle
+++ b/exercises/sum-of-multiples/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/tournament/build.gradle
+++ b/exercises/tournament/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/transpose/build.gradle
+++ b/exercises/transpose/build.gradle
@@ -11,7 +11,8 @@ dependencies {
 }
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/tree-building/build.gradle
+++ b/exercises/tree-building/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/triangle/build.gradle
+++ b/exercises/triangle/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/trinary/build.gradle
+++ b/exercises/trinary/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/twelve-days/build.gradle
+++ b/exercises/twelve-days/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/two-bucket/build.gradle
+++ b/exercises/two-bucket/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/two-fer/build.gradle
+++ b/exercises/two-fer/build.gradle
@@ -11,7 +11,8 @@ dependencies {
 }
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/variable-length-quantity/build.gradle
+++ b/exercises/variable-length-quantity/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/word-count/build.gradle
+++ b/exercises/word-count/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/word-search/build.gradle
+++ b/exercises/word-search/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/wordy/build.gradle
+++ b/exercises/wordy/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/yacht/build.gradle
+++ b/exercises/yacht/build.gradle
@@ -11,8 +11,9 @@ dependencies {
 }
 
 test {
-    testLogging {
-        exceptionFormat = 'full'
-        events = ["passed", "failed", "skipped"]
-    }
+  testLogging {
+    exceptionFormat = 'short'
+    showStandardStreams = true
+    events = ["passed", "failed", "skipped"]
+  }
 }

--- a/exercises/zebra-puzzle/build.gradle
+++ b/exercises/zebra-puzzle/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }

--- a/exercises/zipper/build.gradle
+++ b/exercises/zipper/build.gradle
@@ -12,7 +12,8 @@ dependencies {
 
 test {
   testLogging {
-    exceptionFormat = 'full'
+    exceptionFormat = 'short'
+    showStandardStreams = true
     events = ["passed", "failed", "skipped"]
   }
 }


### PR DESCRIPTION
Enable System.out and System.err to be shown during `gradle build` without additional logging parameters. Also used the short stacktrace given that gives enough information where to look for the exception without overwhelming newcomers. If necessary, people can still use `gradle build -i` to get all information as suggested by gradle on failures.