### PR TITLE
Remove invalid --spec-path argument for data check

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,7 +237,7 @@ To run this script:
 
   1. Clone [the problem-specifications repository](https://github.com/exercism/problem-specifications).
 
-  2. Run `./scripts/canonical_data_check.sh -t . -s --spec-path path_to_problem_specifications` from the root of this repository.
+  2. Run `./scripts/canonical_data_check.sh -t . -s path_to_problem_specifications` from the root of this repository.
   
 ## Checking tests are up to date and submit new issues
 


### PR DESCRIPTION
<!-- Your content goes here: -->

Both `-s` and `--spec-path` arguments are specified in the canonical data check command, whereas only `-s` is supported.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
