### PR TITLE
Remove "Use `gradlew.bat` if you're on Windows"

### DIFF
--- a/config/exercise-readme-insert.md
+++ b/config/exercise-readme-insert.md
@@ -14,8 +14,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -41,8 +41,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/acronym/README.md
+++ b/exercises/acronym/README.md
@@ -23,8 +23,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/affine-cipher/README.md
+++ b/exercises/affine-cipher/README.md
@@ -91,8 +91,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/all-your-base/README.md
+++ b/exercises/all-your-base/README.md
@@ -47,8 +47,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -107,8 +107,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/alphametics/README.md
+++ b/exercises/alphametics/README.md
@@ -47,8 +47,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -22,8 +22,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/armstrong-numbers/README.md
+++ b/exercises/armstrong-numbers/README.md
@@ -33,8 +33,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -106,8 +106,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/bank-account/README.md
+++ b/exercises/bank-account/README.md
@@ -56,8 +56,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/beer-song/README.md
+++ b/exercises/beer-song/README.md
@@ -336,8 +336,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/binary-search-tree/README.md
+++ b/exercises/binary-search-tree/README.md
@@ -69,8 +69,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/binary-search/README.md
+++ b/exercises/binary-search/README.md
@@ -50,8 +50,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/binary/README.md
+++ b/exercises/binary/README.md
@@ -46,8 +46,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -93,8 +93,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/book-store/README.md
+++ b/exercises/book-store/README.md
@@ -83,8 +83,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/bowling/README.md
+++ b/exercises/bowling/README.md
@@ -76,8 +76,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/change/README.md
+++ b/exercises/change/README.md
@@ -32,8 +32,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/circular-buffer/README.md
+++ b/exercises/circular-buffer/README.md
@@ -66,8 +66,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/clock/README.md
+++ b/exercises/clock/README.md
@@ -29,8 +29,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/collatz-conjecture/README.md
+++ b/exercises/collatz-conjecture/README.md
@@ -42,8 +42,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/complex-numbers/README.md
+++ b/exercises/complex-numbers/README.md
@@ -44,8 +44,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/crypto-square/README.md
+++ b/exercises/crypto-square/README.md
@@ -88,8 +88,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/custom-set/README.md
+++ b/exercises/custom-set/README.md
@@ -23,8 +23,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/darts/README.md
+++ b/exercises/darts/README.md
@@ -31,8 +31,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/diamond/README.md
+++ b/exercises/diamond/README.md
@@ -68,8 +68,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -32,8 +32,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/diffie-hellman/README.md
+++ b/exercises/diffie-hellman/README.md
@@ -60,8 +60,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/dnd-character/README.md
+++ b/exercises/dnd-character/README.md
@@ -48,8 +48,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/dominoes/README.md
+++ b/exercises/dominoes/README.md
@@ -30,8 +30,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/error-handling/README.md
+++ b/exercises/error-handling/README.md
@@ -63,8 +63,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -62,8 +62,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/flatten-array/README.md
+++ b/exercises/flatten-array/README.md
@@ -88,8 +88,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/food-chain/README.md
+++ b/exercises/food-chain/README.md
@@ -79,8 +79,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/forth/README.md
+++ b/exercises/forth/README.md
@@ -41,8 +41,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -21,8 +21,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/go-counting/README.md
+++ b/exercises/go-counting/README.md
@@ -51,8 +51,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -50,8 +50,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -42,8 +42,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/grep/README.md
+++ b/exercises/grep/README.md
@@ -142,8 +142,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -55,8 +55,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -38,8 +38,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/hexadecimal/README.md
+++ b/exercises/hexadecimal/README.md
@@ -23,8 +23,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/house/README.md
+++ b/exercises/house/README.md
@@ -121,8 +121,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/isbn-verifier/README.md
+++ b/exercises/isbn-verifier/README.md
@@ -56,8 +56,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/isogram/README.md
+++ b/exercises/isogram/README.md
@@ -42,8 +42,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/kindergarten-garden/README.md
+++ b/exercises/kindergarten-garden/README.md
@@ -75,8 +75,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/knapsack/README.md
+++ b/exercises/knapsack/README.md
@@ -38,8 +38,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -29,8 +29,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -39,8 +39,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/linked-list/README.md
+++ b/exercises/linked-list/README.md
@@ -72,8 +72,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -46,8 +46,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/luhn/README.md
+++ b/exercises/luhn/README.md
@@ -80,8 +80,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/markdown/README.md
+++ b/exercises/markdown/README.md
@@ -30,8 +30,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/matching-brackets/README.md
+++ b/exercises/matching-brackets/README.md
@@ -82,8 +82,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/matrix/README.md
+++ b/exercises/matrix/README.md
@@ -56,8 +56,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/meetup/README.md
+++ b/exercises/meetup/README.md
@@ -42,8 +42,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/minesweeper/README.md
+++ b/exercises/minesweeper/README.md
@@ -42,8 +42,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/nth-prime/README.md
+++ b/exercises/nth-prime/README.md
@@ -24,8 +24,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -90,8 +90,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/ocr-numbers/README.md
+++ b/exercises/ocr-numbers/README.md
@@ -94,8 +94,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/octal/README.md
+++ b/exercises/octal/README.md
@@ -62,8 +62,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/palindrome-products/README.md
+++ b/exercises/palindrome-products/README.md
@@ -48,8 +48,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -24,8 +24,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/parallel-letter-frequency/README.md
+++ b/exercises/parallel-letter-frequency/README.md
@@ -33,8 +33,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/pascals-triangle/README.md
+++ b/exercises/pascals-triangle/README.md
@@ -92,8 +92,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/perfect-numbers/README.md
+++ b/exercises/perfect-numbers/README.md
@@ -33,8 +33,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -106,8 +106,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/pig-latin/README.md
+++ b/exercises/pig-latin/README.md
@@ -95,8 +95,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/poker/README.md
+++ b/exercises/poker/README.md
@@ -21,8 +21,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/prime-factors/README.md
+++ b/exercises/prime-factors/README.md
@@ -107,8 +107,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/protein-translation/README.md
+++ b/exercises/protein-translation/README.md
@@ -57,8 +57,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/proverb/README.md
+++ b/exercises/proverb/README.md
@@ -32,8 +32,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/pythagorean-triplet/README.md
+++ b/exercises/pythagorean-triplet/README.md
@@ -39,8 +39,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/queen-attack/README.md
+++ b/exercises/queen-attack/README.md
@@ -42,8 +42,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/rail-fence-cipher/README.md
+++ b/exercises/rail-fence-cipher/README.md
@@ -74,8 +74,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -33,8 +33,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/rational-numbers/README.md
+++ b/exercises/rational-numbers/README.md
@@ -44,8 +44,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/rectangles/README.md
+++ b/exercises/rectangles/README.md
@@ -79,8 +79,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/resistor-color-duo/README.md
+++ b/exercises/resistor-color-duo/README.md
@@ -43,8 +43,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/resistor-color/README.md
+++ b/exercises/resistor-color/README.md
@@ -35,8 +35,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/reverse-string/README.md
+++ b/exercises/reverse-string/README.md
@@ -28,8 +28,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -40,8 +40,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/robot-name/README.md
+++ b/exercises/robot-name/README.md
@@ -93,8 +93,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -43,8 +43,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -58,8 +58,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/rotational-cipher/README.md
+++ b/exercises/rotational-cipher/README.md
@@ -46,8 +46,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -101,8 +101,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/saddle-points/README.md
+++ b/exercises/saddle-points/README.md
@@ -44,8 +44,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -55,8 +55,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/secret-handshake/README.md
+++ b/exercises/secret-handshake/README.md
@@ -44,8 +44,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -98,8 +98,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/sieve/README.md
+++ b/exercises/sieve/README.md
@@ -45,8 +45,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/simple-cipher/README.md
+++ b/exercises/simple-cipher/README.md
@@ -103,8 +103,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/simple-linked-list/README.md
+++ b/exercises/simple-linked-list/README.md
@@ -37,8 +37,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -33,8 +33,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/spiral-matrix/README.md
+++ b/exercises/spiral-matrix/README.md
@@ -39,8 +39,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -49,8 +49,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -33,8 +33,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -24,8 +24,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/tournament/README.md
+++ b/exercises/tournament/README.md
@@ -80,8 +80,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/transpose/README.md
+++ b/exercises/transpose/README.md
@@ -74,8 +74,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -38,8 +38,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/trinary/README.md
+++ b/exercises/trinary/README.md
@@ -37,8 +37,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/twelve-days/README.md
+++ b/exercises/twelve-days/README.md
@@ -44,8 +44,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/two-bucket/README.md
+++ b/exercises/two-bucket/README.md
@@ -45,8 +45,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -86,8 +86,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/variable-length-quantity/README.md
+++ b/exercises/variable-length-quantity/README.md
@@ -47,8 +47,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -89,8 +89,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/word-search/README.md
+++ b/exercises/word-search/README.md
@@ -42,8 +42,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/wordy/README.md
+++ b/exercises/wordy/README.md
@@ -83,8 +83,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/yacht/README.md
+++ b/exercises/yacht/README.md
@@ -52,8 +52,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/zebra-puzzle/README.md
+++ b/exercises/zebra-puzzle/README.md
@@ -41,8 +41,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the

--- a/exercises/zipper/README.md
+++ b/exercises/zipper/README.md
@@ -43,8 +43,6 @@ terminal:
 $ gradle test
 ```
 
-> Use `gradlew.bat` if you're on Windows
-
 In the test suites all tests but the first have been skipped.
 
 Once you get a test passing, you can enable the next one by removing the


### PR DESCRIPTION
<!-- Your content goes here: -->

It seems that the advice to use `gradlew.bat` is no longer in accordance with the advice given in https://exercism.io/tracks/java/installation on how to install Gradle via `choco install gradle` and then execute it via `gradle test`.

Perhaps a previous version of this advice asked students to download `gradlew` or `gradlew.bat` from the track repo's root, where these are still present. Perhaps for this reason, `/gradlew` and `/gradlew.bat` should also be removed.

**Note:** While this updates READMEs in the track repo, I *think* this PR will not propagate the updated README.md's to students before some change is made in the test file.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
