### PR TITLE
Add sshine as 'contributing maintainer'

### DIFF
--- a/config/maintainers.json
+++ b/config/maintainers.json
@@ -90,6 +90,17 @@
       "link_url": null,
       "avatar_url": null,
       "bio": "I have been writing Java code professionally for the past 3 years and I have had a wonderful experience with it. The functional style of Java 8 took some getting used to, but it really improved my team's codebase and productivity."
+    },
+    {
+      "github_username": "sshine",
+      "alumnus": false,
+      "show_on_website": false,
+      "name": "Simon Shine",
+      "link_text": "https://simonshine.dk/",
+      "link_url": "https://simonshine.dk/",
+      "avatar_url": null,
+      "bio": null
     }
+
   ]
 }


### PR DESCRIPTION
In response to #1789, hereby adding myself as 'contributing maintainer' for the Java track. This entails `"show_on_website": false`. The context of a contributing maintainer is elaborated in a similar request made on exercism/haskell#890. Reiterating the purpose:

> *[...]* We need people to do this as the team membership *[of the repo
> exercism/v3]* is based on this and we need people in the right teams
> for assigning to issues, and Code Owners *[in the exercism/v3 repo]*.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
