### PR TITLE
Explicitly test that the empty string is not treated specially in twofer

### DIFF
--- a/exercises/two-fer/src/test/java/TwoferTest.java
+++ b/exercises/two-fer/src/test/java/TwoferTest.java
@@ -38,4 +38,16 @@ public class TwoferTest {
 
         assertEquals(expected, twofer.twofer(input));
     }
+
+    /* Track specific */
+
+    @Ignore("Remove to run test")
+    @Test
+    public void emptyStringIsNotTheSameAsNull() {
+        String input = "";
+        String expected = "One for , one for me.";
+
+        assertEquals(expected, twofer.twofer(input));
+    }
+    
 }


### PR DESCRIPTION
<!-- Your content goes here: -->

We decided in issue #1783 (and previously) that the empty string should not be treated as a special case like null. As such, I think we should have a test for it.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
