### PR TITLE
Fix rest-api build.gradle and test import ordering.

### DIFF
--- a/exercises/rest-api/build.gradle
+++ b/exercises/rest-api/build.gradle
@@ -8,7 +8,8 @@ repositories {
 
 dependencies {
   compile 'org.json:json:20190722'
-  testCompile "junit:junit:4.12"
+  testCompile "junit:junit:4.13"
+  testImplementation "org.assertj:assertj-core:3.15.0"
 }
 
 test {

--- a/exercises/rest-api/src/test/java/RestApiTest.java
+++ b/exercises/rest-api/src/test/java/RestApiTest.java
@@ -1,11 +1,12 @@
+import static org.junit.Assert.assertEquals;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
-import static org.junit.Assert.assertEquals;
 @RunWith(Enclosed.class)
 public class RestApiTest {
 


### PR DESCRIPTION
<!-- Your content goes here: -->

Updating to JUnit 4.13, adding AssertJ dependency.
Fixes the test imports so static imports are up top and the rest are sorted order.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
