### PR TITLE
set default encoding for all problems to utf-8

### DIFF
--- a/exercises/build.gradle
+++ b/exercises/build.gradle
@@ -28,6 +28,9 @@ subprojects {
   }
 
   afterEvaluate { project ->
+   // set default encoding to UTF-8
+   compileJava.options.encoding = "UTF-8"
+   compileTestJava.options.encoding = "UTF-8"
 
     sourceSets {
       // Set the directory containing the reference solution as the default source set. Default


### PR DESCRIPTION
This Pr addresses issue raised in  https://github.com/exercism/exercism/issues/5353


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
