### PR TITLE
Test for integer overflow

### DIFF
--- a/exercises/practice/largest-series-product/src/test/java/LargestSeriesProductCalculatorTest.java
+++ b/exercises/practice/largest-series-product/src/test/java/LargestSeriesProductCalculatorTest.java
@@ -184,5 +184,16 @@ public class LargestSeriesProductCalculatorTest {
         assertThat(expected)
             .hasMessage("Series length must be non-negative.");
     }
+    
+    @Ignore("Remove to run test")
+    @Test
+    public void testForIntegerOverflow() {
+        LargestSeriesProductCalculator calculator = new LargestSeriesProductCalculator("9999999999");
+        long expectedProduct = 3486784401L;
+
+        long actualProduct = calculator.calculateLargestProductForSeriesLength(10);
+
+        assertEquals(expectedProduct, actualProduct);
+    }
 
 }


### PR DESCRIPTION
<!-- Your content goes here: -->

Since `calculateLargestProductForSeriesLength` return type is declared as long, I wonder if this side exercise is a good place to make students think about integer overflows?

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
