### PR TITLE
Fix issue #1855 (add info about exceptions + removal of tests)

### DIFF
--- a/exercises/hamming/.meta/hints.md
+++ b/exercises/hamming/.meta/hints.md
@@ -8,5 +8,5 @@ We use JUnit's [`ExpectedException`](http://junit.org/junit4/javadoc/4.12/org/ju
 [rule](https://github.com/junit-team/junit4/wiki/rules) throughout the track to verify that the exceptions you throw
 are:
 
-1. instances of a specified Java type;
-2. (optionally) initialized with a specified message.
+1. instances of a specified Java type (in this case : "IllegalArgumentException");
+2. initialized with a specified message (in this case : "leftStrand and rightStrand must be of equal length.").

--- a/exercises/hamming/.meta/src/reference/java/Hamming.java
+++ b/exercises/hamming/.meta/src/reference/java/Hamming.java
@@ -7,12 +7,6 @@ class Hamming {
     Hamming(String leftStrand, String rightStrand) {
         String exceptionMessage = "leftStrand and rightStrand must be of equal length.";
         if (leftStrand.length() != rightStrand.length()) {
-            if (leftStrand.isEmpty()) {
-                exceptionMessage = "left strand must not be empty.";
-            }
-            if (rightStrand.isEmpty()) {
-                exceptionMessage = "right strand must not be empty.";
-            }
             throw new IllegalArgumentException(exceptionMessage);
         }
 

--- a/exercises/hamming/.meta/tests.toml
+++ b/exercises/hamming/.meta/tests.toml
@@ -20,9 +20,3 @@
 
 # disallow second strand longer
 "8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e" = true
-
-# disallow left empty strand
-"5dce058b-28d4-4ca7-aa64-adfe4e17784c" = true
-
-# disallow right empty strand
-"38826d4b-16fb-4639-ac3e-ba027dec8b5f" = true

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -22,6 +22,8 @@ The Hamming distance is only defined for sequences of equal length, so
 an attempt to calculate it between sequences of different lengths should
 not work. The general handling of this situation (e.g., raising an
 exception vs returning a special value) may differ between languages.
+Here, we ask that you throw an IllegalArgumentException with the following
+message "leftStrand and rightStrand must be of equal length.".
 
 # Tips
 
@@ -35,8 +37,8 @@ We use JUnit's [`ExpectedException`](http://junit.org/junit4/javadoc/4.12/org/ju
 [rule](https://github.com/junit-team/junit4/wiki/rules) throughout the track to verify that the exceptions you throw
 are:
 
-1. instances of a specified Java type;
-2. (optionally) initialized with a specified message.
+1. instances of a specified Java type (in this case : "IllegalArgumentException");
+2. initialized with a specified message (in this case : "leftStrand and rightStrand must be of equal length.").
 
 
 ## Setup

--- a/exercises/hamming/src/test/java/HammingTest.java
+++ b/exercises/hamming/src/test/java/HammingTest.java
@@ -60,28 +60,4 @@ public class HammingTest {
             .hasMessage("leftStrand and rightStrand must be of equal length.");
     }
 
-    @Ignore("Remove to run test")
-    @Test
-    public void testDisallowLeftEmptyStrand() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new Hamming("", "G"));
-
-        assertThat(expected)
-            .hasMessage("left strand must not be empty.");
-    }
-
-    @Ignore("Remove to run test")
-    @Test
-    public void testDisallowRightEmptyStrand() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new Hamming("G", ""));
-
-        assertThat(expected)
-            .hasMessage("right strand must not be empty.");
-    }
-
 }


### PR DESCRIPTION
This commit fixes the issue #1855. More precisely, it add some info about
the kind of exception that should be thrown for the hamming problem as well
as the message that should be send.
The tests checking if one strand is empty and not the other were also removed
as they did not really seem relevant.

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
