### PR TITLE
Updated deprecated Gradle config

### DIFF
--- a/_template/build.gradle
+++ b/_template/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/concept/basics/build.gradle
+++ b/exercises/concept/basics/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/concept/bird-watcher/build.gradle
+++ b/exercises/concept/bird-watcher/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/concept/booleans/build.gradle
+++ b/exercises/concept/booleans/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/concept/chars/build.gradle
+++ b/exercises/concept/chars/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/concept/classes/build.gradle
+++ b/exercises/concept/classes/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/concept/conditionals/build.gradle
+++ b/exercises/concept/conditionals/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/concept/constructors/build.gradle
+++ b/exercises/concept/constructors/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/concept/inheritance/build.gradle
+++ b/exercises/concept/inheritance/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-    testCompile "junit:junit:4.13"
+    testImplementation "junit:junit:4.13"
     testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/concept/interfaces/build.gradle
+++ b/exercises/concept/interfaces/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/concept/numbers/build.gradle
+++ b/exercises/concept/numbers/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/concept/strings/build.gradle
+++ b/exercises/concept/strings/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/concept/switch-statement/build.gradle
+++ b/exercises/concept/switch-statement/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    testCompile "junit:junit:4.13"
+    testImplementation "junit:junit:4.13"
     testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/concept/ternary-operators/build.gradle
+++ b/exercises/concept/ternary-operators/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/accumulate/build.gradle
+++ b/exercises/practice/accumulate/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/acronym/build.gradle
+++ b/exercises/practice/acronym/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/affine-cipher/build.gradle
+++ b/exercises/practice/affine-cipher/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/all-your-base/build.gradle
+++ b/exercises/practice/all-your-base/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/allergies/build.gradle
+++ b/exercises/practice/allergies/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/alphametics/build.gradle
+++ b/exercises/practice/alphametics/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/anagram/build.gradle
+++ b/exercises/practice/anagram/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/armstrong-numbers/build.gradle
+++ b/exercises/practice/armstrong-numbers/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/atbash-cipher/build.gradle
+++ b/exercises/practice/atbash-cipher/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/bank-account/build.gradle
+++ b/exercises/practice/bank-account/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/beer-song/build.gradle
+++ b/exercises/practice/beer-song/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/binary-search-tree/build.gradle
+++ b/exercises/practice/binary-search-tree/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/binary-search/build.gradle
+++ b/exercises/practice/binary-search/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/binary/build.gradle
+++ b/exercises/practice/binary/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/bob/build.gradle
+++ b/exercises/practice/bob/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/book-store/build.gradle
+++ b/exercises/practice/book-store/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/bowling/build.gradle
+++ b/exercises/practice/bowling/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/change/build.gradle
+++ b/exercises/practice/change/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/circular-buffer/build.gradle
+++ b/exercises/practice/circular-buffer/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/clock/build.gradle
+++ b/exercises/practice/clock/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/collatz-conjecture/build.gradle
+++ b/exercises/practice/collatz-conjecture/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/complex-numbers/build.gradle
+++ b/exercises/practice/complex-numbers/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/crypto-square/build.gradle
+++ b/exercises/practice/crypto-square/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/custom-set/build.gradle
+++ b/exercises/practice/custom-set/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/darts/build.gradle
+++ b/exercises/practice/darts/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/diamond/build.gradle
+++ b/exercises/practice/diamond/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/difference-of-squares/build.gradle
+++ b/exercises/practice/difference-of-squares/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/diffie-hellman/build.gradle
+++ b/exercises/practice/diffie-hellman/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/dnd-character/build.gradle
+++ b/exercises/practice/dnd-character/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/dominoes/build.gradle
+++ b/exercises/practice/dominoes/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/error-handling/build.gradle
+++ b/exercises/practice/error-handling/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/etl/build.gradle
+++ b/exercises/practice/etl/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/flatten-array/build.gradle
+++ b/exercises/practice/flatten-array/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/food-chain/build.gradle
+++ b/exercises/practice/food-chain/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/forth/build.gradle
+++ b/exercises/practice/forth/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/gigasecond/build.gradle
+++ b/exercises/practice/gigasecond/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/go-counting/build.gradle
+++ b/exercises/practice/go-counting/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/grade-school/build.gradle
+++ b/exercises/practice/grade-school/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/grains/build.gradle
+++ b/exercises/practice/grains/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/grep/build.gradle
+++ b/exercises/practice/grep/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/hamming/build.gradle
+++ b/exercises/practice/hamming/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/hangman/build.gradle
+++ b/exercises/practice/hangman/build.gradle
@@ -13,7 +13,7 @@ repositories {
 dependencies {
   compile 'io.reactivex.rxjava2:rxjava:2.2.12'
 
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/hello-world/build.gradle
+++ b/exercises/practice/hello-world/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/hexadecimal/build.gradle
+++ b/exercises/practice/hexadecimal/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/house/build.gradle
+++ b/exercises/practice/house/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/isbn-verifier/build.gradle
+++ b/exercises/practice/isbn-verifier/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/isogram/build.gradle
+++ b/exercises/practice/isogram/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/kindergarten-garden/build.gradle
+++ b/exercises/practice/kindergarten-garden/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/knapsack/build.gradle
+++ b/exercises/practice/knapsack/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/largest-series-product/build.gradle
+++ b/exercises/practice/largest-series-product/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/leap/build.gradle
+++ b/exercises/practice/leap/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/linked-list/build.gradle
+++ b/exercises/practice/linked-list/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/list-ops/build.gradle
+++ b/exercises/practice/list-ops/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/luhn/build.gradle
+++ b/exercises/practice/luhn/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/markdown/build.gradle
+++ b/exercises/practice/markdown/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/matching-brackets/build.gradle
+++ b/exercises/practice/matching-brackets/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/matrix/build.gradle
+++ b/exercises/practice/matrix/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/meetup/build.gradle
+++ b/exercises/practice/meetup/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/micro-blog/build.gradle
+++ b/exercises/practice/micro-blog/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/minesweeper/build.gradle
+++ b/exercises/practice/minesweeper/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/nth-prime/build.gradle
+++ b/exercises/practice/nth-prime/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/nucleotide-count/build.gradle
+++ b/exercises/practice/nucleotide-count/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/ocr-numbers/build.gradle
+++ b/exercises/practice/ocr-numbers/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/octal/build.gradle
+++ b/exercises/practice/octal/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/palindrome-products/build.gradle
+++ b/exercises/practice/palindrome-products/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/pangram/build.gradle
+++ b/exercises/practice/pangram/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/parallel-letter-frequency/build.gradle
+++ b/exercises/practice/parallel-letter-frequency/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/pascals-triangle/build.gradle
+++ b/exercises/practice/pascals-triangle/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/perfect-numbers/build.gradle
+++ b/exercises/practice/perfect-numbers/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/phone-number/build.gradle
+++ b/exercises/practice/phone-number/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/pig-latin/build.gradle
+++ b/exercises/practice/pig-latin/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/poker/build.gradle
+++ b/exercises/practice/poker/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/prime-factors/build.gradle
+++ b/exercises/practice/prime-factors/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/protein-translation/build.gradle
+++ b/exercises/practice/protein-translation/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/proverb/build.gradle
+++ b/exercises/practice/proverb/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/pythagorean-triplet/build.gradle
+++ b/exercises/practice/pythagorean-triplet/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/queen-attack/build.gradle
+++ b/exercises/practice/queen-attack/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/rail-fence-cipher/build.gradle
+++ b/exercises/practice/rail-fence-cipher/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/raindrops/build.gradle
+++ b/exercises/practice/raindrops/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/rational-numbers/build.gradle
+++ b/exercises/practice/rational-numbers/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/rectangles/build.gradle
+++ b/exercises/practice/rectangles/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/resistor-color-duo/build.gradle
+++ b/exercises/practice/resistor-color-duo/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/resistor-color/build.gradle
+++ b/exercises/practice/resistor-color/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/rest-api/build.gradle
+++ b/exercises/practice/rest-api/build.gradle
@@ -12,7 +12,7 @@ repositories {
 
 dependencies {
   compile 'org.json:json:20190722'
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/reverse-string/build.gradle
+++ b/exercises/practice/reverse-string/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/rna-transcription/build.gradle
+++ b/exercises/practice/rna-transcription/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/robot-name/build.gradle
+++ b/exercises/practice/robot-name/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/robot-simulator/build.gradle
+++ b/exercises/practice/robot-simulator/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/roman-numerals/build.gradle
+++ b/exercises/practice/roman-numerals/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/rotational-cipher/build.gradle
+++ b/exercises/practice/rotational-cipher/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/run-length-encoding/build.gradle
+++ b/exercises/practice/run-length-encoding/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/saddle-points/build.gradle
+++ b/exercises/practice/saddle-points/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/satellite/build.gradle
+++ b/exercises/practice/satellite/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/say/build.gradle
+++ b/exercises/practice/say/build.gradle
@@ -7,7 +7,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.12"
+  testImplementation "junit:junit:4.12"
 }
 
 test {

--- a/exercises/practice/scrabble-score/build.gradle
+++ b/exercises/practice/scrabble-score/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/secret-handshake/build.gradle
+++ b/exercises/practice/secret-handshake/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/series/build.gradle
+++ b/exercises/practice/series/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/sieve/build.gradle
+++ b/exercises/practice/sieve/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/simple-cipher/build.gradle
+++ b/exercises/practice/simple-cipher/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/simple-linked-list/build.gradle
+++ b/exercises/practice/simple-linked-list/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/space-age/build.gradle
+++ b/exercises/practice/space-age/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/spiral-matrix/build.gradle
+++ b/exercises/practice/spiral-matrix/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/strain/build.gradle
+++ b/exercises/practice/strain/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/sublist/build.gradle
+++ b/exercises/practice/sublist/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/sum-of-multiples/build.gradle
+++ b/exercises/practice/sum-of-multiples/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/tournament/build.gradle
+++ b/exercises/practice/tournament/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/transpose/build.gradle
+++ b/exercises/practice/transpose/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/tree-building/build.gradle
+++ b/exercises/practice/tree-building/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/triangle/build.gradle
+++ b/exercises/practice/triangle/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/trinary/build.gradle
+++ b/exercises/practice/trinary/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/twelve-days/build.gradle
+++ b/exercises/practice/twelve-days/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/two-bucket/build.gradle
+++ b/exercises/practice/two-bucket/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/two-fer/build.gradle
+++ b/exercises/practice/two-fer/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/variable-length-quantity/build.gradle
+++ b/exercises/practice/variable-length-quantity/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/word-count/build.gradle
+++ b/exercises/practice/word-count/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/word-search/build.gradle
+++ b/exercises/practice/word-search/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/wordy/build.gradle
+++ b/exercises/practice/wordy/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/yacht/build.gradle
+++ b/exercises/practice/yacht/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/zebra-puzzle/build.gradle
+++ b/exercises/practice/zebra-puzzle/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 

--- a/exercises/practice/zipper/build.gradle
+++ b/exercises/practice/zipper/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  testCompile "junit:junit:4.13"
+  testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }
 


### PR DESCRIPTION
This PR replaced deprecated Gradle config `testComple` with `testImplementation`.

Quoting [user guide for `Gradle` v6.7.1](https://docs.gradle.org/6.7.1/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations) (the latest stable `Gradle` is v6.8.1):

> **Dependencies should no longer be declared using the `compile` and `runtime` configurations**
> The usage of the `compile` and `runtime` configurations in the Java ecosystem plugins has been discouraged since Gradle 3.4.
> 
> These configurations are used for compiling and running code from the main source set. Other sources sets create similar configurations (e.g. `testCompile` and `testRuntime` for the test source set), should not be used either. The `implementation`, `api`, `compileOnly` and `runtimeOnly` configurations should be used to declare dependencies and the `compileClasspath` and `runtimeClasspath` configurations to resolve dependencies. See the relationship of these configurations.



Fixes #1853



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
