### PR TITLE
fix deprecated gradle configurations

### DIFF
--- a/exercises/practice/hangman/build.gradle
+++ b/exercises/practice/hangman/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  compile 'io.reactivex.rxjava2:rxjava:2.2.12'
+  implementation 'io.reactivex.rxjava2:rxjava:2.2.12'
 
   testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"

--- a/exercises/practice/rest-api/build.gradle
+++ b/exercises/practice/rest-api/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-  compile 'org.json:json:20190722'
+  implementation 'org.json:json:20190722'
   testImplementation "junit:junit:4.13"
   testImplementation "org.assertj:assertj-core:3.15.0"
 }


### PR DESCRIPTION
<!-- Your content goes here: -->

Fix the `build.gradle' of some exercises, moving from deprecated `compile` to `implementation` settings 

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
