### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "55a9fa1c-b272-4229-9e7c-8ecbc158c9ee",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Java locally",
+      "blurb": "Learn how to install Java locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "cf49e0f4-0903-4430-8fec-0f8671c71c96",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Java",
+      "blurb": "An overview of how to get started from scratch with Java"
+    },
+    {
+      "uuid": "b58182a0-198c-44e7-871b-0a22dde46a5b",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Java track",
+      "blurb": "Learn how to test your Java exercises on Exercism"
+    },
+    {
+      "uuid": "91ad7ea1-41b0-4fee-8733-729b5185f0b5",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Java resources",
+      "blurb": "A collection of useful resources to help you master Java"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
