### PR TITLE
🤖 Flatten authors and contributors in .meta/config.json files

### DIFF
--- a/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for booleans exercise",
   "authors": [
-    {
-      "github_username": "mikedamay",
-      "exercism_username": "mikedamay"
-    }
+    "mikedamay"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/bird-watcher/.meta/config.json
+++ b/exercises/concept/bird-watcher/.meta/config.json
@@ -1,14 +1,8 @@
 {
   "blurb": "TODO: add blurb for bird-watcher exercise",
   "authors": [
-    {
-      "github_username": "samuelteixeiras",
-      "exercism_username": "samuelteixeiras"
-    },
-    {
-      "github_username": "ystromm",
-      "exercism_username": "ystromm"
-    }
+    "samuelteixeiras",
+    "ystromm"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/blackjack/.meta/config.json
+++ b/exercises/concept/blackjack/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for conditionals exercise",
   "authors": [
-    {
-      "github_username": "TalesDias",
-      "exercism_username": "TalesDias"
-    }
+    "TalesDias"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/cars-assemble/.meta/config.json
+++ b/exercises/concept/cars-assemble/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for numbers exercise",
   "authors": [
-    {
-      "github_username": "TalesDias",
-      "exercism_username": "TalesDias"
-    }
+    "TalesDias"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/classes/.meta/config.json
+++ b/exercises/concept/classes/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for classes exercise",
   "contributors": [
-    {
-      "github_username": "mirkoperillo",
-      "exercism_username": "mirkoperillo"
-    }
+    "mirkoperillo"
   ],
   "files": {
     "solution": [
@@ -18,9 +15,6 @@
     ]
   },
   "authors": [
-    {
-      "github_username": "mikedamay",
-      "exercism_username": "mikedamay"
-    }
+    "mikedamay"
   ]
 }

--- a/exercises/concept/constructors/.meta/config.json
+++ b/exercises/concept/constructors/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for constructors exercise",
   "contributors": [
-    {
-      "github_username": "mirkoperillo",
-      "exercism_username": "mirkoperillo"
-    }
+    "mirkoperillo"
   ],
   "files": {
     "solution": [
@@ -18,9 +15,6 @@
     ]
   },
   "authors": [
-    {
-      "github_username": "ystromm",
-      "exercism_username": "ystromm"
-    }
+    "ystromm"
   ]
 }

--- a/exercises/concept/inheritance/.meta/config.json
+++ b/exercises/concept/inheritance/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for inheritance exercise",
   "authors": [
-    {
-      "github_username": "himanshugoyal1065",
-      "exercism_username": "himanshugoyal1065"
-    }
+    "himanshugoyal1065"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/interfaces/.meta/config.json
+++ b/exercises/concept/interfaces/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for interfaces exercise",
   "authors": [
-    {
-      "github_username": "mikedamay",
-      "exercism_username": "mikedamay"
-    }
+    "mikedamay"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/lasagna/.meta/config.json
+++ b/exercises/concept/lasagna/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for lasagna exercise",
   "authors": [
-    {
-      "github_username": "mirkoperillo",
-      "exercism_username": "mirkoperillo"
-    }
+    "mirkoperillo"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/log-levels/.meta/config.json
+++ b/exercises/concept/log-levels/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for strings exercise",
   "authors": [
-    {
-      "github_username": "mirkoperillo",
-      "exercism_username": "mirkoperillo"
-    }
+    "mirkoperillo"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/squeaky-clean/.meta/config.json
+++ b/exercises/concept/squeaky-clean/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for chars exercise",
   "authors": [
-    {
-      "github_username": "ystromm",
-      "exercism_username": "ystromm"
-    }
+    "ystromm"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/switch-statement/.meta/config.json
+++ b/exercises/concept/switch-statement/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for switch-statement exercise",
   "authors": [
-    {
-      "github_username": "Azumix",
-      "exercism_username": "Azumix"
-    }
+    "Azumix"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/ternary-operators/.meta/config.json
+++ b/exercises/concept/ternary-operators/.meta/config.json
@@ -1,10 +1,7 @@
 {
   "blurb": "TODO: add blurb for ternary-operators exercise",
   "authors": [
-    {
-      "github_username": "TalesDias",
-      "exercism_username": "TalesDias"
-    }
+    "TalesDias"
   ],
   "files": {
     "solution": [


### PR DESCRIPTION
The authors and contributors of exercises are stored in an array of objects in the exercises' `.meta/config.json` files.
Each author/contributor used to have two properties: their GitHub username _and_ their Exercism username.
As we're only using the GitHub username, we're flattening the `authors` and `contributors` array to an array of strings representing the GitHub usernames.

We will update `configlet` to validate the new structure, so you might be seeing build failures once we've implemented this change. 

See https://github.com/exercism/docs/pull/90/files

## Automatic Merging

We will automatically merge this PR immediately to be able to submit a different PR in which we'll add the authors/contributors for practice exercises.

## Tracking

https://github.com/exercism/v3-launch/issues/26
