### PR TITLE
Removed zero-width space characters from test methods

### DIFF
--- a/exercises/practice/nucleotide-count/src/test/java/NucleotideCounterTest.java
+++ b/exercises/practice/nucleotide-count/src/test/java/NucleotideCounterTest.java
@@ -13,7 +13,7 @@ public class NucleotideCounterTest {
         NucleotideCounter nucleotideCounter = new NucleotideCounter("");
 
         assertThat(nucleotideCounter.nucleotideCounts())
-            .containsExactlyInAnyOrderEntriesOf​(
+            .containsExactlyInAnyOrderEntriesOf(
                 Map.of('A', 0, 'C', 0, 'G', 0, 'T', 0));
     }
 
@@ -23,7 +23,7 @@ public class NucleotideCounterTest {
         NucleotideCounter nucleotideCounter = new NucleotideCounter("G");
 
         assertThat(nucleotideCounter.nucleotideCounts())
-            .containsExactlyInAnyOrderEntriesOf​(
+            .containsExactlyInAnyOrderEntriesOf(
                 Map.of('A', 0, 'C', 0, 'G', 1, 'T', 0));
     }
 
@@ -33,7 +33,7 @@ public class NucleotideCounterTest {
         NucleotideCounter nucleotideCounter = new NucleotideCounter("GGGGGGG");
 
         assertThat(nucleotideCounter.nucleotideCounts())
-            .containsExactlyInAnyOrderEntriesOf​(
+            .containsExactlyInAnyOrderEntriesOf(
                 Map.of('A', 0, 'C', 0, 'G', 7, 'T', 0));
     }
 
@@ -44,7 +44,7 @@ public class NucleotideCounterTest {
             = new NucleotideCounter("AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC");
 
         assertThat(nucleotideCounter.nucleotideCounts())
-            .containsExactlyInAnyOrderEntriesOf​(
+            .containsExactlyInAnyOrderEntriesOf(
                 Map.of('A', 20, 'C', 12, 'G', 17, 'T', 21));
     }
 


### PR DESCRIPTION
<!-- Your content goes here: -->
Fix for #1843 referencing discussion in #1938 
Removed zero-width space from the end of `containsExactlyInAnyOrderEntriesOf` method.
U+200B	​	0xe2 0x80 0x8b	ZERO WIDTH SPACE
These zero-width space characters only seem to be a problem with IntelliJ. They are only visible in the hex view of the file.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
