### PR TITLE
Removed zero-width space characters from test methods

### DIFF
--- a/exercises/practice/anagram/src/test/java/AnagramTest.java
+++ b/exercises/practice/anagram/src/test/java/AnagramTest.java
@@ -24,7 +24,7 @@ public class AnagramTest {
         Anagram detector = new Anagram("master");
 
         assertThat(detector.match(Arrays.asList("stream", "pigeon", "maters")))
-            .containsExactlyInAnyOrder​("maters", "stream");
+            .containsExactlyInAnyOrder("maters", "stream");
     }
 
     @Ignore("Remove to run test")
@@ -43,7 +43,7 @@ public class AnagramTest {
         assertThat(
             detector.match(
                 Arrays.asList("enlists", "google", "inlets", "banana")))
-            .containsExactlyInAnyOrder​("inlets");
+            .containsExactlyInAnyOrder("inlets");
     }
 
     @Ignore("Remove to run test")
@@ -59,7 +59,7 @@ public class AnagramTest {
                     "clergy",
                     "largely",
                     "leading")))
-            .containsExactlyInAnyOrder​("gallery", "regally", "largely");
+            .containsExactlyInAnyOrder("gallery", "regally", "largely");
     }
 
     @Ignore("Remove to run test")
@@ -68,7 +68,7 @@ public class AnagramTest {
         Anagram detector = new Anagram("nose");
 
         assertThat(detector.match(Arrays.asList("Eons", "ONES")))
-            .containsExactlyInAnyOrder​("Eons", "ONES");
+            .containsExactlyInAnyOrder("Eons", "ONES");
     }
 
     @Ignore("Remove to run test")
@@ -88,7 +88,7 @@ public class AnagramTest {
         assertThat(
             detector.match(
                 Arrays.asList("cashregister", "Carthorse", "radishes")))
-            .containsExactlyInAnyOrder​("Carthorse");
+            .containsExactlyInAnyOrder("Carthorse");
     }
 
     @Ignore("Remove to run test")
@@ -99,7 +99,7 @@ public class AnagramTest {
         assertThat(
             detector.match(
                 Arrays.asList("cashregister", "carthorse", "radishes")))
-            .containsExactlyInAnyOrder​("carthorse");
+            .containsExactlyInAnyOrder("carthorse");
     }
 
     @Ignore("Remove to run test")
@@ -110,7 +110,7 @@ public class AnagramTest {
         assertThat(
             detector.match(
                 Arrays.asList("cashregister", "Carthorse", "radishes")))
-            .containsExactlyInAnyOrder​("Carthorse");
+            .containsExactlyInAnyOrder("Carthorse");
     }
 
     @Ignore("Remove to run test")
@@ -146,7 +146,7 @@ public class AnagramTest {
         Anagram detector = new Anagram("LISTEN");
 
         assertThat(detector.match(Arrays.asList("Listen", "Silent", "LISTEN")))
-            .containsExactlyInAnyOrder​("Silent");
+            .containsExactlyInAnyOrder("Silent");
     }
 
 }


### PR DESCRIPTION

<!-- Your content goes here: -->
Fix for #1938
Removed zero-width space from the end of `containsExactlyInAnyOrder` method.
U+200B ​ 0xe2 0x80 0x8b ZERO WIDTH SPACE
These zero-width space characters only seem to be a problem with IntelliJ. They are only visible in the hex view of the file.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
