### PR TITLE
🤖 Update name of `dnd-character` exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -519,7 +519,7 @@
       },
       {
         "slug": "dnd-character",
-        "name": "Dnd Character",
+        "name": "D&D Character",
         "uuid": "09bb515c-0270-4d34-8d56-89ee04588494",
         "practices": [],
         "prerequisites": [],


### PR DESCRIPTION
This PR correct the name of the `dnd-character` exercise to its correct value: "D&D Character"