### PR TITLE
Fix #1956: move test instructions to v3

### DIFF
--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -38,7 +38,7 @@ Choose your operating system:
      ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-5. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/TUTORIAL.md)).
+5. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/TUTORIAL.md)).
 
 
 Good luck!  Have fun!

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -1,0 +1,116 @@
+# Running the Tests
+
+Choose your operating system:
+
+* [Windows](#windows)
+* [macOS](#macos)
+* [Linux](#linux)
+
+----
+
+# Windows
+
+1. Open a Command Prompt.
+2. Get the first exercise:
+
+     ```batchfile
+     C:\Users\JohnDoe>exercism download --exercise hello-world --track java
+
+     Not Submitted:     1 problem
+     java (Hello World) C:\Users\JohnDoe\exercism\java\hello-world
+
+     New:               1 problem
+     java (Hello World) C:\Users\JohnDoe\exercism\java\hello-world
+
+     unchanged: 0, updated: 0, new: 1
+   ```
+
+3. Change directory into the exercism:
+
+     ```batchfile
+     C:\Users\JohnDoe>cd C:\Users\JohnDoe\exercism\java\hello-world
+     ```
+   
+4. Run the tests:
+
+     ```batchfile
+     C:\Users\JohnDoe>gradle test
+     ```
+   *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
+
+5. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/TUTORIAL.md)).
+
+
+Good luck!  Have fun!
+
+If you get stuck, at any point, don't forget to reach out for [help](http://exercism.io/languages/java/help).
+
+----
+
+# macOS
+
+1. In the terminal window, get the first exercise:
+
+     ```
+     $ exercism download --exercise hello-world --track java
+
+     New:                 1 problem
+     Java (Etl) /Users/johndoe/exercism/java/hello-world
+
+     unchanged: 0, updated: 0, new: 1
+    ```
+
+2. Change directory into the exercise:
+
+     ```
+     $ cd /Users/johndoe/exercism/java/hello-world
+     ```
+
+3. Run the tests:
+
+    ```
+    $ gradle test
+    ```
+   *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
+
+4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/TUTORIAL.md)).
+
+Good luck!  Have fun!
+
+If you get stuck, at any point, don't forget to reach out for [help](http://exercism.io/languages/java/help).
+
+----
+
+# Linux
+
+1. In the terminal window, get the first exercise:
+
+     ```
+     $ exercism download --exercise hello-world --track java
+
+     New:                 1 problem
+     Java (Etl) /home/johndoe/exercism/java/hello-world
+
+     unchanged: 0, updated: 0, new: 1
+
+    ```
+
+2. Change directory into the exercise:
+
+     ```
+     $ cd /home/johndoe/exercism/java/hello-world
+     ```
+
+3. Run the tests:
+
+    ```
+    $ gradle test
+    ```
+   *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
+
+4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/TUTORIAL.md)).
+
+Good luck!  Have fun!
+
+If you get stuck, at any point, don't forget to reach out for [help](http://exercism.io/languages/java/help).
+

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -108,9 +108,8 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
     ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/TUTORIAL.md)).
+4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/TUTORIAL.md)).
 
 Good luck!  Have fun!
 
 If you get stuck, at any point, don't forget to reach out for [help](http://exercism.io/languages/java/help).
-


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->
Move instructions about how to run tests from v2 path ( `java/docs/TESTS.md`) to v3 one (`java/exrcise/shared/.docs/tests.md`)


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
