### PR TITLE
Add more exhaustive tests for secret handshake

### DIFF
--- a/exercises/practice/secret-handshake/src/test/java/HandshakeCalculatorTest.java
+++ b/exercises/practice/secret-handshake/src/test/java/HandshakeCalculatorTest.java
@@ -103,4 +103,28 @@ public class HandshakeCalculatorTest {
                 handshakeCalculator.calculateHandshake(0));
     }
 
+    @Ignore("Remove to run test")
+    @Test
+    public void testThatHandlesMoreThanFiveBinaryPlacesWithReversal() {
+        assertEquals(
+                asList(Signal.DOUBLE_BLINK, Signal.WINK),
+                handshakeCalculator.calculateHandshake(51));
+    }
+
+    @Ignore("Remove to run test")
+    @Test
+    public void testThatHandlesMoreThanFiveBinaryPlacesWithoutReversal() {
+        assertEquals(
+                asList(Signal.WINK, Signal.DOUBLE_BLINK),
+                handshakeCalculator.calculateHandshake(35));
+    }
+
+    @Ignore("Remove to run test")
+    @Test
+    public void testInputThatYieldsAllActionsFromMoreThanFiveBinaryPlaces() {
+        assertEquals(
+                asList(Signal.WINK, Signal.DOUBLE_BLINK, Signal.CLOSE_YOUR_EYES, Signal.JUMP),
+                handshakeCalculator.calculateHandshake(111));
+    }
+
 }


### PR DESCRIPTION
# Pull request fixes exercism/java#1965

<!-- Your content goes here: -->
Some solutions simply checked if the input is greater than 16 to reverse, thus wrongly reversing the sequence for numbers greater than 16 whose bit at position 4 is not set. These test cases enforce that solutions check the bit at position 4 explicitly.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
