### PR TITLE
Specify custom icon for elons-toy-car

### DIFF
--- a/exercises/concept/elons-toy-car/.meta/config.json
+++ b/exercises/concept/elons-toy-car/.meta/config.json
@@ -1,5 +1,6 @@
 {
   "blurb": "TODO: add blurb for classes exercise",
+  "icon": "elons-toys",
   "contributors": [
     "mirkoperillo"
   ],


### PR DESCRIPTION
The icon for this exercise is called `elons-toys`, see: https://raw.githubusercontent.com/exercism/website-icons/main/exercises/elons-toys.svg