### PR TITLE
replaced TODO with blurbs from exercises these were forked from.

### DIFF
--- a/exercises/concept/annalyns-infiltration/.meta/config.json
+++ b/exercises/concept/annalyns-infiltration/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for booleans exercise",
+  "blurb": "Learn about booleans while helping Annalyn rescue her friend.",
   "authors": [
     "mikedamay"
   ],

--- a/exercises/concept/bird-watcher/.meta/config.json
+++ b/exercises/concept/bird-watcher/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for bird-watcher exercise",
+  "blurb": "Learn about arrays by keeping track of how many birds visit your garden.",
   "authors": [
     "samuelteixeiras",
     "ystromm"

--- a/exercises/concept/blackjack/.meta/config.json
+++ b/exercises/concept/blackjack/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for conditionals exercise",
+  "blurb": "Learn about conditionals by playing Blackjack.",
   "authors": [
     "TalesDias"
   ],

--- a/exercises/concept/cars-assemble/.meta/config.json
+++ b/exercises/concept/cars-assemble/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for numbers exercise",
+  "blurb": "Learn about numbers by analyzing the production of an asseMbly line.",
   "authors": [
     "TalesDias"
   ],

--- a/exercises/concept/elons-toy-car/.meta/config.json
+++ b/exercises/concept/elons-toy-car/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for classes exercise",
+  "blurb": "Learn about classes by working on a remote controlled car.",
   "icon": "elons-toys",
   "contributors": [
     "mirkoperillo"

--- a/exercises/concept/football-match-reports/.meta/config.json
+++ b/exercises/concept/football-match-reports/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for football-match-reports exercise",
+  "blurb": "Learn about switches by developing a system to report on soccer matches.",
   "authors": [
       "Azumix"
   ],

--- a/exercises/concept/log-levels/.meta/config.json
+++ b/exercises/concept/log-levels/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for strings exercise",
+  "blurb": "Learn about strings by processing logs.",
   "authors": [
     "mirkoperillo"
   ],

--- a/exercises/concept/need-for-speed/.meta/config.json
+++ b/exercises/concept/need-for-speed/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for constructors exercise",
+  "blurb": "Learn about classes by creating cars.",
   "contributors": [
     "mirkoperillo"
   ],

--- a/exercises/concept/remote-control-competition/.meta/config.json
+++ b/exercises/concept/remote-control-competition/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for interfaces exercise",
+  "blurb": "Learn about interfaces by working on cars.",
   "authors": [
     "mikedamay"
   ],

--- a/exercises/concept/salary-calculator/.meta/config.json
+++ b/exercises/concept/salary-calculator/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for ternary-operators exercise",
+  "blurb": "Learn about ternary operators by calculating salaries.",
   "authors": [
     "TalesDias"
   ],

--- a/exercises/concept/squeaky-clean/.meta/config.json
+++ b/exercises/concept/squeaky-clean/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for chars exercise",
+  "blurb": "Learn about characters and StringBuilder by cleaning strings.",
   "authors": [
     "ystromm"
   ],

--- a/exercises/concept/wizards-and-warriors/.meta/config.json
+++ b/exercises/concept/wizards-and-warriors/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "TODO: add blurb for inheritance exercise",
+  "blurb": "Learn about inheritance by creating an RPG.",
   "authors": [
     "himanshugoyal1065"
   ],

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Score a bowling game",
+  "blurb": "Score a bowling game.",
   "authors": [],
   "contributors": [
     "aadityakulkarni",

--- a/exercises/practice/darts/.meta/config.json
+++ b/exercises/practice/darts/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Write a function that returns the earned points in a single toss of a Darts game",
+  "blurb": "Write a function that returns the earned points in a single toss of a Darts game.",
   "authors": [
     "lemoncurry"
   ],

--- a/exercises/practice/dnd-character/.meta/config.json
+++ b/exercises/practice/dnd-character/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Randomly generate Dungeons & Dragons characters",
+  "blurb": "Randomly generate Dungeons & Dragons characters.",
   "authors": [
     "lemoncurry"
   ],

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Take a nested list and return a single list with all values except nil/null",
+  "blurb": "Take a nested list and return a single list with all values except nil/null.",
   "authors": [
     "stkent"
   ],

--- a/exercises/practice/food-chain/.meta/config.json
+++ b/exercises/practice/food-chain/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Generate the lyrics of the song 'I Know an Old Lady Who Swallowed a Fly'",
+  "blurb": "Generate the lyrics of the song \"I Know an Old Lady Who Swallowed a Fly.\"",
   "authors": [
     "Smarticles101"
   ],

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
+  "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length `n`.",
   "authors": [
     "stkent"
   ],

--- a/exercises/practice/linked-list/.meta/config.json
+++ b/exercises/practice/linked-list/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Implement a doubly linked list",
+  "blurb": "Implement a doubly linked list.",
   "authors": [
     "counterleft"
   ],

--- a/exercises/practice/markdown/.meta/config.json
+++ b/exercises/practice/markdown/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Refactor a Markdown parser",
+  "blurb": "Refactor a Markdown parser.",
   "authors": [
     "bmkiefer"
   ],

--- a/exercises/practice/minesweeper/.meta/config.json
+++ b/exercises/practice/minesweeper/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Add the numbers to a minesweeper board",
+  "blurb": "Add the numbers to a minesweeper board.",
   "authors": [
     "stkent"
   ],

--- a/exercises/practice/pig-latin/.meta/config.json
+++ b/exercises/practice/pig-latin/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Implement a program that translates from English to Pig Latin",
+  "blurb": "Implement a program that translates from English to Pig Latin.",
   "authors": [],
   "contributors": [
     "aadityakulkarni",

--- a/exercises/practice/resistor-color/.meta/config.json
+++ b/exercises/practice/resistor-color/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Convert a resistor band's color to its numeric representation",
+  "blurb": "Convert a resistor band's color to its numeric representation.",
   "authors": [
     "Smarticles101"
   ],

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Reverse a string",
+  "blurb": "Reverse a string.",
   "authors": [
     "bmkiefer"
   ],

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
+  "blurb": "Output the lyrics to \"The Twelve Days of Christmas.\"",
   "authors": [
     "FridaTveit"
   ],

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Score a single throw of dice in the game Yacht",
+  "blurb": "Score a single throw of dice in the game Yacht.",
   "authors": [
     "lemoncurry"
   ],


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->
I copied the blurb text from the exercises these were forked from to replace the "TODO" text that was there. Most from csharp track, one from go. Don't know where the salary-calculator exercise came from so left it as a TODO.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
