### PR TITLE
avoid deprecation warnings

### DIFF
--- a/exercises/practice/resistor-color/src/test/java/ResistorColorTest.java
+++ b/exercises/practice/resistor-color/src/test/java/ResistorColorTest.java
@@ -2,6 +2,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.Ignore;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public class ResistorColorTest {
@@ -44,7 +45,7 @@ public class ResistorColorTest {
     public void testColors() {
         String[] expected = {"black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"};
 
-        assertEquals(expected, resistorColor.colors());
+        assertArrayEquals(expected, resistorColor.colors());
     }
     
 }


### PR DESCRIPTION
a student was confused by the compiler warning and I think it is even displayed as error in the UI. So let's use `assertArrayEquals` instead of `assertEquals(Object[], Object[])` which is deprecated..

# pull request

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
