### PR TITLE
Fix broken Java CI with Gradle workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Compile and checkstyle with Gradle
-      run: cd exercises && ../gradlew check compileStarterSourceJava --parallel --continue
+      run: cd exercises && ../gradlew check compileStarterSourceJava --parallel --continue --stacktrace
 
   test:
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -3,24 +3,9 @@
 
 name: Java CI with Gradle
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
-  lint:
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-    - name: Fetch configlet
-      run: bin/fetch-configlet
-    - name: Lint
-      run: bin/configlet lint .
-
   build:
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #1986

# pull request

Adds canonical triggers (including manual launch). Removes lint since we have a separate workflow / action for Configlet.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
