### PR TITLE
Fix SalaryCalculatorTest.skippedAboveThreshold

### DIFF
--- a/exercises/concept/salary-calculator/src/test/java/SalaryCalculatorTest.java
+++ b/exercises/concept/salary-calculator/src/test/java/SalaryCalculatorTest.java
@@ -30,7 +30,7 @@ public class SalaryCalculatorTest {
     @Test
     @Ignore("Remove to run test")
     public void skippedAboveThreshold() {
-        assertThat(calculator.finalSalary(5, 0)).isEqualTo(850.0);
+        assertThat(calculator.finalSalary(7, 0)).isEqualTo(850.0);
     }
     
     @Test


### PR DESCRIPTION
... by using a value that is actually above the threshold

Fixes #1989

# pull request

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
