### PR TITLE
Mark unreachable concept exercises as wip

### DIFF
--- a/config.json
+++ b/config.json
@@ -118,7 +118,7 @@
         "prerequisites": [
           "classes"
         ],
-        "status": "active"
+        "status": "wip"
       },
       {
         "slug": "remote-control-competition",
@@ -197,7 +197,7 @@
           "strings",
           "booleans"
         ],
-        "status": "active"
+        "status": "wip"
       }
     ],
     "practice": [

--- a/config.json
+++ b/config.json
@@ -94,7 +94,7 @@
           "numbers",
           "strings"
         ],
-        "status": "active"
+        "status": "wip"
       },
       {
         "slug": "blackjack",
@@ -132,7 +132,7 @@
           "lists",
           "strings"
         ],
-        "status": "active"
+        "status": "wip"
       },
       {
         "slug": "cars-assemble",
@@ -183,7 +183,7 @@
           "methods",
           "variables"
         ],
-        "status": "active"
+        "status": "wip"
       },
       {
         "slug": "wizards-and-warriors",


### PR DESCRIPTION
Fixes config.json after latest configlet linting. See #1992

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
