### PR TITLE
Updating ResistorColorDuo tests to use AssertJ

### DIFF
--- a/exercises/practice/resistor-color-duo/src/test/java/ResistorColorDuoTest.java
+++ b/exercises/practice/resistor-color-duo/src/test/java/ResistorColorDuoTest.java
@@ -1,6 +1,7 @@
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.Ignore;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import static org.junit.Assert.assertEquals;
 
@@ -14,50 +15,40 @@ public class ResistorColorDuoTest {
 
     @Test
     public void testBrownAndBlack() {
-        String[] input = { "brown", "black" };
-        int expected = 10;
-        int actual = resistorColorDuo.value(input);
-
-        assertEquals(expected, actual);
+        assertThat(
+                resistorColorDuo.value(new String[]{"brown", "black"})
+        ).isEqualTo(10);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testBlueAndGrey() {
-        String[] input = { "blue", "grey" };
-        int expected = 68;
-        int actual = resistorColorDuo.value(input);
-
-        assertEquals(expected, actual);
+        assertThat(
+                resistorColorDuo.value(new String[]{ "blue", "grey" })
+        ).isEqualTo(68);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testYellowAndViolet() {
-        String[] input = { "yellow", "violet" };
-        int expected = 47;
-        int actual = resistorColorDuo.value(input);
-
-        assertEquals(expected, actual);
+        assertThat(resistorColorDuo.value(
+                new String[]{ "yellow", "violet" })
+        ).isEqualTo(47);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testOrangeAndOrange() {
-        String[] input = { "orange", "orange" };
-        int expected = 33;
-        int actual = resistorColorDuo.value(input);
-
-        assertEquals(expected, actual);
+        assertThat(
+                resistorColorDuo.value(new String[]{ "orange", "orange" })
+        ).isEqualTo(33);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testIgnoreAdditionalColors() {
-        String[] input = { "green", "brown", "orange" };
-        int expected = 51;
-        int actual = resistorColorDuo.value(input);
-
-        assertEquals(expected, actual);
+        assertThat(
+                resistorColorDuo.value(new String[]{ "green", "brown", "orange" })
+        ).isEqualTo(51);
     }
 }

--- a/exercises/practice/resistor-color-duo/src/test/java/ResistorColorDuoTest.java
+++ b/exercises/practice/resistor-color-duo/src/test/java/ResistorColorDuoTest.java
@@ -1,9 +1,8 @@
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.Ignore;
-import static org.assertj.core.api.Assertions.assertThat;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class ResistorColorDuoTest {
     private ResistorColorDuo resistorColorDuo;


### PR DESCRIPTION
# pull request

Another AssertJ update.  This one for ResistorColorDuo.

Let me know if there's any issues with the formatting.  I'm using IntelliJ's defaults of 8 spaces for continuation indents, but have no issues changing it if you use another style here.

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
