### PR TITLE
Use info rather than stacktrace for gradle

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Compile and checkstyle with Gradle
-      run: cd exercises && ../gradlew check compileStarterSourceJava --parallel --continue --stacktrace
+      run: cd exercises && ../gradlew check compileStarterSourceJava --parallel --continue --info
 
   test:
 


### PR DESCRIPTION
--info returns more helpful information than --stacktrace

# pull request

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
