### PR TITLE
Add a workflow to automatically close stale PRs and comment / tag stale issues

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -3,6 +3,10 @@
 # https://github.com/exercism/org-wide-files/blob/main/global-files/.github/labels.yml.     #
 # ----------------------------------------------------------------------------------------- #
 
+- name: "action/stale"
+  description: "Applied (and removed) automatically by the stale workflow to indicate an issue or pull request is stale"
+  color: "d93f0b"
+
 - name: "announcement"
   description: ""
   color: "d461d8"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,49 @@
+# This workflow warns for stale issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '41 3 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v4
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        # Mark issues as stale once per quarter, but never close.
+        days-before-issue-stale: 90
+        days-before-issue-close: -1
+        # Mark PRs as stale every month, close if not updated in a week.
+        days-before-pr-stale: 30
+        days-before-pr-close: 7
+
+        # Milestones on an issue or a PR exempted from being marked as stale.
+        exempt-milestones: true
+        # Exempt all issues with milestones from being marked as stale.
+        exempt-all-issue-milestones: true
+
+        stale-issue-label: 'action/stale'
+        stale-issue-message: >
+          This issue has been automatically marked as `action/stale`
+          because it has not had recent activity. Please update if there are
+          new updates to provide.
+
+        stale-pr-label: 'action/stale'
+        stale-pr-message: >
+          This pull request has been automatically marked as `stale`
+          because it has not had recent activity. It will be closed if no
+          further activity occurs. Thank you for your contributions.
+        close-pr-message: >
+          Closing stale pull request. If you are still working on this,
+          please reopen this pull request.


### PR DESCRIPTION
# pull request

The workflow definition is pretty self-documenting, but the full documentation is here: https://github.com/actions/stale

This is setup to leave stale issues open (but tagged) but auto-close stale pull requests.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
