### PR TITLE
change parameter name to numberOfVictories

### DIFF
--- a/exercises/concept/remote-control-competition/src/main/java/ProductionRemoteControlCar.java
+++ b/exercises/concept/remote-control-competition/src/main/java/ProductionRemoteControlCar.java
@@ -12,7 +12,7 @@ class ProductionRemoteControlCar {
         throw new UnsupportedOperationException("Please implement the ProductionRemoteControlCar.getNumberOfVictories() method");
     }
 
-    public void setNumberOfVictories(int numberofFictories) {
+    public void setNumberOfVictories(int numberofVictories) {
         throw new UnsupportedOperationException("Please implement the ProductionRemoteControlCar.setNumberOfVictories() method");
     }
 }


### PR DESCRIPTION
# pull request

The parameter for the `setNumberOfVictories()` method has an incorrect name in the exercise.



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
