### PR TITLE
Fix typos in Remote Control Competition

### DIFF
--- a/exercises/concept/remote-control-competition/.docs/instructions.md
+++ b/exercises/concept/remote-control-competition/.docs/instructions.md
@@ -35,7 +35,7 @@ exp.getDistanceTravelled();
 
 Please implement the `Comparable<T>` interface in the `ProductionRemoteControlCar` class. The default sort order for cars should be ascending order of victories.
 
-Implement the static `TestTrack.getRankedCars()` to return the cars passed is sorted in ascending order of number of victories.
+Implement the static `TestTrack.getRankedCars()` to return the cars passed in, sorted in ascending order of number of victories.
 
 ```java
 ProductionRemoteControlCar prc1 = new ProductionRemoteControlCar();

--- a/exercises/concept/remote-control-competition/.docs/introduction.md
+++ b/exercises/concept/remote-control-competition/.docs/introduction.md
@@ -10,11 +10,11 @@ public interface Language {
     String speak();
 }
 
-public class ItalianTaveller implements Language, Cloneable {
+public class ItalianTraveller implements Language, Cloneable {
 
     // from Language interface
     public String getLanguageName() {
-        return  "Italiano";
+        return "Italiano";
     }
 
     // from Language interface
@@ -23,7 +23,7 @@ public class ItalianTaveller implements Language, Cloneable {
     }
 
     // from Cloneable interface
-    public Object Clone() {
+    public Object clone() {
         ItalianTaveller it = new ItalianTaveller();
         return it;
     }
@@ -34,4 +34,4 @@ All operations defined by the interface must be implemented by the implementing 
 
 Interfaces usually contain instance methods.
 
-An example of an interface found in the Java Class Library, apart from `Clonable` illustrated above, is `Comparable<T>`. The `Comparable<T>` interface can be implemented where a default generic sort order in collections is required.
+An example of an interface found in the Java Class Library, apart from `Cloneable` illustrated above, is `Comparable<T>`. The `Comparable<T>` interface can be implemented where a default generic sort order in collections is required.


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->
Besides typos, uses correct `clone` method signature for Java.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
