### PR TITLE
Converting tests to AssertJ (exercises starting with H, I, K)

### DIFF
--- a/exercises/practice/hamming/src/test/java/HammingTest.java
+++ b/exercises/practice/hamming/src/test/java/HammingTest.java
@@ -1,5 +1,4 @@
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import org.junit.Ignore;
@@ -9,31 +8,31 @@ public class HammingTest {
 
     @Test
     public void testNoDistanceBetweenEmptyStrands() {
-        assertEquals(0, new Hamming("", "").getHammingDistance());
+        assertThat(new Hamming("", "").getHammingDistance()).isEqualTo(0);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testNoDistanceBetweenShortIdenticalStrands() {
-        assertEquals(0, new Hamming("A", "A").getHammingDistance());
+        assertThat(new Hamming("A", "A").getHammingDistance()).isEqualTo(0);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testCompleteDistanceInSingleLetterDifferentStrands() {
-        assertEquals(1, new Hamming("G", "T").getHammingDistance());
+        assertThat(new Hamming("G", "T").getHammingDistance()).isEqualTo(1);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testDistanceInLongIdenticalStrands() {
-        assertEquals(0, new Hamming("GGACTGAAATCTG", "GGACTGAAATCTG").getHammingDistance());
+        assertThat(new Hamming("GGACTGAAATCTG", "GGACTGAAATCTG").getHammingDistance()).isEqualTo(0);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testDistanceInLongDifferentStrands() {
-        assertEquals(9, new Hamming("GGACGGATTCTG", "AGGACGGATTCT").getHammingDistance());
+        assertThat(new Hamming("GGACGGATTCTG", "AGGACGGATTCT").getHammingDistance()).isEqualTo(9);
     }
 
     @Ignore("Remove to run test")

--- a/exercises/practice/hangman/src/test/java/HangmanTest.java
+++ b/exercises/practice/hangman/src/test/java/HangmanTest.java
@@ -51,7 +51,7 @@ public class HangmanTest {
 
         Output last = result.blockingLast();
         assertThat(last.discovered).isEqualTo("_e__e_");
-        assertThat(last.guess).containsExactlyInAnyOrder("e");
+        assertThat(last.guess).containsExactly("e");
         assertThat(last.misses).isEmpty();
         assertThat(last.parts).isEmpty();
         assertThat(last.status).isEqualTo(Status.PLAYING);
@@ -67,8 +67,8 @@ public class HangmanTest {
 
         assertThat(last.discovered).isEqualTo("______");
         assertThat(last.guess).isEmpty();
-        assertThat(last.misses).containsExactlyInAnyOrder("a");
-        assertThat(last.parts).containsExactlyInAnyOrder(Part.HEAD);
+        assertThat(last.misses).containsExactly("a");
+        assertThat(last.parts).containsExactly(Part.HEAD);
         assertThat(last.status).isEqualTo(Status.PLAYING);
     }
 

--- a/exercises/practice/hangman/src/test/java/HangmanTest.java
+++ b/exercises/practice/hangman/src/test/java/HangmanTest.java
@@ -8,10 +8,10 @@ import org.junit.Test;
 
 import java.util.*;
 import java.util.stream.Stream;
+
 import org.junit.rules.ExpectedException;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class HangmanTest {
@@ -32,13 +32,14 @@ public class HangmanTest {
             Observable.fromArray("secret"),
             Observable.fromArray());
         Output init = result.blockingFirst();
-        assertNotNull(init);
-        assertEquals("secret", init.secret);
-        assertEquals("______", init.discovered);
-        assertEquals(Collections.emptySet(), init.guess);
-        assertEquals(Collections.emptySet(), init.misses);
-        assertEquals(Collections.emptyList(), init.parts);
-        assertEquals(Status.PLAYING, init.status);
+
+        assertThat(init).isNotNull();
+        assertThat(init.secret).isEqualTo("secret");
+        assertThat(init.discovered).isEqualTo("______");
+        assertThat(init.guess).isEmpty();
+        assertThat(init.misses).isEmpty();
+        assertThat(init.parts).isEmpty();
+        assertThat(init.status).isEqualTo(Status.PLAYING);
     }
 
     @Ignore("Remove to run test")
@@ -47,12 +48,13 @@ public class HangmanTest {
         Observable<Output> result = hangman.play(
             Observable.fromArray("secret"),
             Observable.fromArray("e"));
+
         Output last = result.blockingLast();
-        assertEquals("_e__e_", last.discovered);
-        assertEquals(Collections.singleton("e"), last.guess);
-        assertEquals(Collections.emptySet(), last.misses);
-        assertEquals(Collections.emptyList(), last.parts);
-        assertEquals(Status.PLAYING, last.status);
+        assertThat(last.discovered).isEqualTo("_e__e_");
+        assertThat(last.guess).containsExactlyInAnyOrder("e");
+        assertThat(last.misses).isEmpty();
+        assertThat(last.parts).isEmpty();
+        assertThat(last.status).isEqualTo(Status.PLAYING);
     }
 
     @Ignore("Remove to run test")
@@ -62,11 +64,12 @@ public class HangmanTest {
             Observable.fromArray("secret"),
             Observable.fromArray("a"));
         Output last = result.blockingLast();
-        assertEquals("______", last.discovered);
-        assertEquals(Collections.emptySet(), last.guess);
-        assertEquals(Collections.singleton("a"), last.misses);
-        assertEquals(Collections.singletonList(Part.HEAD), last.parts);
-        assertEquals(Status.PLAYING, last.status);
+
+        assertThat(last.discovered).isEqualTo("______");
+        assertThat(last.guess).isEmpty();
+        assertThat(last.misses).containsExactlyInAnyOrder("a");
+        assertThat(last.parts).containsExactlyInAnyOrder(Part.HEAD);
+        assertThat(last.status).isEqualTo(Status.PLAYING);
     }
 
     @Ignore("Remove to run test")
@@ -76,15 +79,12 @@ public class HangmanTest {
             Observable.fromArray("secret"),
             Observable.fromArray("a", "e", "o", "s"));
         Output last = result.blockingLast();
-        assertEquals("se__e_", last.discovered);
-        assertEquals(Set.of("e", "s"), last.guess);
-        assertEquals(Set.of("a", "o"), last.misses);
-        assertEquals(
-            Arrays.asList(
-                Part.HEAD,
-                Part.BODY),
-            last.parts);
-        assertEquals(Status.PLAYING, last.status);
+
+        assertThat(last.discovered).isEqualTo("se__e_");
+        assertThat(last.guess).containsExactlyInAnyOrder("e", "s");
+        assertThat(last.misses).containsExactlyInAnyOrder("a", "o");
+        assertThat(last.parts).containsExactlyInAnyOrder(Part.HEAD, Part.BODY);
+        assertThat(last.status).isEqualTo(Status.PLAYING);
     }
 
     @Ignore("Remove to run test")
@@ -94,9 +94,10 @@ public class HangmanTest {
             Observable.fromArray("secret"),
             Observable.fromArray("a", "e", "o", "s", "c", "r", "g", "t"));
         Output last = result.blockingLast();
-        assertEquals("secret", last.discovered);
-        assertEquals(Set.of("c", "e", "r", "s", "t"), last.guess);
-        assertEquals(Status.WIN, last.status);
+
+        assertThat(last.discovered).isEqualTo("secret");
+        assertThat(last.guess).containsExactlyInAnyOrder("c", "e", "r", "s", "t");
+        assertThat(last.status).isEqualTo(Status.WIN);
     }
 
     @Ignore("Remove to run test")
@@ -106,18 +107,18 @@ public class HangmanTest {
             Observable.fromArray("secret"),
             Observable.fromArray("a", "b", "c", "d", "e", "f", "g", "h"));
         Output last = result.blockingLast();
-        assertEquals("_ec_e_", last.discovered);
-        assertEquals(Set.of("a", "b", "d", "f", "g", "h"), last.misses);
-        assertEquals(Status.LOSS, last.status);
-        assertEquals(
-            Arrays.asList(
+
+        assertThat(last.discovered).isEqualTo("_ec_e_");
+        assertThat(last.misses).containsExactlyInAnyOrder("a", "b", "d", "f", "g", "h");
+        assertThat(last.status).isEqualTo(Status.LOSS);
+        assertThat(last.parts).containsExactlyInAnyOrder(
                 Part.HEAD,
                 Part.BODY,
                 Part.LEFT_ARM,
                 Part.RIGHT_ARM,
                 Part.LEFT_LEG,
-                Part.RIGHT_LEG),
-            last.parts);
+                Part.RIGHT_LEG
+        );
     }
 
     @Ignore("Remove to run test")
@@ -149,19 +150,19 @@ public class HangmanTest {
         Disposable subscription = outputs.filter(output -> output.status != Status.PLAYING)
             .subscribe(results::add);
         try {
-            assertEquals(2, results.size());
+            assertThat(results.size()).isEqualTo(2);
 
             Output first = results.get(0);
-            assertEquals("secret", first.discovered);
-            assertEquals(Set.of("s", "e", "c", "r", "t"), first.guess);
-            assertEquals(Set.of("a", "o", "g"), first.misses);
-            assertEquals(Status.WIN, first.status);
+            assertThat(first.discovered).isEqualTo("secret");
+            assertThat(first.guess).containsExactlyInAnyOrder("s", "e", "c", "r", "t");
+            assertThat(first.misses).containsExactlyInAnyOrder("a", "o", "g");
+            assertThat(first.status).isEqualTo(Status.WIN);
 
             Output second = results.get(1);
-            assertEquals("abba", second.discovered);
-            assertEquals(Set.of("a", "b"), second.guess);
-            assertEquals(Set.of("e", "s"), second.misses);
-            assertEquals(Status.WIN, first.status);
+            assertThat(second.discovered).isEqualTo("abba");
+            assertThat(second.guess).containsExactlyInAnyOrder("a", "b");
+            assertThat(second.misses).containsExactlyInAnyOrder("e", "s");
+            assertThat(first.status).isEqualTo(Status.WIN);
         } finally {
             subscription.dispose();
         }

--- a/exercises/practice/hello-world/src/test/java/GreeterTest.java
+++ b/exercises/practice/hello-world/src/test/java/GreeterTest.java
@@ -1,12 +1,12 @@
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GreeterTest {
 
     @Test
     public void testThatGreeterReturnsTheCorrectGreeting() {
-        assertEquals("Hello, World!", new Greeter().getGreeting());
+        assertThat(new Greeter().getGreeting()).isEqualTo("Hello, World!");
     }
 
 }

--- a/exercises/practice/hexadecimal/src/test/java/HexadecimalTest.java
+++ b/exercises/practice/hexadecimal/src/test/java/HexadecimalTest.java
@@ -1,76 +1,66 @@
 import org.junit.Test;
 import org.junit.Ignore;
-import static org.junit.Assert.assertEquals;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HexadecimalTest {
 
-
     @Test
     public void testOne() {
-        int expected = 1;
-        assertEquals(expected, Hexadecimal.toDecimal("1"));
+        assertThat(Hexadecimal.toDecimal("1")).isEqualTo(1);
     }
 
     @Ignore
     @Test
     public void testC() {
-        int expected = 12;
-        assertEquals(expected, Hexadecimal.toDecimal("c"));
+        assertThat(Hexadecimal.toDecimal("c")).isEqualTo(12);
     }
 
     @Ignore
     @Test
     public void test10() {
-        int expected = 16;
-        assertEquals(expected, Hexadecimal.toDecimal("10"));
+        assertThat(Hexadecimal.toDecimal("10")).isEqualTo(16);
     }
 
     @Ignore
     @Test
     public void testAf() {
-        int expected = 175;
-        assertEquals(expected, Hexadecimal.toDecimal("af"));
+        assertThat(Hexadecimal.toDecimal("af")).isEqualTo(175);
     }
 
     @Ignore
     @Test
     public void test100() {
-        int expected = 256;
-        assertEquals(expected, Hexadecimal.toDecimal("100"));
+        assertThat(Hexadecimal.toDecimal("100")).isEqualTo(256);
     }
 
     @Ignore
     @Test
     public void test19ace() {
-        int expected = 105166;
-        assertEquals(expected, Hexadecimal.toDecimal("19ace"));
+        assertThat(Hexadecimal.toDecimal("19ace")).isEqualTo(105166);
     }
 
     @Ignore
     @Test
     public void testInvalid() {
-        int expected = 0;
-        assertEquals(expected, Hexadecimal.toDecimal("carrot"));
+        assertThat(Hexadecimal.toDecimal("carrot")).isEqualTo(0);
     }
 
     @Ignore
     @Test
     public void testBlack() {
-        int expected = 0;
-        assertEquals(expected, Hexadecimal.toDecimal("000000"));
+        assertThat(Hexadecimal.toDecimal("000000")).isEqualTo(0);
     }
 
     @Ignore
     @Test
     public void testWhite() {
-        int expected = 16777215;
-        assertEquals(expected, Hexadecimal.toDecimal("ffffff"));
+        assertThat(Hexadecimal.toDecimal("ffffff")).isEqualTo(16777215);
     }
 
     @Ignore
     @Test
     public void testYellow() {
-        int expected = 16776960;
-        assertEquals(expected, Hexadecimal.toDecimal("ffff00"));
+        assertThat(Hexadecimal.toDecimal("ffff00")).isEqualTo(16776960);
     }
 }

--- a/exercises/practice/house/src/test/java/HouseTest.java
+++ b/exercises/practice/house/src/test/java/HouseTest.java
@@ -15,151 +15,152 @@ public class HouseTest {
 
     @Test
     public void verseOne() {
-        assertThat(house.verse(1))
-            .isEqualTo("This is the house that Jack built.");
+        assertThat(house.verse(1)).isEqualTo(
+            "This is the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseTwo() {
-        assertThat(house.verse(2))
-            .isEqualTo("This is the malt " +
-                "that lay in the house that Jack built.");
+        assertThat(house.verse(2)).isEqualTo(
+            "This is the malt " +
+            "that lay in the house that Jack built."
+        );
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseThree() {
-        assertThat(house.verse(3))
-            .isEqualTo("This is the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.");
+        assertThat(house.verse(3)).isEqualTo(
+            "This is the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseFour() {
-        assertThat(house.verse(4))
-            .isEqualTo("This is the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.");
+        assertThat(house.verse(4)).isEqualTo(
+            "This is the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseFive() {
-        assertThat(house.verse(5))
-            .isEqualTo("This is the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.");
+        assertThat(house.verse(5)).isEqualTo(
+            "This is the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseSix() {
-        assertThat(house.verse(6))
-            .isEqualTo("This is the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.");
+        assertThat(house.verse(6)).isEqualTo(
+            "This is the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseSeven() {
-        assertThat(house.verse(7))
-            .isEqualTo("This is the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.");
+        assertThat(house.verse(7)).isEqualTo(
+            "This is the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseEight() {
-        assertThat(house.verse(8))
-            .isEqualTo("This is the man all tattered and torn " +
-                "that kissed the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.");
+        assertThat(house.verse(8)).isEqualTo(
+            "This is the man all tattered and torn " +
+            "that kissed the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseNine() {
-        assertThat(house.verse(9))
-            .isEqualTo("This is the priest all shaven and shorn " +
-                "that married the man all tattered and torn " +
-                "that kissed the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.");
+        assertThat(house.verse(9)).isEqualTo(
+            "This is the priest all shaven and shorn " +
+            "that married the man all tattered and torn " +
+            "that kissed the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verse10() {
-        assertThat(house.verse(10))
-            .isEqualTo("This is the rooster that crowed in the morn " +
-                "that woke the priest all shaven and shorn " +
-                "that married the man all tattered and torn " +
-                "that kissed the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.");
+        assertThat(house.verse(10)).isEqualTo(
+            "This is the rooster that crowed in the morn " +
+            "that woke the priest all shaven and shorn " +
+            "that married the man all tattered and torn " +
+            "that kissed the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verse11() {
-        assertThat(house.verse(11))
-            .isEqualTo("This is the farmer sowing his corn " +
-                "that kept the rooster that crowed in the morn " +
-                "that woke the priest all shaven and shorn " +
-                "that married the man all tattered and torn " +
-                "that kissed the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.");
+        assertThat(house.verse(11)).isEqualTo(
+            "This is the farmer sowing his corn " +
+            "that kept the rooster that crowed in the morn " +
+            "that woke the priest all shaven and shorn " +
+            "that married the man all tattered and torn " +
+            "that kissed the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verse12() {
-        assertThat(house.verse(12))
-            .isEqualTo("This is the horse and the hound and the horn " +
-                "that belonged to the farmer sowing his corn " +
-                "that kept the rooster that crowed in the morn " +
-                "that woke the priest all shaven and shorn " +
-                "that married the man all tattered and torn " +
-                "that kissed the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.");
+        assertThat(house.verse(12)).isEqualTo(
+            "This is the horse and the hound and the horn " +
+            "that belonged to the farmer sowing his corn " +
+            "that kept the rooster that crowed in the morn " +
+            "that woke the priest all shaven and shorn " +
+            "that married the man all tattered and torn " +
+            "that kissed the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
@@ -168,121 +169,120 @@ public class HouseTest {
         int startVerse = 4;
         int endVerse = 8;
 
-        assertThat(house.verses(startVerse, endVerse))
-            .isEqualTo("This is the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the man all tattered and torn " +
-                "that kissed the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.");
+        assertThat(house.verses(startVerse, endVerse)).isEqualTo(
+            "This is the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the man all tattered and torn " +
+            "that kissed the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void wholeRhyme() {
-        assertThat(house.sing())
-            .isEqualTo(
-                "This is the house that Jack built.\n" +
-                    "This is the malt " +
-                    "that lay in the house that Jack built.\n" +
-                    "This is the rat " +
-                    "that ate the malt " +
-                    "that lay in the house that Jack built.\n" +
-                    "This is the cat " +
-                    "that killed the rat " +
-                    "that ate the malt " +
-                    "that lay in the house that Jack built.\n" +
-                    "This is the dog " +
-                    "that worried the cat " +
-                    "that killed the rat " +
-                    "that ate the malt " +
-                    "that lay in the house that Jack built.\n" +
-                    "This is the cow with the crumpled horn " +
-                    "that tossed the dog " +
-                    "that worried the cat " +
-                    "that killed the rat " +
-                    "that ate the malt " +
-                    "that lay in the house that Jack built.\n" +
-                    "This is the maiden all forlorn " +
-                    "that milked the cow with the crumpled horn " +
-                    "that tossed the dog " +
-                    "that worried the cat " +
-                    "that killed the rat " +
-                    "that ate the malt " +
-                    "that lay in the house that Jack built.\n" +
-                    "This is the man all tattered and torn " +
-                    "that kissed the maiden all forlorn " +
-                    "that milked the cow with the crumpled horn " +
-                    "that tossed the dog " +
-                    "that worried the cat " +
-                    "that killed the rat " +
-                    "that ate the malt " +
-                    "that lay in the house that Jack built.\n" +
-                    "This is the priest all shaven and shorn " +
-                    "that married the man all tattered and torn " +
-                    "that kissed the maiden all forlorn " +
-                    "that milked the cow with the crumpled horn " +
-                    "that tossed the dog " +
-                    "that worried the cat " +
-                    "that killed the rat " +
-                    "that ate the malt " +
-                    "that lay in the house that Jack built.\n" +
-                    "This is the rooster that crowed in the morn " +
-                    "that woke the priest all shaven and shorn " +
-                    "that married the man all tattered and torn " +
-                    "that kissed the maiden all forlorn " +
-                    "that milked the cow with the crumpled horn " +
-                    "that tossed the dog " +
-                    "that worried the cat " +
-                    "that killed the rat " +
-                    "that ate the malt " +
-                    "that lay in the house that Jack built.\n" +
-                    "This is the farmer sowing his corn " +
-                    "that kept the rooster that crowed in the morn " +
-                    "that woke the priest all shaven and shorn " +
-                    "that married the man all tattered and torn " +
-                    "that kissed the maiden all forlorn " +
-                    "that milked the cow with the crumpled horn " +
-                    "that tossed the dog " +
-                    "that worried the cat " +
-                    "that killed the rat " +
-                    "that ate the malt " +
-                    "that lay in the house that Jack built.\n" +
-                    "This is the horse and the hound and the horn " +
-                    "that belonged to the farmer sowing his corn " +
-                    "that kept the rooster that crowed in the morn " +
-                    "that woke the priest all shaven and shorn " +
-                    "that married the man all tattered and torn " +
-                    "that kissed the maiden all forlorn " +
-                    "that milked the cow with the crumpled horn " +
-                    "that tossed the dog " +
-                    "that worried the cat " +
-                    "that killed the rat " +
-                    "that ate the malt " +
-                    "that lay in the house that Jack built.");
+        assertThat(house.sing()).isEqualTo(
+            "This is the house that Jack built.\n" +
+            "This is the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the man all tattered and torn " +
+            "that kissed the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the priest all shaven and shorn " +
+            "that married the man all tattered and torn " +
+            "that kissed the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the rooster that crowed in the morn " +
+            "that woke the priest all shaven and shorn " +
+            "that married the man all tattered and torn " +
+            "that kissed the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the farmer sowing his corn " +
+            "that kept the rooster that crowed in the morn " +
+            "that woke the priest all shaven and shorn " +
+            "that married the man all tattered and torn " +
+            "that kissed the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.\n" +
+            "This is the horse and the hound and the horn " +
+            "that belonged to the farmer sowing his corn " +
+            "that kept the rooster that crowed in the morn " +
+            "that woke the priest all shaven and shorn " +
+            "that married the man all tattered and torn " +
+            "that kissed the maiden all forlorn " +
+            "that milked the cow with the crumpled horn " +
+            "that tossed the dog " +
+            "that worried the cat " +
+            "that killed the rat " +
+            "that ate the malt " +
+            "that lay in the house that Jack built.");
     }
 }

--- a/exercises/practice/house/src/test/java/HouseTest.java
+++ b/exercises/practice/house/src/test/java/HouseTest.java
@@ -2,7 +2,7 @@ import org.junit.Test;
 import org.junit.Ignore;
 import org.junit.Before;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class HouseTest {
 
@@ -15,115 +15,92 @@ public class HouseTest {
 
     @Test
     public void verseOne() {
-        String expected = "This is the house that Jack built.";
-        int verse = 1;
-
-        assertEquals(expected, house.verse(verse));
+        assertThat(house.verse(1))
+            .isEqualTo("This is the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseTwo() {
-        String expected =
-                "This is the malt " +
-                "that lay in the house that Jack built.";
-        int verse = 2;
-
-        assertEquals(expected, house.verse(verse));
+        assertThat(house.verse(2))
+            .isEqualTo("This is the malt " +
+                "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseThree() {
-        String expected =
-                "This is the rat " +
+        assertThat(house.verse(3))
+            .isEqualTo("This is the rat " +
                 "that ate the malt " +
-                "that lay in the house that Jack built.";
-        int verse = 3;
-
-        assertEquals(expected, house.verse(verse));
+                "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseFour() {
-        String expected =
-                "This is the cat " +
+        assertThat(house.verse(4))
+            .isEqualTo("This is the cat " +
                 "that killed the rat " +
                 "that ate the malt " +
-                "that lay in the house that Jack built.";
-        int verse = 4;
-
-        assertEquals(expected, house.verse(verse));
+                "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseFive() {
-        String expected =
-                "This is the dog " +
+        assertThat(house.verse(5))
+            .isEqualTo("This is the dog " +
                 "that worried the cat " +
                 "that killed the rat " +
                 "that ate the malt " +
-                "that lay in the house that Jack built.";
-        int verse = 5;
-
-        assertEquals(expected, house.verse(verse));
+                "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseSix() {
-        String expected =
-                "This is the cow with the crumpled horn " +
+        assertThat(house.verse(6))
+            .isEqualTo("This is the cow with the crumpled horn " +
                 "that tossed the dog " +
                 "that worried the cat " +
                 "that killed the rat " +
                 "that ate the malt " +
-                "that lay in the house that Jack built.";
-        int verse = 6;
-
-        assertEquals(expected, house.verse(verse));
+                "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseSeven() {
-        String expected =
-                "This is the maiden all forlorn " +
+        assertThat(house.verse(7))
+            .isEqualTo("This is the maiden all forlorn " +
                 "that milked the cow with the crumpled horn " +
                 "that tossed the dog " +
                 "that worried the cat " +
                 "that killed the rat " +
                 "that ate the malt " +
-                "that lay in the house that Jack built.";
-        int verse = 7;
-
-        assertEquals(expected, house.verse(verse));
+                "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseEight() {
-        String expected =
-                "This is the man all tattered and torn " +
+        assertThat(house.verse(8))
+            .isEqualTo("This is the man all tattered and torn " +
                 "that kissed the maiden all forlorn " +
                 "that milked the cow with the crumpled horn " +
                 "that tossed the dog " +
                 "that worried the cat " +
                 "that killed the rat " +
                 "that ate the malt " +
-                "that lay in the house that Jack built.";
-        int verse = 8;
-
-        assertEquals(expected, house.verse(verse));
+                "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verseNine() {
-        String expected =
-                "This is the priest all shaven and shorn " +
+        assertThat(house.verse(9))
+            .isEqualTo("This is the priest all shaven and shorn " +
                 "that married the man all tattered and torn " +
                 "that kissed the maiden all forlorn " +
                 "that milked the cow with the crumpled horn " +
@@ -131,17 +108,14 @@ public class HouseTest {
                 "that worried the cat " +
                 "that killed the rat " +
                 "that ate the malt " +
-                "that lay in the house that Jack built.";
-        int verse = 9;
-
-        assertEquals(expected, house.verse(verse));
+                "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verse10() {
-        String expected =
-                "This is the rooster that crowed in the morn " +
+        assertThat(house.verse(10))
+            .isEqualTo("This is the rooster that crowed in the morn " +
                 "that woke the priest all shaven and shorn " +
                 "that married the man all tattered and torn " +
                 "that kissed the maiden all forlorn " +
@@ -150,17 +124,14 @@ public class HouseTest {
                 "that worried the cat " +
                 "that killed the rat " +
                 "that ate the malt " +
-                "that lay in the house that Jack built.";
-        int verse = 10;
-
-        assertEquals(expected, house.verse(verse));
+                "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verse11() {
-        String expected =
-                "This is the farmer sowing his corn " +
+        assertThat(house.verse(11))
+            .isEqualTo("This is the farmer sowing his corn " +
                 "that kept the rooster that crowed in the morn " +
                 "that woke the priest all shaven and shorn " +
                 "that married the man all tattered and torn " +
@@ -170,17 +141,14 @@ public class HouseTest {
                 "that worried the cat " +
                 "that killed the rat " +
                 "that ate the malt " +
-                "that lay in the house that Jack built.";
-        int verse = 11;
-
-        assertEquals(expected, house.verse(verse));
+                "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void verse12() {
-        String expected =
-                "This is the horse and the hound and the horn " +
+        assertThat(house.verse(12))
+            .isEqualTo("This is the horse and the hound and the horn " +
                 "that belonged to the farmer sowing his corn " +
                 "that kept the rooster that crowed in the morn " +
                 "that woke the priest all shaven and shorn " +
@@ -191,17 +159,17 @@ public class HouseTest {
                 "that worried the cat " +
                 "that killed the rat " +
                 "that ate the malt " +
-                "that lay in the house that Jack built.";
-        int verse = 12;
-
-        assertEquals(expected, house.verse(verse));
+                "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void multipleVerses() {
-        String expected =
-                "This is the cat " +
+        int startVerse = 4;
+        int endVerse = 8;
+
+        assertThat(house.verses(startVerse, endVerse))
+            .isEqualTo("This is the cat " +
                 "that killed the rat " +
                 "that ate the malt " +
                 "that lay in the house that Jack built.\n" +
@@ -230,97 +198,91 @@ public class HouseTest {
                 "that worried the cat " +
                 "that killed the rat " +
                 "that ate the malt " +
-                "that lay in the house that Jack built.";
-
-        int startVerse = 4;
-        int endVerse = 8;
-
-        assertEquals(expected, house.verses(startVerse, endVerse));
+                "that lay in the house that Jack built.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void wholeRhyme() {
-        String expected =
+        assertThat(house.sing())
+            .isEqualTo(
                 "This is the house that Jack built.\n" +
-                "This is the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the man all tattered and torn " +
-                "that kissed the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the priest all shaven and shorn " +
-                "that married the man all tattered and torn " +
-                "that kissed the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the rooster that crowed in the morn " +
-                "that woke the priest all shaven and shorn " +
-                "that married the man all tattered and torn " +
-                "that kissed the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the farmer sowing his corn " +
-                "that kept the rooster that crowed in the morn " +
-                "that woke the priest all shaven and shorn " +
-                "that married the man all tattered and torn " +
-                "that kissed the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.\n" +
-                "This is the horse and the hound and the horn " +
-                "that belonged to the farmer sowing his corn " +
-                "that kept the rooster that crowed in the morn " +
-                "that woke the priest all shaven and shorn " +
-                "that married the man all tattered and torn " +
-                "that kissed the maiden all forlorn " +
-                "that milked the cow with the crumpled horn " +
-                "that tossed the dog " +
-                "that worried the cat " +
-                "that killed the rat " +
-                "that ate the malt " +
-                "that lay in the house that Jack built.";
-
-        assertEquals(expected, house.sing());
+                    "This is the malt " +
+                    "that lay in the house that Jack built.\n" +
+                    "This is the rat " +
+                    "that ate the malt " +
+                    "that lay in the house that Jack built.\n" +
+                    "This is the cat " +
+                    "that killed the rat " +
+                    "that ate the malt " +
+                    "that lay in the house that Jack built.\n" +
+                    "This is the dog " +
+                    "that worried the cat " +
+                    "that killed the rat " +
+                    "that ate the malt " +
+                    "that lay in the house that Jack built.\n" +
+                    "This is the cow with the crumpled horn " +
+                    "that tossed the dog " +
+                    "that worried the cat " +
+                    "that killed the rat " +
+                    "that ate the malt " +
+                    "that lay in the house that Jack built.\n" +
+                    "This is the maiden all forlorn " +
+                    "that milked the cow with the crumpled horn " +
+                    "that tossed the dog " +
+                    "that worried the cat " +
+                    "that killed the rat " +
+                    "that ate the malt " +
+                    "that lay in the house that Jack built.\n" +
+                    "This is the man all tattered and torn " +
+                    "that kissed the maiden all forlorn " +
+                    "that milked the cow with the crumpled horn " +
+                    "that tossed the dog " +
+                    "that worried the cat " +
+                    "that killed the rat " +
+                    "that ate the malt " +
+                    "that lay in the house that Jack built.\n" +
+                    "This is the priest all shaven and shorn " +
+                    "that married the man all tattered and torn " +
+                    "that kissed the maiden all forlorn " +
+                    "that milked the cow with the crumpled horn " +
+                    "that tossed the dog " +
+                    "that worried the cat " +
+                    "that killed the rat " +
+                    "that ate the malt " +
+                    "that lay in the house that Jack built.\n" +
+                    "This is the rooster that crowed in the morn " +
+                    "that woke the priest all shaven and shorn " +
+                    "that married the man all tattered and torn " +
+                    "that kissed the maiden all forlorn " +
+                    "that milked the cow with the crumpled horn " +
+                    "that tossed the dog " +
+                    "that worried the cat " +
+                    "that killed the rat " +
+                    "that ate the malt " +
+                    "that lay in the house that Jack built.\n" +
+                    "This is the farmer sowing his corn " +
+                    "that kept the rooster that crowed in the morn " +
+                    "that woke the priest all shaven and shorn " +
+                    "that married the man all tattered and torn " +
+                    "that kissed the maiden all forlorn " +
+                    "that milked the cow with the crumpled horn " +
+                    "that tossed the dog " +
+                    "that worried the cat " +
+                    "that killed the rat " +
+                    "that ate the malt " +
+                    "that lay in the house that Jack built.\n" +
+                    "This is the horse and the hound and the horn " +
+                    "that belonged to the farmer sowing his corn " +
+                    "that kept the rooster that crowed in the morn " +
+                    "that woke the priest all shaven and shorn " +
+                    "that married the man all tattered and torn " +
+                    "that kissed the maiden all forlorn " +
+                    "that milked the cow with the crumpled horn " +
+                    "that tossed the dog " +
+                    "that worried the cat " +
+                    "that killed the rat " +
+                    "that ate the malt " +
+                    "that lay in the house that Jack built.");
     }
 }

--- a/exercises/practice/isbn-verifier/src/test/java/IsbnVerifierTest.java
+++ b/exercises/practice/isbn-verifier/src/test/java/IsbnVerifierTest.java
@@ -2,8 +2,9 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThat;
 
 public class IsbnVerifierTest {
     private IsbnVerifier isbnVerifier;
@@ -15,108 +16,108 @@ public class IsbnVerifierTest {
 
     @Test
     public void validIsbnNumber() {
-        assertTrue(isbnVerifier.isValid("3-598-21508-8"));
+        assertThat(isbnVerifier.isValid("3-598-21508-8")).isTrue();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void invalidIsbnCheckDigit() {
-        assertFalse(isbnVerifier.isValid("3-598-21508-9"));
+        assertThat(isbnVerifier.isValid("3-598-21508-9")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void validIsbnNumberWithCheckDigitOfTen() {
-        assertTrue(isbnVerifier.isValid("3-598-21507-X"));
+        assertThat(isbnVerifier.isValid("3-598-21507-X")).isTrue();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void validIsbnNumberWithCheckDigitPaddedWithLettersIsInvalid() {
-        assertFalse(isbnVerifier.isValid("ABCDEFG3-598-21507-XQWERTYUI"));
+        assertThat(isbnVerifier.isValid("ABCDEFG3-598-21507-XQWERTYUI")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void checkDigitIsACharacterOtherThanX() {
-        assertFalse(isbnVerifier.isValid("3-598-21507-A"));
+        assertThat(isbnVerifier.isValid("3-598-21507-A")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void invalidCharacterInIsbn() {
-        assertFalse(isbnVerifier.isValid("3-598-P1581-X"));
+        assertThat(isbnVerifier.isValid("3-598-P1581-X")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void xIsOnlyValidAsACheckDigit() {
-        assertFalse(isbnVerifier.isValid("3-598-2X507-9"));
+        assertThat(isbnVerifier.isValid("3-598-2X507-9")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void validIsbnWithoutSeparatingDashes() {
-        assertTrue(isbnVerifier.isValid("3598215088"));
+        assertThat(isbnVerifier.isValid("3598215088")).isTrue();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void isbnWithoutSeparatingDashesAndXAsCheckDigit() {
-        assertTrue(isbnVerifier.isValid("359821507X"));
+        assertThat(isbnVerifier.isValid("359821507X")).isTrue();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void isbnWithoutCheckDigitAndDashes() {
-        assertFalse(isbnVerifier.isValid("359821507"));
+        assertThat(isbnVerifier.isValid("359821507")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void tooLongIsbnAndNoDashes() {
-        assertFalse(isbnVerifier.isValid("3598215078X"));
+        assertThat(isbnVerifier.isValid("3598215078X")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void tooShortIsbn() {
-        assertFalse(isbnVerifier.isValid("00"));
+        assertThat(isbnVerifier.isValid("00")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void isbnWithoutCheckDigit() {
-        assertFalse(isbnVerifier.isValid("3-598-21507"));
+        assertThat(isbnVerifier.isValid("3-598-21507")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void checkDigitOfXShouldNotBeUsedForZero() {
-        assertFalse(isbnVerifier.isValid("3-598-21515-X"));
+        assertThat(isbnVerifier.isValid("3-598-21515-X")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void emptyIsbn() {
-        assertFalse(isbnVerifier.isValid(""));
+        assertThat(isbnVerifier.isValid("")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void inputIsNineCharacters() {
-        assertFalse(isbnVerifier.isValid("134456729"));
+        assertThat(isbnVerifier.isValid("134456729")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void invalidCharactersAreNotIgnored() {
-        assertFalse(isbnVerifier.isValid("3132P34035"));
+        assertThat(isbnVerifier.isValid("3132P34035")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void inputIsTooLongButContainsAValidIsbn() {
-        assertFalse(isbnVerifier.isValid("98245726788"));
+        assertThat(isbnVerifier.isValid("98245726788")).isFalse();
     }
 }

--- a/exercises/practice/isbn-verifier/src/test/java/IsbnVerifierTest.java
+++ b/exercises/practice/isbn-verifier/src/test/java/IsbnVerifierTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertThat;
 
 public class IsbnVerifierTest {
     private IsbnVerifier isbnVerifier;

--- a/exercises/practice/isogram/src/test/java/IsogramCheckerTest.java
+++ b/exercises/practice/isogram/src/test/java/IsogramCheckerTest.java
@@ -1,98 +1,92 @@
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class IsogramCheckerTest {
+    private IsogramChecker isogramChecker;
+    
+    @Before
+    public void setUp() {
+        isogramChecker = new IsogramChecker();
+    }
 
     @Test
     public void testEmptyString() {
-        IsogramChecker iso = new IsogramChecker();
-        assertTrue(iso.isIsogram(""));
+        assertThat(isogramChecker.isIsogram("")).isTrue();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testLowercaseIsogram() {
-        IsogramChecker iso = new IsogramChecker();
-        assertTrue(iso.isIsogram("isogram"));
+        assertThat(isogramChecker.isIsogram("isogram")).isTrue();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testNotIsogram() {
-        IsogramChecker iso = new IsogramChecker();
-        assertFalse(iso.isIsogram("eleven"));
+        assertThat(isogramChecker.isIsogram("eleven")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testDuplicateEndAlphabet() {
-        IsogramChecker iso = new IsogramChecker();
-        assertFalse(iso.isIsogram("zzyzx"));
+        assertThat(isogramChecker.isIsogram("zzyzx")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testMediumLongIsogram() {
-        IsogramChecker iso = new IsogramChecker();
-        assertTrue(iso.isIsogram("subdermatoglyphic"));
+        assertThat(isogramChecker.isIsogram("subdermatoglyphic")).isTrue();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testCaseInsensitive() {
-        IsogramChecker iso = new IsogramChecker();
-        assertFalse(iso.isIsogram("Alphabet"));
+        assertThat(isogramChecker.isIsogram("Alphabet")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testDuplicatMixedCase() {
-        IsogramChecker iso = new IsogramChecker();
-        assertFalse(iso.isIsogram("alphAbet"));
+        assertThat(isogramChecker.isIsogram("alphAbet")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testIsogramWithHyphen() {
-        IsogramChecker iso = new IsogramChecker();
-        assertTrue(iso.isIsogram("thumbscrew-japingly"));
+        assertThat(isogramChecker.isIsogram("thumbscrew-japingly")).isTrue();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testIsogramWithDuplicatedCharAfterHyphen() {
-        IsogramChecker iso = new IsogramChecker();
-        assertFalse(iso.isIsogram("thumbscrew-jappingly"));
+        assertThat(isogramChecker.isIsogram("thumbscrew-jappingly")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testIsogramWithDuplicatedHyphen() {
-        IsogramChecker iso = new IsogramChecker();
-        assertTrue(iso.isIsogram("six-year-old"));
+        assertThat(isogramChecker.isIsogram("six-year-old")).isTrue();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testMadeUpNameThatIsAnIsogram() {
-        IsogramChecker iso = new IsogramChecker();
-        assertTrue(iso.isIsogram("Emily Jung Schwartzkopf"));
+        assertThat(isogramChecker.isIsogram("Emily Jung Schwartzkopf")).isTrue();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testDuplicatedCharacterInTheMiddleIsNotIsogram() {
-        IsogramChecker iso = new IsogramChecker();
-        assertFalse(iso.isIsogram("accentor"));
+        assertThat(isogramChecker.isIsogram("accentor")).isFalse();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSameFirstAndLast() {
-        IsogramChecker iso = new IsogramChecker();
-        assertFalse(iso.isIsogram("angola"));
+        assertThat(new IsogramChecker().isIsogram("angola")).isFalse();
     }
 
 }

--- a/exercises/practice/kindergarten-garden/src/test/java/KindergartenGardenTest.java
+++ b/exercises/practice/kindergarten-garden/src/test/java/KindergartenGardenTest.java
@@ -1,126 +1,97 @@
-import java.util.List;
-import java.util.Arrays;
 
 import org.junit.Test;
 import org.junit.Ignore;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class KindergartenGardenTest {
 
     @Test
     public void singleStudent() {
-        String student = "Alice";
-        String plants = "RC\nGG";
-        List<Plant> expected = Arrays.asList(Plant.RADISHES, Plant.CLOVER, Plant.GRASS, Plant.GRASS);
-
-        assertEquals(
-            expected,
-            new KindergartenGarden(plants).getPlantsOfStudent(student)
+        assertThat(
+            new KindergartenGarden("RC\nGG").getPlantsOfStudent("Alice")
+        ).containsExactly(
+            Plant.RADISHES, Plant.CLOVER, Plant.GRASS, Plant.GRASS
         );
     }
 
     @Ignore("Remove to run test")
     @Test
     public void singleStudent2() {
-        String student = "Alice";
-        String plants = "VC\nRC";
-        List<Plant> expected = Arrays.asList(Plant.VIOLETS, Plant.CLOVER, Plant.RADISHES, Plant.CLOVER);
-
-        assertEquals(
-            expected,
-            new KindergartenGarden(plants).getPlantsOfStudent(student)
+        assertThat(
+            new KindergartenGarden("VC\nRC").getPlantsOfStudent("Alice")
+        ).containsExactly(
+            Plant.VIOLETS, Plant.CLOVER, Plant.RADISHES, Plant.CLOVER
         );
     }
 
     @Ignore("Remove to run test")
     @Test
     public void twoStudents() {
-        String student = "Bob";
-        String plants = "VVCG\nVVRC";
-        List<Plant> expected = Arrays.asList(Plant.CLOVER, Plant.GRASS, Plant.RADISHES, Plant.CLOVER);
-
-        assertEquals(
-            expected,
-            new KindergartenGarden(plants).getPlantsOfStudent(student)
+        assertThat(
+            new KindergartenGarden("VVCG\nVVRC").getPlantsOfStudent("Bob")
+        ).containsExactly(
+            Plant.CLOVER, Plant.GRASS, Plant.RADISHES, Plant.CLOVER
         );
     }
 
     @Ignore("Remove to run test")
     @Test
     public void oneGardenSecondStudent() {
-        String student = "Bob";
-        String plants = "VVCCGG\nVVCCGG";
-        List<Plant> expected = Arrays.asList(Plant.CLOVER, Plant.CLOVER, Plant.CLOVER, Plant.CLOVER);
-
-        assertEquals(
-            expected,
-            new KindergartenGarden(plants).getPlantsOfStudent(student)
+        assertThat(
+            new KindergartenGarden("VVCCGG\nVVCCGG").getPlantsOfStudent("Bob")
+        ).containsExactly(
+            Plant.CLOVER, Plant.CLOVER, Plant.CLOVER, Plant.CLOVER
         );
     }
 
     @Ignore("Remove to run test")
     @Test
     public void oneGardenThirdStudent() {
-        String student = "Charlie";
-        String plants = "VVCCGG\nVVCCGG";
-        List<Plant> expected = Arrays.asList(Plant.GRASS, Plant.GRASS, Plant.GRASS, Plant.GRASS);
-
-        assertEquals(
-            expected,
-            new KindergartenGarden(plants).getPlantsOfStudent(student)
+        assertThat(
+            new KindergartenGarden("VVCCGG\nVVCCGG").getPlantsOfStudent("Charlie")
+        ).containsExactly(
+            Plant.GRASS, Plant.GRASS, Plant.GRASS, Plant.GRASS
         );
     }
 
     @Ignore("Remove to run test")
     @Test
     public void fullGardenFirstStudent() {
-        String student = "Alice";
-        String plants = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV";
-        List<Plant> expected = Arrays.asList(Plant.VIOLETS, Plant.RADISHES, Plant.VIOLETS, Plant.RADISHES);
-
-        assertEquals(
-            expected,
-            new KindergartenGarden(plants).getPlantsOfStudent(student)
+        assertThat(
+            new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV").getPlantsOfStudent("Alice")
+        ).containsExactly(
+            Plant.VIOLETS, Plant.RADISHES, Plant.VIOLETS, Plant.RADISHES
         );
     }
 
     @Ignore("Remove to run test")
     @Test
     public void fullGardenSecondStudent() {
-        String student = "Bob";
-        String plants = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV";
-        List<Plant> expected = Arrays.asList(Plant.CLOVER, Plant.GRASS, Plant.CLOVER, Plant.CLOVER);
-
-        assertEquals(
-            expected,
-            new KindergartenGarden(plants).getPlantsOfStudent(student)
+        assertThat(
+            new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV").getPlantsOfStudent("Bob")
+        ).containsExactly(
+            Plant.CLOVER, Plant.GRASS, Plant.CLOVER, Plant.CLOVER
         );
     }
 
     @Ignore("Remove to run test")
     @Test
     public void fullGardenSecondToLastStudent() {
-        String student = "Kincaid";
-        String plants = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV";
-        List<Plant> expected = Arrays.asList(Plant.GRASS, Plant.CLOVER, Plant.CLOVER, Plant.GRASS);
-
-        assertEquals(
-            expected,
-            new KindergartenGarden(plants).getPlantsOfStudent(student)
+        assertThat(
+            new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV").getPlantsOfStudent("Kincaid")
+        ).containsExactly(
+            Plant.GRASS, Plant.CLOVER, Plant.CLOVER, Plant.GRASS
         );
     }
 
     @Ignore("Remove to run test")
     @Test
     public void fullGardenLastStudent() {
-        String student = "Larry";
-        String plants = "VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV";
-        List<Plant> expected = Arrays.asList(Plant.GRASS, Plant.VIOLETS, Plant.CLOVER, Plant.VIOLETS);
-
-        assertEquals(
-            expected,
-            new KindergartenGarden(plants).getPlantsOfStudent(student)
+        assertThat(
+            new KindergartenGarden("VRCGVVRVCGGCCGVRGCVCGCGV\nVRCCCGCRRGVCGCRVVCVGCGCV").getPlantsOfStudent("Larry")
+        ).containsExactly(
+            Plant.GRASS, Plant.VIOLETS, Plant.CLOVER, Plant.VIOLETS
         );
     }
 

--- a/exercises/practice/knapsack/.meta/src/reference/java/Knapsack.java
+++ b/exercises/practice/knapsack/.meta/src/reference/java/Knapsack.java
@@ -1,13 +1,13 @@
-import java.util.ArrayList;
+import java.util.List;
 
 class Knapsack {
 
-    int maximumValue(int maximumWeight, ArrayList<Item> items) {
+    int maximumValue(int maximumWeight, List<Item> items) {
         return maximumValueHelperBottomUp(maximumWeight, items);
     }
 
     private int maximumValueHelperBottomUp(
-        int maximumWeight, ArrayList<Item> items) {
+        int maximumWeight, List<Item> items) {
         int[][] knapsack = new int[items.size() + 1][maximumWeight + 1]; 
         for (int item = 0; item <= items.size(); item++) {
             for (int weight = 0; weight <= maximumWeight; weight++) {

--- a/exercises/practice/knapsack/src/test/java/KnapsackTest.java
+++ b/exercises/practice/knapsack/src/test/java/KnapsackTest.java
@@ -2,9 +2,10 @@ import org.junit.Ignore;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
+import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class KnapsackTest {
 
@@ -17,88 +18,100 @@ public class KnapsackTest {
 
     @Test
     public void testNoItems() {
-        ArrayList<Item> items = new ArrayList<>();
-        assertEquals(0, knapsack.maximumValue(100, items));
+        List<Item> items = List.of();
+        assertThat(knapsack.maximumValue(100, items)).isEqualTo(0);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testOneItemTooHeavy() {
-        ArrayList<Item> items = new ArrayList<>();
-        items.add(new Item(100, 1));
-        assertEquals(0, knapsack.maximumValue(10, items));
+        List<Item> items = List.of(
+            new Item(100, 1)
+        );
+
+        assertThat(knapsack.maximumValue(10, items)).isEqualTo(0);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testFiveItemsCannotBeGreedyByWeight() {
-        ArrayList<Item> items = new ArrayList<>();
-        items.add(new Item(2, 5));
-        items.add(new Item(2, 5));
-        items.add(new Item(2, 5));
-        items.add(new Item(2, 5));
-        items.add(new Item(10, 21));
-        assertEquals(21, knapsack.maximumValue(10, items));
+        List<Item> items = List.of(
+            new Item(2, 5),
+            new Item(2, 5),
+            new Item(2, 5),
+            new Item(2, 5),
+            new Item(10, 21)
+        );
+
+        assertThat(knapsack.maximumValue(10, items)).isEqualTo(21);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testFiveItemsCannotBeGreedyByValue() {
-        ArrayList<Item> items = new ArrayList<>();
-        items.add(new Item(2, 20));
-        items.add(new Item(2, 20));
-        items.add(new Item(2, 20));
-        items.add(new Item(2, 20));
-        items.add(new Item(10, 50));
-        assertEquals(80, knapsack.maximumValue(10, items));
+        List<Item> items = List.of(
+            new Item(2, 20),
+            new Item(2, 20),
+            new Item(2, 20),
+            new Item(2, 20),
+            new Item(10, 50)
+        );
+
+        assertThat(knapsack.maximumValue(10, items)).isEqualTo(80);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testExampleKnapsack() {
-        ArrayList<Item> items = new ArrayList<>();
-        items.add(new Item(5, 10));
-        items.add(new Item(4, 40));
-        items.add(new Item(6, 30));
-        items.add(new Item(4, 50));
-        assertEquals(90, knapsack.maximumValue(10, items));
+        List<Item> items = List.of(
+            new Item(5, 10),
+            new Item(4, 40),
+            new Item(6, 30),
+            new Item(4, 50)
+        );
+
+        assertThat(knapsack.maximumValue(10, items)).isEqualTo(90);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testEightItems() {
-        ArrayList<Item> items = new ArrayList<>();
-        items.add(new Item(25, 350));
-        items.add(new Item(35, 400));
-        items.add(new Item(45, 450));
-        items.add(new Item(5, 20));
-        items.add(new Item(25, 70));
-        items.add(new Item(3, 8));
-        items.add(new Item(2, 5));
-        items.add(new Item(2, 5));
-        assertEquals(900, knapsack.maximumValue(104, items));
+        List<Item> items = List.of(
+            new Item(25, 350),
+            new Item(35, 400),
+            new Item(45, 450),
+            new Item(5, 20),
+            new Item(25, 70),
+            new Item(3, 8),
+            new Item(2, 5),
+            new Item(2, 5)
+        );
+
+        assertThat(knapsack.maximumValue(104, items)).isEqualTo(900);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testFifteenItems() {
-        ArrayList<Item> items = new ArrayList<>();
-        items.add(new Item(70, 135));
-        items.add(new Item(73, 139));
-        items.add(new Item(77, 149));
-        items.add(new Item(80, 150));
-        items.add(new Item(82, 156));
-        items.add(new Item(87, 163));
-        items.add(new Item(90, 173));
-        items.add(new Item(94, 184));
-        items.add(new Item(98, 192));
-        items.add(new Item(106, 201));
-        items.add(new Item(110, 210));
-        items.add(new Item(113, 214));
-        items.add(new Item(115, 221));
-        items.add(new Item(118, 229));
-        items.add(new Item(120, 240));
-        assertEquals(1458, knapsack.maximumValue(750, items));
+        List<Item> items = List.of(
+            new Item(70, 135),
+            new Item(73, 139),
+            new Item(77, 149),
+            new Item(80, 150),
+            new Item(82, 156),
+            new Item(87, 163),
+            new Item(90, 173),
+            new Item(94, 184),
+            new Item(98, 192),
+            new Item(106, 201),
+            new Item(110, 210),
+            new Item(113, 214),
+            new Item(115, 221),
+            new Item(118, 229),
+            new Item(120, 240)
+        );
+
+        assertThat(knapsack.maximumValue(750, items)).isEqualTo(1458);
     }
 
 }


### PR DESCRIPTION
I saw someone else group their AssertJ conversions together and figured I'd start doing the same.

The tests have been converted from using JUnit's assertions to use AssertJ, cleaning up and inlining portions of the tests that make sense to do so.

I also updated the reference implementation for knapsack.  It needlessly specified ArrayList in its method signatures (instead of just List).  Switching to List let me clean up the tests a little more.

Exercises updated:
- hamming
- hangman
- hello-world
- hexadecimal
- house
- isbn-verifier
- isogram
- kindergarten-garden
- knapsack


---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
