### PR TITLE
Fix Exercism Contributing Guide Link on CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ This guide covers contributing to the Java track.  If you are new to the exercis
 
 If, at any point, you're having any trouble, pop in the [Gitter exercism/java room](https://gitter.im/exercism/java) or the [Gitter exercism/dev room](https://gitter.im/exercism/dev) for help.
 
-For general guidelines about contributing to Exercism see the [Exercism contributing guide](https://github.com/exercism/docs/tree/master/contributing-to-language-tracks).
+For general guidelines about contributing to Exercism see the [Exercism contributing guide](https://exercism.org/docs/building).
 
 ## Before Making Your Pull Request
 


### PR DESCRIPTION
Link for the 'Exercism Contributing Guide' on the Overview
was broken. Fixed with the correct link.

# pull request

<!-- Your content goes here: -->

Screenshots with the change:
Before ->
<img width="665" alt="Captura de ecrã 2021-12-12, às 12 38 44" src="https://user-images.githubusercontent.com/54470604/145710641-c7a4eea0-ceb5-4e26-99a1-113c2be93b42.png">

After ->
<img width="682" alt="Captura de ecrã 2021-12-12, às 12 39 10" src="https://user-images.githubusercontent.com/54470604/145710651-f6222f59-d652-46e3-ad94-4150fc4c9eba.png">




<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
