### PR TITLE
Replaced the class name Array with Arrays

### DIFF
--- a/concepts/arrays/about.md
+++ b/concepts/arrays/about.md
@@ -43,7 +43,7 @@ int secondElement = twoInts[1];
 
 Accessing an index that is outside of the valid indexes for the array results in an `IndexOutOfBoundsException`.
 
-Arrays can be manipulated by either calling an array instance's methods or properties, or by using the static methods defined in the `Array` class (typically only used in generic code).
+Arrays can be manipulated by either calling an array instance's methods or properties, or by using the static methods defined in the `Arrays` class (typically only used in generic code).
 The most commonly used property for arrays is its length which can be accessed like this:
 
 ```java

--- a/concepts/arrays/introduction.md
+++ b/concepts/arrays/introduction.md
@@ -43,7 +43,7 @@ int secondElement = twoInts[1];
 
 Accessing an index that is outside of the valid indexes for the array results in an `IndexOutOfBoundsException`.
 
-Arrays can be manipulated by either calling an array instance's methods or properties, or by using the static methods defined in the `Array` class (typically only used in generic code).
+Arrays can be manipulated by either calling an array instance's methods or properties, or by using the static methods defined in the `Arrays` class (typically only used in generic code).
 The most commonly used property for arrays is its length which can be accessed like this:
 
 ```java

--- a/exercises/concept/bird-watcher/.docs/introduction.md
+++ b/exercises/concept/bird-watcher/.docs/introduction.md
@@ -21,7 +21,7 @@ int[] threeIntsV1 = new int[] { 4, 9, 7 };
 int[] threeIntsV2 = { 4, 9, 7 };
 ```
 
-Arrays can be manipulated by either calling an array instance's methods or properties, or by using the static methods defined in the `Array` class.
+Arrays can be manipulated by either calling an array instance's methods or properties, or by using the static methods defined in the `Arrays` class.
 
 The fact that an array is also a _collection_ means that, besides accessing values by index, you can iterate over _all_ its values using a `foreach` loop:
 


### PR DESCRIPTION
In java, the class that contains static methods,
to manipulate arrays, is java.util.Arrays.

Corrected the instructions.

https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Arrays.html
# pull request

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
