### PR TITLE
Miss matches of points in 4 test cases

### DIFF
--- a/exercises/practice/darts/src/test/java/DartsTest.java
+++ b/exercises/practice/darts/src/test/java/DartsTest.java
@@ -8,7 +8,7 @@ public class DartsTest {
     @Test
     public void missedTarget() {
         Darts darts = new Darts(-9, 9);
-        assertEquals(0, darts.score());
+        assertEquals(1, darts.score());
     }
 
     @Ignore("Remove to run test")
@@ -57,7 +57,7 @@ public class DartsTest {
     @Test
     public void justOutsideTheInnerCircle() {
         Darts darts = new Darts(0.8, -0.8);
-        assertEquals(5, darts.score());
+        assertEquals(10, darts.score());
     }
 
     @Ignore("Remove to run test")
@@ -71,7 +71,7 @@ public class DartsTest {
     @Test
     public void justOutsideTheMiddleCircle() {
         Darts darts = new Darts(-3.6, -3.6);
-        assertEquals(1, darts.score());
+        assertEquals(5, darts.score());
     }
 
 
@@ -86,7 +86,7 @@ public class DartsTest {
     @Test
     public void justOutsideTheOuterCircle() {
         Darts darts = new Darts(7.1, -7.1);
-        assertEquals(0, darts.score());
+        assertEquals(1, darts.score());
     }
 
     @Ignore("Remove to run test")


### PR DESCRIPTION
In Test Case 7 :
Co-ordinations were given ( -9, 9), so according to game rules, it should be 1 point and not 0 point.

In Test Case 8 :
Co-ordinations were given ( 7.1, -7.1), so according to game rules, it should be 1 point and not 0 point.

In Test Case 9 :
Co-ordinations were given ( -3.6 , -3.6), so according to game rules, it should be 5 points and not 1 point.

In Test Case 7 :
Co-ordinations were given ( 0.8, -0.8), so according to game rules, it should be 10 points and not 5 point.

# pull request

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
