### PR TITLE
`need-for-speed`: Change method `canFinishTrack` to `tryFinishTrack`

### DIFF
--- a/exercises/concept/need-for-speed/.docs/instructions.md
+++ b/exercises/concept/need-for-speed/.docs/instructions.md
@@ -80,6 +80,11 @@ var car = new NeedForSpeed(speed, batteryDrain);
 int distance = 100;
 var race = new RaceTrack(distance);
 
+car.distanceDriven()
+// => 0
+
 race.tryFinishTrack(car);
 // => true
-```
+
+car.distanceDriven()
+// => 100

--- a/exercises/concept/need-for-speed/.docs/instructions.md
+++ b/exercises/concept/need-for-speed/.docs/instructions.md
@@ -70,7 +70,7 @@ car.distanceDriven();
 
 ## 6. Check if a remote control car can finish a race
 
-To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `RaceTrack.carCanFinish()` method that takes a `NeedForSpeed` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`:
+To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `RaceTrack.tryFinishTrack()` method that takes a `NeedForSpeed` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`:
 
 ```java
 int speed = 5;
@@ -80,6 +80,6 @@ var car = new NeedForSpeed(speed, batteryDrain);
 int distance = 100;
 var race = new RaceTrack(distance);
 
-race.carCanFinish(car);
+race.tryFinishTrack(car);
 // => true
 ```

--- a/exercises/concept/need-for-speed/.docs/instructions.md
+++ b/exercises/concept/need-for-speed/.docs/instructions.md
@@ -70,7 +70,7 @@ car.distanceDriven();
 
 ## 6. Check if a remote control car can finish a race
 
-To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `RaceTrack.tryFinishTrack()` method that takes a `NeedForSpeed` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`:
+To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `RaceTrack.tryFinishTrack()` method that takes a `NeedForSpeed` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`. To see if the car can finish the race, you should try to drive the car until either you reach the end of the track or the battery drains:
 
 ```java
 int speed = 5;

--- a/exercises/concept/need-for-speed/.meta/src/reference/java/NeedForSpeed.java
+++ b/exercises/concept/need-for-speed/.meta/src/reference/java/NeedForSpeed.java
@@ -36,7 +36,7 @@ class RaceTrack {
         this.distance = distance;
     }
 
-    public boolean carCanFinish(NeedForSpeed car) {
+    public boolean tryFinishTrack(NeedForSpeed car) {
         while (!car.batteryDrained()) {
             car.drive();
         }

--- a/exercises/concept/need-for-speed/src/main/java/NeedForSpeed.java
+++ b/exercises/concept/need-for-speed/src/main/java/NeedForSpeed.java
@@ -21,7 +21,7 @@ class NeedForSpeed {
 class RaceTrack {
     // TODO: define the constructor for the 'RaceTrack' class
 
-    public boolean carCanFinish(NeedForSpeed car) {
-        throw new UnsupportedOperationException("Please implement the RaceTrack.carCanFinish() method");
+    public boolean tryFinishTrack(NeedForSpeed car) {
+        throw new UnsupportedOperationException("Please implement the RaceTrack.tryFinishTrack() method");
     }
 }

--- a/exercises/concept/need-for-speed/src/test/java/NeedForSpeedTest.java
+++ b/exercises/concept/need-for-speed/src/test/java/NeedForSpeedTest.java
@@ -121,7 +121,7 @@ public class NeedForSpeedTest {
         int distance = 100;
         var race = new RaceTrack(distance);
 
-        assertThat(race.carCanFinish(car)).isTrue();
+        assertThat(race.tryFinishTrack(car)).isTrue();
     }
 
     @Test
@@ -133,7 +133,7 @@ public class NeedForSpeedTest {
         int distance = 20;
         var race = new RaceTrack(distance);
 
-        assertThat(race.carCanFinish(car)).isTrue();
+        assertThat(race.tryFinishTrack(car)).isTrue();
     }
 
     @Test
@@ -145,7 +145,7 @@ public class NeedForSpeedTest {
         int distance = 16;
         var race = new RaceTrack(distance);
 
-        assertThat(race.carCanFinish(car)).isFalse();
+        assertThat(race.tryFinishTrack(car)).isFalse();
     }
 
     @Test
@@ -157,7 +157,7 @@ public class NeedForSpeedTest {
         int distance = 678;
         var race = new RaceTrack(distance);
 
-        assertThat(race.carCanFinish(car)).isFalse();
+        assertThat(race.tryFinishTrack(car)).isFalse();
     }
 }
 


### PR DESCRIPTION
# Pull Request

This name change clarifies that the method is supposed to try and drive
the car around the track to see if it can finish the track before it
runs out of battery as opposed to exposing the state of the car and
directly calculating the remaining distance that that car can travel.

This can sometimes be confusing to those completing the exercise as to
whether to expose the state of the car or try to drive the car around
the track and see if it can make it. This clarifies that the latter
should be implemented

Co-authored-by: Erik Schierboom <erik_schierboom@hotmail.com>

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
