### PR TITLE
Remove argument in connect exercise

### DIFF
--- a/exercises/practice/connect/src/main/java/Connect.java
+++ b/exercises/practice/connect/src/main/java/Connect.java
@@ -4,7 +4,7 @@ class Connect {
         throw new UnsupportedOperationException("Implement this function");
     }
 
-    public Winner computeWinner(String[] board) {
+    public Winner computeWinner() {
         throw new UnsupportedOperationException("Implement this function");
     }
 }


### PR DESCRIPTION
The tests are expecting no arguments in method computeWinner() in the connect exercise. The idea (I think) is that the Connect class would have an internal representation of the board after initiated using the string[] argument and would use this to calculate the winner, instead of receiving the board as argument to the computeWinner() again (which will render the constructor needless).

# pull request

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
