### PR TITLE
fixed emptyStringIsNotTheSameAsNull test to align with instructions

### DIFF
--- a/exercises/practice/two-fer/src/test/java/TwoferTest.java
+++ b/exercises/practice/two-fer/src/test/java/TwoferTest.java
@@ -39,7 +39,7 @@ public class TwoferTest {
     @Test
     public void emptyStringIsNotTheSameAsNull() {
         assertThat(twofer.twofer(""))
-                .isEqualTo("One for , one for me.");
+                .isEqualTo("One for you, one for me.");
     }
 
 }


### PR DESCRIPTION

# pull request

<!-- Your content goes here: -->

Based on the example in the README.md file, a blank string ("") should return "One for you, one for me". The test currently is looking for a blank response. Fixing the test to align with readme expectations of the problem. 

While in Java null != empty, the directions state they should both return "one for you, one for me"


Readme excerpt:
```Here are some examples:

|Name    |String to return
|:-------|:------------------
|Alice   |One for Alice, one for me.
|Bob     |One for Bob, one for me.
|        |One for you, one for me.
|Zaphod  |One for Zaphod, one for me.
```

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
