### PR TITLE
Updated link broken hyperlink to running the tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ To submit a fix for an existing exercise or port an exercise to Java with the le
 
 1. **Ensure you have the basic Java tooling installed:**  JDK 1.11+, an editor and Gradle 2.x.
 
-   (see [exercism.io: Installing Java](http://exercism.io/languages/java/installation))
+   (see [exercism.io: Installing Java](https://exercism.org/docs/tracks/java/installation))
 -  **Setup a branch on a fork of [exercism/java](https://github.com/exercism/java) on your computer.**
 
    See [GitHub Help: Forking](https://help.github.com/articles/fork-a-repo/).  Use those instructions (in conjunction with the [Git Basics doc](https://github.com/exercism/docs/blob/master/contributing/git-basics.md)) to:
@@ -170,7 +170,6 @@ Any completely new exercise needs to be added and accepted there before it can b
 There is a [general Exercism guide for porting an exercise to a new language](https://github.com/exercism/docs/blob/master/you-can-help/implement-an-exercise-from-specification.md).
 Please review this before porting an exercise to the Java track.
 
-See [here](http://exercism.io/languages/java/todo) for a list of exercises that have yet to be implemented on the Java track and can therefore be ported to this track.
 Please make sure no one else has a pull request open to implement your chosen exercise before you start.
 
 It might also be a good idea to open a WIP pull request to make it clear to others that you are working on this exercise.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -47,7 +47,7 @@ We recommend closing the administrative command prompt and opening a new command
 
 You now are ready to get started with the Java track of Exercism!
 
-To get started, see "[Running the Tests](http://exercism.io/languages/java/tests)".
+To get started, see "[Running the Tests](https://exercism.org/docs/tracks/java/tests)".
 
 ----
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -83,7 +83,7 @@ Below are instructions for install using the most common method - using Homebrew
 
 You now are ready to get started with the Java track of Exercism!
 
-To get started, see "[Running the Tests](http://exercism.io/languages/java/tests)".
+To get started, see "[Running the Tests](https://exercism.org/docs/tracks/java/tests)".
 
 ----
 
@@ -120,7 +120,7 @@ If you are using Debian or its derivatives (like Ubuntu), use APT:
 
 You now are ready to get started with the Java track of Exercism!
 
-To get started, see "[Running the Tests](http://exercism.io/languages/java/tests)".
+To get started, see "[Running the Tests](https://exercism.org/docs/tracks/java/tests)".
 
 ----
 
@@ -145,7 +145,7 @@ both OpenJdk11 and the latest Gradle with ease. Use the following steps:
 
 You now are ready to get started with the Java track of Exercism!
 
-To get started, see "[Running the Tests](http://exercism.io/languages/java/tests)".
+To get started, see "[Running the Tests](https://exercism.org/docs/tracks/java/tests)".
 
 ----
 
@@ -173,7 +173,7 @@ To get started, see "[Running the Tests](http://exercism.io/languages/java/tests
 
 You now are ready to get started with the Java track of Exercism!
 
-To get started, see "[Running the Tests](http://exercism.io/languages/java/tests)".
+To get started, see "[Running the Tests](https://exercism.org/docs/tracks/java/tests)".
 
 ----
 
@@ -207,7 +207,7 @@ To get started, see "[Running the Tests](http://exercism.io/languages/java/tests
 
 You now are ready to get started with the Java track of Exercism!
 
-To get started, see "[Running the Tests](http://exercism.io/languages/java/tests)".
+To get started, see "[Running the Tests](https://exercism.org/docs/tracks/java/tests)".
 
 ----
 
@@ -240,7 +240,7 @@ To get started, see "[Running the Tests](http://exercism.io/languages/java/tests
 
 You now are ready to get started with the Java track of Exercism!
 
-To get started, see "[Running the Tests](http://exercism.io/languages/java/tests)".
+To get started, see "[Running the Tests](https://exercism.org/docs/tracks/java/tests)".
 
 ----
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -43,7 +43,7 @@ Choose your operating system:
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](http://exercism.io/languages/java/help).
+If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
 
 ----
 
@@ -77,7 +77,7 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](http://exercism.io/languages/java/help).
+If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
 
 ----
 
@@ -112,5 +112,5 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](http://exercism.io/languages/java/help).
+If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
 

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -248,7 +248,7 @@ Regardless of what you decide to do next, we sincerely hope you learn
 and enjoy being part of this community.  If at any time you need assistance
 do not hesitate to ask for help:
 
-http://exercism.io/languages/java/help
+https://gitter.im/exercism/support
 
 Cheers!
 

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -43,7 +43,7 @@ Choose your operating system:
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](http://exercism.io/languages/java/help).
+If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
 
 ----
 
@@ -77,7 +77,7 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](http://exercism.io/languages/java/help).
+If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
 
 ----
 
@@ -112,4 +112,4 @@ If you get stuck, at any point, don't forget to reach out for [help](http://exer
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](http://exercism.io/languages/java/help).
+If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->

Fixed link on Java track's INSTALLATION.MD for running the tests, was pointing to 404.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
