### PR TITLE
Add warriors and wizards test

### DIFF
--- a/exercises/concept/wizards-and-warriors/src/test/java/FighterTest.java
+++ b/exercises/concept/wizards-and-warriors/src/test/java/FighterTest.java
@@ -5,9 +5,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FighterTest {
 
     @Test
-    public void testToString() {
+    public void testWarriorToString() {
         Fighter warrior = new Warrior();
         assertThat(warrior.toString()).isEqualTo("Fighter is a Warrior");
+    }
+
+    @Test
+    public void testWizardToString() {
+        Wizard wizard = new Wizard();
+        assertThat(wizard.toString()).isEqualTo("Fighter is a Wizard");
     }
 
     @Test

--- a/exercises/concept/wizards-and-warriors/src/test/java/FighterTest.java
+++ b/exercises/concept/wizards-and-warriors/src/test/java/FighterTest.java
@@ -5,15 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FighterTest {
 
     @Test
-    public void testWarriorToString() {
+    public void testToString() {
         Fighter warrior = new Warrior();
         assertThat(warrior.toString()).isEqualTo("Fighter is a Warrior");
-    }
-
-    @Test
-    public void testWizardToString() {
-        Wizard wizard = new Wizard();
-        assertThat(wizard.toString()).isEqualTo("Fighter is a Wizard");
     }
 
     @Test


### PR DESCRIPTION
# pull request

An issue arose when mentoring the exercise, where the person doing it had `return String.format("Fighter is a Warrior");` in their Warrior class, and knew that it was wrong. The tests however passed this incorrect behaviour.

The test I have added ensures they call the override in the correct class - the base class. I believe they may need to Google to use something like `.getClass().getSimpleName()` to figure out the class name.

One more thing to consider is that they may implement the override in each class individually, which would still be wrong really. This is probably better left up to the mentor to guide them where they could improve, as it seems the simplest way of guiding them, and won't add any extra confusion. This test at least helps guide them in the right direction.

Apologies if I do this PR wrong, it is actually my first time using the "fork" feature, I'm used to just branching.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
