### PR TITLE
Update BankAccountTest.java

### DIFF
--- a/exercises/practice/bank-account/src/test/java/BankAccountTest.java
+++ b/exercises/practice/bank-account/src/test/java/BankAccountTest.java
@@ -10,12 +10,13 @@ import java.util.Random;
 
 public class BankAccountTest {
     private BankAccount bankAccount = new BankAccount();
-
+    private static final double DELTA = 1e-15;
+    
     @Test
     public void newlyOpenedAccountHasEmptyBalance() throws BankAccountActionInvalidException {
         bankAccount.open();
 
-        assertEquals(0, bankAccount.getBalance());
+        assertEquals(0, bankAccount.getBalance(),DELTA);
     }
 
     @Ignore("Remove to run test")
@@ -25,7 +26,7 @@ public class BankAccountTest {
 
         bankAccount.deposit(10);
 
-        assertEquals(10, bankAccount.getBalance());
+        assertEquals(10, bankAccount.getBalance(),DELTA);
     }
 
     @Ignore("Remove to run test")
@@ -36,7 +37,7 @@ public class BankAccountTest {
         bankAccount.deposit(5);
         bankAccount.deposit(23);
 
-        assertEquals(28, bankAccount.getBalance());
+        assertEquals(28, bankAccount.getBalance(),DELTA);
     }
 
     @Ignore("Remove to run test")
@@ -47,7 +48,7 @@ public class BankAccountTest {
 
         bankAccount.withdraw(5);
 
-        assertEquals(5, bankAccount.getBalance());
+        assertEquals(5, bankAccount.getBalance(),DELTA);
     }
 
     @Ignore("Remove to run test")
@@ -59,7 +60,7 @@ public class BankAccountTest {
         bankAccount.withdraw(10);
         bankAccount.withdraw(13);
 
-        assertEquals(0, bankAccount.getBalance());
+        assertEquals(0, bankAccount.getBalance(),DELTA);
     }
 
     @Ignore("Remove to run test")
@@ -185,7 +186,7 @@ public class BankAccountTest {
 
         for (int i = 0; i < 10; i++) {
             adjustBalanceConcurrently();
-            assertEquals(1000, bankAccount.getBalance());
+            assertEquals(1000, bankAccount.getBalance(),DELTA);
         }
     }
 


### PR DESCRIPTION
Hi, the tests for this exercise are failing as 'assertEquals(double, double)' is deprecated 

Error message shown in the testing panel when reviewing tests on the failed submission:
Message: Use assertEquals(expected, actual, delta) to compare floating-point numbers
Exception: java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
	at BankAccountTest.canDepositMoneySequentially(BankAccountTest.java:39)

# pull request

<!-- Your content goes here: -->
I've added a DELTA variable and inserted it into the 6 uses of the assertEquals() function that were dealing with doubles.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
