### PR TITLE
Make README title match Exercism track name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# java ![Java CI with Gradle](https://github.com/exercism/java/workflows/Java%20CI%20with%20Gradle/badge.svg) [![Join the chat at https://gitter.im/exercism/xjava](https://badges.gitter.im/exercism/java.svg)](https://gitter.im/exercism/java?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# Exercism Java Track
+
+![Java CI with Gradle](https://github.com/exercism/java/workflows/Java%20CI%20with%20Gradle/badge.svg) [![Join the chat at https://gitter.im/exercism/xjava](https://badges.gitter.im/exercism/java.svg)](https://gitter.im/exercism/java?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Source for Exercism Exercises in Java.
 


### PR DESCRIPTION
In the early days of Exercism we named each track for the
programming language, prefixed with an 'x'. This was reflected
in the name of the repository as well as the title of the README.

At some point we changed this decision, and renamed all the
repositories.

Over time most of the READMEs have also been updated.

Some tracks changed the README title to be just the language name,
whereas others changed the title to reflect that this isn't the language
itself, but rather the Exercism track for that language.

This normalizes the README title.

Ref: exercism/exercism/issues/6363