### PR TITLE
Fixed the url 404 not found for tutorial.md and changed the name

### DIFF
--- a/POLICIES.md
+++ b/POLICIES.md
@@ -125,7 +125,7 @@ References: [[1](https://github.com/exercism/java/issues/1075)]
 
 > The hello world exercise has an extensive tutorial on how to solve exercism exercises.
 > This tutorial would probably be useful to have as a reference when solving some of the other earlier exercises as well.
-> Therefore any exercise with difficulty less than 3 should have a hints.md file which references [the hello world tutorial](https://github.com/exercism/java/blob/master/exercises/hello-world/TUTORIAL.md).
+> Therefore any exercise with difficulty less than 3 should have a hints.md file which references [the hello world tutorial](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial).
 
 References: [[1](https://github.com/exercism/java/issues/1389)]
 

--- a/POLICIES.md
+++ b/POLICIES.md
@@ -125,7 +125,7 @@ References: [[1](https://github.com/exercism/java/issues/1075)]
 
 > The hello world exercise has an extensive tutorial on how to solve exercism exercises.
 > This tutorial would probably be useful to have as a reference when solving some of the other earlier exercises as well.
-> Therefore any exercise with difficulty less than 3 should have a hints.md file which references [the hello world tutorial](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial).
+> Therefore any exercise with difficulty less than 3 should have a hints.md file which references [the hello world tutorial](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial).
 
 References: [[1](https://github.com/exercism/java/issues/1389)]
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -38,7 +38,7 @@ Choose your operating system:
      ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-5. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
+5. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 
 Good luck!  Have fun!
@@ -73,7 +73,7 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
     ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
+4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 Good luck!  Have fun!
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -38,7 +38,7 @@ Choose your operating system:
      ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-5. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/hello-world/TUTORIAL.md)).
+5. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 
 Good luck!  Have fun!
@@ -73,7 +73,7 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
     ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/hello-world/TUTORIAL.md)).
+4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 Good luck!  Have fun!
 
@@ -108,9 +108,8 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
     ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/hello-world/TUTORIAL.md)).
+4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 Good luck!  Have fun!
 
 If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
-

--- a/exercises/practice/armstrong-numbers/.docs/instructions.append.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.append.md
@@ -1,4 +1,4 @@
 # Instructions append
 
 For more help on how to solve this exercise, please refer to the tutorial provided as part of the hello world exercise:
-[TUTORIAL.md](https://github.com/exercism/java/blob/master/exercises/hello-world/TUTORIAL.md)
+[instructions.append.md](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)

--- a/exercises/practice/armstrong-numbers/.docs/instructions.append.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.append.md
@@ -1,4 +1,4 @@
 # Instructions append
 
 For more help on how to solve this exercise, please refer to the tutorial provided as part of the hello world exercise:
-[instructions.append.md](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)
+[instructions.append.md](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,7 +1,7 @@
 # Instructions append
 
 Before you start, make sure you understand how to write code that can pass the test cases.
-For more context, check out this [tutorial](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial).
+For more context, check out this [tutorial](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial).
 
 Most Java exercises include multiple test cases. These cases are structured to
 support a useful process known as

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,7 +1,7 @@
 # Instructions append
 
 Before you start, make sure you understand how to write code that can pass the test cases.
-For more context, check out this [tutorial](https://github.com/exercism/java/blob/master/exercises/hello-world/TUTORIAL.md).
+For more context, check out this [tutorial](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial).
 
 Most Java exercises include multiple test cases. These cases are structured to
 support a useful process known as

--- a/exercises/practice/rna-transcription/.docs/instructions.append.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.append.md
@@ -1,4 +1,4 @@
 # Instructions append
 
 For more help on how to solve this exercise, please refer to the tutorial provided as part of the hello world exercise:
-[TUTORIAL.md](https://github.com/exercism/java/blob/master/exercises/hello-world/TUTORIAL.md)
+[instructions.append.md](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)

--- a/exercises/practice/rna-transcription/.docs/instructions.append.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.append.md
@@ -1,4 +1,4 @@
 # Instructions append
 
 For more help on how to solve this exercise, please refer to the tutorial provided as part of the hello world exercise:
-[instructions.append.md](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)
+[instructions.append.md](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)

--- a/exercises/practice/two-fer/.docs/instructions.append.md
+++ b/exercises/practice/two-fer/.docs/instructions.append.md
@@ -1,7 +1,7 @@
 # Instructions append
 
 Before you start, make sure you understand how to write code that can pass the test cases.
-For more context, check out this [tutorial](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial).
+For more context, check out this [tutorial](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial).
 
 Most Java exercises include multiple test cases. These cases are structured to
 support a useful process known as

--- a/exercises/practice/two-fer/.docs/instructions.append.md
+++ b/exercises/practice/two-fer/.docs/instructions.append.md
@@ -1,7 +1,7 @@
 # Instructions append
 
 Before you start, make sure you understand how to write code that can pass the test cases.
-For more context, check out this [tutorial](https://github.com/exercism/java/blob/master/exercises/hello-world/TUTORIAL.md).
+For more context, check out this [tutorial](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial).
 
 Most Java exercises include multiple test cases. These cases are structured to
 support a useful process known as

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -38,7 +38,7 @@ Choose your operating system:
      ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-5. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/TUTORIAL.md)).
+5. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 
 Good luck!  Have fun!
@@ -73,7 +73,7 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
     ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/TUTORIAL.md)).
+4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 Good luck!  Have fun!
 
@@ -108,7 +108,7 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
     ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-4. Solve the exercise.  Find and work through the `TUTORIAL.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/TUTORIAL.md)).
+4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 Good luck!  Have fun!
 

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -38,7 +38,7 @@ Choose your operating system:
      ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-5. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
+5. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 
 Good luck!  Have fun!
@@ -73,7 +73,7 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
     ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
+4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 Good luck!  Have fun!
 
@@ -108,7 +108,7 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
     ```
    *(Don't worry about the tests failing, at first, this is how you begin each exercise.)*
 
-4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/master/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
+4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 Good luck!  Have fun!
 


### PR DESCRIPTION
#2137 

# Description

<!-- Your content goes here: -->
### Problem:
-  When you click on this url [tutorial](https://github.com/exercism/java/blob/main/exercises/hello-world/TUTORIAL.md) you will receive a 404 not found

### Solution:
- Get the real path for the tutorial and substitute all the old ones for the real url tutorial.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/master/POLICIES.md#event-checklist)
