### PR TITLE
Use 'temurin' instead of 'adopt' and update to java 17

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,11 +12,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-    - name: Set up JDK 1.11
-      uses: actions/setup-java@v3.4.1
+    - name: Set up JDK 1.17
+      uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3
       with:
-        java-version: 11
-        distribution: 'adopt'
+        java-version: 17
+        distribution: 'temurin'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Compile and checkstyle with Gradle
@@ -28,11 +28,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-    - name: Set up JDK 1.11
-      uses: actions/setup-java@v3.4.1
+    - name: Set up JDK 1.17
+      uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3
       with:
-        java-version: 11
-        distribution: 'adopt'
+        java-version: 17
+        distribution: 'temurin'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Journey test


### PR DESCRIPTION
The documentation for `setup-java` recommends moving away from 'adopt' which has been discontinued and to use 'temurin' instead:

> NOTE: Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).
[Source](https://github.com/actions/setup-java).

Summary of changes:

* Use 'temurin' instead of 'adopt'
* Update to Java 17, which is the version of java the test runner uses
* Convert action versions to SHAs

cc @exercism/reviewers @exercism/java 