### PR TITLE
Update DartsTest.java for typos Where "Circle" was written as "Cirlce"

### DIFF
--- a/exercises/practice/darts/src/test/java/DartsTest.java
+++ b/exercises/practice/darts/src/test/java/DartsTest.java
@@ -62,7 +62,7 @@ public class DartsTest {
 
     @Ignore("Remove to run test")
     @Test
-    public void justWithinTheMiddleCirlce() {
+    public void justWithinTheMiddleCircle() {
         Darts darts = new Darts(-3.5, 3.5);
         assertEquals(5, darts.score());
     }
@@ -77,7 +77,7 @@ public class DartsTest {
 
     @Ignore("Remove to run test")
     @Test
-    public void justWithinTheOuterCirlce() {
+    public void justWithinTheOuterCircle() {
         Darts darts = new Darts(-7.0, 7.0);
         assertEquals(1, darts.score());
     }


### PR DESCRIPTION
There were two typos in the file. There were two instances where "Cirlce" was written as "Cirlce" at LINE 65 and at LINE 80. 
Just wanted to correct the typos.
Cheers.

# pull request

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
