### PR TITLE
Pin actions to SHAs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - name: Set up JDK 1.11
-      uses: actions/setup-java@v3.4.1
+      uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3
       with:
         java-version: 11
         distribution: 'adopt'
@@ -29,7 +29,7 @@ jobs:
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
     - name: Set up JDK 1.11
-      uses: actions/setup-java@v3.4.1
+      uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3
       with:
         java-version: 11
         distribution: 'adopt'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5.1.1
+    - uses: actions/stale@9c1b1c6e115ca2af09755448e0dbba24e5061cc8
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         # Mark issues as stale once per quarter, but never close.


### PR DESCRIPTION
As per exercism guidelines on actions [GHA Best Practices: Pin actions to SHAs](https://exercism.org/docs/building/github/gha-best-practices#pin-actions-to-shas)

Commit references:

- [actions/setup-java@v3.4.1](https://github.com/actions/setup-java/releases/tag/v3.4.1)
- [actions/stale@v5.1.1](https://github.com/actions/stale/releases/tag/v5.1.1)

cc @exercism/reviewers 