### PR TITLE
removed the reference to UnsupportedOperationException in instructions

### DIFF
--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -50,15 +50,16 @@ if you want to solve the problem and run tests locally check these links below:
 
 
 
-[`Exception`s](https://docs.oracle.com/javase/tutorial/essential/exceptions/)
-are often used in Java to draw the attention of a developer when something goes
-wrong. In our case, nothing is wrong per se; we just haven't written our
-solution yet! The use of an
-[`UnsupportedOperationException`](http://docs.oracle.com/javase/8/docs/api/?java/lang/UnsupportedOperationException.html)
-in this situation is designed to remind us of exactly this fact. It effectively
-says: "Your Code Goes Here!".
+## Step 1: `Fix the solution`
 
-Delete the contents of line 4 and replace it with:
+Either working locally or using the online editor, you should find an exception on line 4:
+
+```java
+throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+```
+
+The objective is to modify the provided code so it produces the text "Hello, World!". To accomplish this, delete the contents of line 4 and replace it with:
+
 
 ```java
     public String getGreeting() {

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -49,13 +49,6 @@ if you want to solve the problem and run tests locally check these links below:
 * [Testing locally on the java track](https://exercism.org/docs/tracks/java/tests);
 
 
-## Step 1: Replace the `UnsupportedOperationException`
-
-Either working locally or using the online editor, you should find an exception on line 4:
-
-```java
-throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
-```
 
 [`Exception`s](https://docs.oracle.com/javase/tutorial/essential/exceptions/)
 are often used in Java to draw the attention of a developer when something goes

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -52,20 +52,15 @@ if you want to solve the problem and run tests locally check these links below:
 
 ## Step 1: `Fix the solution`
 
-Either working locally or using the online editor, you should find an exception on line 4:
+Either working locally or using the online editor, you should find the following code:
 
 ```java
-throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+String getGreeting() {
+        return "Goodbye, Mars!";
+}
 ```
 
-The objective is to modify the provided code so it produces the text "Hello, World!". To accomplish this, delete the contents of line 4 and replace it with:
-
-
-```java
-    public String getGreeting() {
-        return "Hello, World!";
-    }
-```
+The objective is to modify the provided code so it produces the text `"Hello, World!"` instead of `"Goodbye, Mars!"`.
 
 ## Step 2: Run the Tests
 


### PR DESCRIPTION
# pull request remove the reference to UnsupportedOperationException in instructions #2151 

I deleted lines 52 - 59 in [java/exercises/practice/hello-world/.docs](https://github.com/exercism/java/blob/9abbe2a744625d698691249714d992fbdc17662c/exercises/practice/hello-world/.docs/instructions.append.md?plain=1#L52-L59)

## This is to solve issue #2151 

Thanks @andrerfcsantos for the issue assignment! Always happy to contribute to building Exercism. 


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
