### PR TITLE
Convert exception assertions to AssertJ in classes starting with 'A' and 'B'.

### DIFF
--- a/exercises/practice/affine-cipher/src/test/java/AffineCipherTest.java
+++ b/exercises/practice/affine-cipher/src/test/java/AffineCipherTest.java
@@ -2,7 +2,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class AffineCipherTest {
 
@@ -62,13 +62,9 @@ public class AffineCipherTest {
     @Ignore("Remove to run test")
     @Test
     public void testEncodeThrowsMeaningfulException() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> affineCipher.encode("This is a test", 6, 17));
-
-        assertThat(expected)
-            .hasMessage("Error: keyA and alphabet size must be coprime.");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> affineCipher.encode("This is a test", 6, 17))
+            .withMessage("Error: keyA and alphabet size must be coprime.");
     }
 
     @Ignore("Remove to run test")
@@ -116,13 +112,9 @@ public class AffineCipherTest {
     @Ignore("Remove to run test")
     @Test
     public void testDecodeThrowsMeaningfulException() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> affineCipher.decode("Test", 13, 5));
-
-        assertThat(expected)
-            .hasMessage("Error: keyA and alphabet size must be coprime.");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> affineCipher.decode("Test", 13, 5))
+            .withMessage("Error: keyA and alphabet size must be coprime.");
     }
 
 }

--- a/exercises/practice/all-your-base/src/test/java/BaseConverterTest.java
+++ b/exercises/practice/all-your-base/src/test/java/BaseConverterTest.java
@@ -2,7 +2,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class BaseConverterTest {
 
@@ -116,57 +116,41 @@ public class BaseConverterTest {
     @Ignore("Remove to run test")
     @Test
     public void testFirstBaseIsOne() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new BaseConverter(1, new int[]{1}));
-
-        assertThat(expected).hasMessage("Bases must be at least 2.");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new BaseConverter(1, new int[]{1}))
+            .withMessage("Bases must be at least 2.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testFirstBaseIsZero() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new BaseConverter(0, new int[]{1}));
-
-        assertThat(expected).hasMessage("Bases must be at least 2.");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new BaseConverter(0, new int[]{1}))
+            .withMessage("Bases must be at least 2.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testFirstBaseIsNegative() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new BaseConverter(-2, new int[]{1}));
-
-        assertThat(expected).hasMessage("Bases must be at least 2.");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new BaseConverter(-2, new int[]{1}))
+            .withMessage("Bases must be at least 2.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testNegativeDigit() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new BaseConverter(2, new int[]{1, -1, 1, 0, 1, 0}));
-
-        assertThat(expected).hasMessage("Digits may not be negative.");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new BaseConverter(2, new int[]{1, -1, 1, 0, 1, 0}))
+            .withMessage("Digits may not be negative.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testInvalidPositiveDigit() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new BaseConverter(2, new int[]{1, 2, 1, 0, 1, 0}));
-
-        assertThat(expected)
-            .hasMessage("All digits must be strictly less than the base.");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> new BaseConverter(2, new int[]{1, 2, 1, 0, 1, 0}))
+            .withMessage("All digits must be strictly less than the base.");
     }
 
     @Ignore("Remove to run test")
@@ -175,12 +159,9 @@ public class BaseConverterTest {
         BaseConverter baseConverter =
             new BaseConverter(2, new int[]{1, 0, 1, 0, 1, 0});
 
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> baseConverter.convertToBase(1));
-
-        assertThat(expected).hasMessage("Bases must be at least 2.");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> baseConverter.convertToBase(1))
+            .withMessage("Bases must be at least 2.");
     }
 
     @Ignore("Remove to run test")
@@ -188,12 +169,9 @@ public class BaseConverterTest {
     public void testSecondBaseIsZero() {
         BaseConverter baseConverter = new BaseConverter(10, new int[]{7});
 
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> baseConverter.convertToBase(0));
-
-        assertThat(expected).hasMessage("Bases must be at least 2.");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> baseConverter.convertToBase(0))
+            .withMessage("Bases must be at least 2.");
     }
 
     @Ignore("Remove to run test")
@@ -201,12 +179,9 @@ public class BaseConverterTest {
     public void testSecondBaseIsNegative() {
         BaseConverter baseConverter = new BaseConverter(2, new int[]{1});
 
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> baseConverter.convertToBase(-7));
-
-        assertThat(expected).hasMessage("Bases must be at least 2.");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> baseConverter.convertToBase(-7))
+            .withMessage("Bases must be at least 2.");
     }
 
 }

--- a/exercises/practice/alphametics/src/test/java/AlphameticsTest.java
+++ b/exercises/practice/alphametics/src/test/java/AlphameticsTest.java
@@ -3,7 +3,7 @@ import org.junit.Test;
 
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class AlphameticsTest {
 
@@ -21,7 +21,8 @@ public class AlphameticsTest {
     public void testUniqueValue() {
         Alphametics alphametics = new Alphametics("A == B");
 
-        assertThrows(UnsolvablePuzzleException.class, alphametics::solve);
+        assertThatExceptionOfType(UnsolvablePuzzleException.class)
+            .isThrownBy(alphametics::solve);
     }
 
     @Ignore("Remove to run test")
@@ -29,7 +30,8 @@ public class AlphameticsTest {
     public void testLeadingZero() {
         Alphametics alphametics = new Alphametics("ACA + DD == BD");
 
-        assertThrows(UnsolvablePuzzleException.class, alphametics::solve);
+        assertThatExceptionOfType(UnsolvablePuzzleException.class)
+            .isThrownBy(alphametics::solve);
     }
 
     @Ignore("Remove to run test")

--- a/exercises/practice/bank-account/src/test/java/BankAccountTest.java
+++ b/exercises/practice/bank-account/src/test/java/BankAccountTest.java
@@ -1,6 +1,6 @@
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.fail;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -66,13 +66,9 @@ public class BankAccountTest {
     public void cannotWithdrawMoneyFromEmptyAccount() {
         bankAccount.open();
 
-        BankAccountActionInvalidException expected =
-            assertThrows(
-                BankAccountActionInvalidException.class,
-                () -> bankAccount.withdraw(5));
-
-        assertThat(expected)
-            .hasMessage("Cannot withdraw money from an empty account");
+        assertThatExceptionOfType(BankAccountActionInvalidException.class)
+            .isThrownBy(() -> bankAccount.withdraw(5))
+            .withMessage("Cannot withdraw money from an empty account");
     }
 
     @Ignore("Remove to run test")
@@ -81,15 +77,9 @@ public class BankAccountTest {
         bankAccount.open();
         bankAccount.deposit(6);
 
-        BankAccountActionInvalidException expected =
-            assertThrows(
-                BankAccountActionInvalidException.class,
-                () -> bankAccount.withdraw(7));
-
-        assertThat(expected)
-            .hasMessage(
-                "Cannot withdraw more money than is currently in the account");
-
+        assertThatExceptionOfType(BankAccountActionInvalidException.class)
+            .isThrownBy(() -> bankAccount.withdraw(7))
+            .withMessage("Cannot withdraw more money than is currently in the account");
     }
 
     @Ignore("Remove to run test")
@@ -97,13 +87,9 @@ public class BankAccountTest {
     public void cannotDepositNegativeAmount() {
         bankAccount.open();
 
-        BankAccountActionInvalidException expected =
-            assertThrows(
-                BankAccountActionInvalidException.class,
-                () -> bankAccount.deposit(-1));
-
-        assertThat(expected)
-            .hasMessage("Cannot deposit or withdraw negative amount");
+        assertThatExceptionOfType(BankAccountActionInvalidException.class)
+            .isThrownBy(() -> bankAccount.deposit(-1))
+            .withMessage("Cannot deposit or withdraw negative amount");
     }
 
     @Ignore("Remove to run test")
@@ -112,13 +98,9 @@ public class BankAccountTest {
         bankAccount.open();
         bankAccount.deposit(105);
 
-        BankAccountActionInvalidException expected =
-            assertThrows(
-                BankAccountActionInvalidException.class,
-                () -> bankAccount.withdraw(-5));
-
-        assertThat(expected)
-            .hasMessage("Cannot deposit or withdraw negative amount");
+        assertThatExceptionOfType(BankAccountActionInvalidException.class)
+            .isThrownBy(() -> bankAccount.withdraw(-5))
+            .withMessage("Cannot deposit or withdraw negative amount");
     }
 
     @Ignore("Remove to run test")
@@ -128,12 +110,9 @@ public class BankAccountTest {
         bankAccount.deposit(10);
         bankAccount.close();
 
-        BankAccountActionInvalidException expected =
-            assertThrows(
-                BankAccountActionInvalidException.class,
-                bankAccount::getBalance);
-
-        assertThat(expected).hasMessage("Account closed");
+        assertThatExceptionOfType(BankAccountActionInvalidException.class)
+            .isThrownBy(bankAccount::getBalance)
+            .withMessage("Account closed");
     }
 
     @Ignore("Remove to run test")
@@ -142,12 +121,9 @@ public class BankAccountTest {
         bankAccount.open();
         bankAccount.close();
 
-        BankAccountActionInvalidException expected =
-            assertThrows(
-                BankAccountActionInvalidException.class,
-                () -> bankAccount.deposit(5));
-
-        assertThat(expected).hasMessage("Account closed");
+        assertThatExceptionOfType(BankAccountActionInvalidException.class)
+            .isThrownBy(() -> bankAccount.deposit(5))
+            .withMessage("Account closed");
     }
 
     @Ignore("Remove to run test")
@@ -157,23 +133,17 @@ public class BankAccountTest {
         bankAccount.deposit(20);
         bankAccount.close();
 
-        BankAccountActionInvalidException expected =
-            assertThrows(
-                BankAccountActionInvalidException.class,
-                () -> bankAccount.withdraw(5));
-
-        assertThat(expected).hasMessage("Account closed");
+        assertThatExceptionOfType(BankAccountActionInvalidException.class)
+            .isThrownBy(() -> bankAccount.withdraw(5))
+            .withMessage("Account closed");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void bankAccountIsClosedBeforeItIsOpened() {
-        BankAccountActionInvalidException expected =
-            assertThrows(
-                BankAccountActionInvalidException.class,
-                bankAccount::getBalance);
-
-        assertThat(expected).hasMessage("Account closed");
+        assertThatExceptionOfType(BankAccountActionInvalidException.class)
+            .isThrownBy(bankAccount::getBalance)
+            .withMessage("Account closed");
     }
 
     @Ignore("Remove to run test")

--- a/exercises/practice/binary-search/src/test/java/BinarySearchTest.java
+++ b/exercises/practice/binary-search/src/test/java/BinarySearchTest.java
@@ -1,5 +1,5 @@
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -75,12 +75,9 @@ public class BinarySearchTest {
 
         BinarySearch search = new BinarySearch(sortedList);
 
-        ValueNotFoundException expected =
-            assertThrows(
-                ValueNotFoundException.class,
-                () -> search.indexOf(7));
-
-        assertThat(expected).hasMessage("Value not in array");
+        assertThatExceptionOfType(ValueNotFoundException.class)
+            .isThrownBy(() -> search.indexOf(7))
+            .withMessage("Value not in array");
     }
 
     @Ignore("Remove to run test")
@@ -90,12 +87,9 @@ public class BinarySearchTest {
 
         BinarySearch search = new BinarySearch(sortedList);
 
-        ValueNotFoundException expected =
-            assertThrows(
-                ValueNotFoundException.class,
-                () -> search.indexOf(0));
-
-        assertThat(expected).hasMessage("Value not in array");
+        assertThatExceptionOfType(ValueNotFoundException.class)
+            .isThrownBy(() -> search.indexOf(0))
+            .withMessage("Value not in array");
     }
 
     @Ignore("Remove to run test")
@@ -105,12 +99,9 @@ public class BinarySearchTest {
 
         BinarySearch search = new BinarySearch(sortedList);
 
-        ValueNotFoundException expected =
-            assertThrows(
-                ValueNotFoundException.class,
-                () -> search.indexOf(13));
-
-        assertThat(expected).hasMessage("Value not in array");
+        assertThatExceptionOfType(ValueNotFoundException.class)
+            .isThrownBy(() -> search.indexOf(13))
+            .withMessage("Value not in array");
     }
 
     @Ignore("Remove to run test")
@@ -120,12 +111,9 @@ public class BinarySearchTest {
 
         BinarySearch search = new BinarySearch(emptyList);
 
-        ValueNotFoundException expected =
-            assertThrows(
-                ValueNotFoundException.class,
-                () -> search.indexOf(1));
-
-        assertThat(expected).hasMessage("Value not in array");
+        assertThatExceptionOfType(ValueNotFoundException.class)
+            .isThrownBy(() -> search.indexOf(1))
+            .withMessage("Value not in array");
     }
 
     @Ignore("Remove to run test")
@@ -135,12 +123,9 @@ public class BinarySearchTest {
 
         BinarySearch search = new BinarySearch(sortedList);
 
-        ValueNotFoundException expected =
-            assertThrows(
-                ValueNotFoundException.class,
-                () -> search.indexOf(0));
-
-        assertThat(expected).hasMessage("Value not in array");
+        assertThatExceptionOfType(ValueNotFoundException.class)
+            .isThrownBy(() -> search.indexOf(0))
+            .withMessage("Value not in array");
     }
 
 }

--- a/exercises/practice/bowling/src/test/java/BowlingGameTest.java
+++ b/exercises/practice/bowling/src/test/java/BowlingGameTest.java
@@ -1,5 +1,5 @@
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -143,10 +143,9 @@ public class BowlingGameTest {
     public void rollsCanNotScoreNegativePoints() {
         int[] rolls = {-1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, () -> playGame(rolls));
-
-        assertThat(expected).hasMessage("Negative roll is invalid");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> playGame(rolls))
+            .withMessage("Negative roll is invalid");
     }
 
     @Ignore("Remove to run test")
@@ -154,10 +153,9 @@ public class BowlingGameTest {
     public void aRollCanNotScoreMoreThan10Points() {
         int[] rolls = {11, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, () -> playGame(rolls));
-
-        assertThat(expected).hasMessage("Pin count exceeds pins on the lane");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> playGame(rolls))
+            .withMessage("Pin count exceeds pins on the lane");
     }
 
     @Ignore("Remove to run test")
@@ -165,10 +163,9 @@ public class BowlingGameTest {
     public void twoRollsInAFrameCanNotScoreMoreThan10Points() {
         int[] rolls = {5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, () -> playGame(rolls));
-
-        assertThat(expected).hasMessage("Pin count exceeds pins on the lane");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> playGame(rolls))
+            .withMessage("Pin count exceeds pins on the lane");
     }
 
     @Ignore("Remove to run test")
@@ -176,10 +173,9 @@ public class BowlingGameTest {
     public void bonusRollAfterAStrikeInTheLastFrameCanNotScoreMoreThan10Points() {
         int[] rolls = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 11, 0};
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, () -> playGame(rolls));
-
-        assertThat(expected).hasMessage("Pin count exceeds pins on the lane");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> playGame(rolls))
+            .withMessage("Pin count exceeds pins on the lane");
     }
 
     @Ignore("Remove to run test")
@@ -187,10 +183,9 @@ public class BowlingGameTest {
     public void twoBonusRollsAfterAStrikeInTheLastFrameCanNotScoreMoreThan10Points() {
         int[] rolls = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5, 6};
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, () -> playGame(rolls));
-
-        assertThat(expected).hasMessage("Pin count exceeds pins on the lane");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> playGame(rolls))
+            .withMessage("Pin count exceeds pins on the lane");
     }
 
     @Ignore("Remove to run test")
@@ -208,10 +203,9 @@ public class BowlingGameTest {
     public void theSecondBonusRollsAfterAStrikeInTheLastFrameCanNotBeAStrikeIfTheFirstOneIsNotAStrike() {
         int[] rolls = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6, 10};
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, () -> playGame(rolls));
-
-        assertThat(expected).hasMessage("Pin count exceeds pins on the lane");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> playGame(rolls))
+            .withMessage("Pin count exceeds pins on the lane");
     }
 
     @Ignore("Remove to run test")
@@ -219,10 +213,9 @@ public class BowlingGameTest {
     public void secondBonusRollAfterAStrikeInTheLastFrameCanNotScoreMoreThan10Points() {
         int[] rolls = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 11};
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, () -> playGame(rolls));
-
-        assertThat(expected).hasMessage("Pin count exceeds pins on the lane");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> playGame(rolls))
+            .withMessage("Pin count exceeds pins on the lane");
     }
 
     @Ignore("Remove to run test")
@@ -232,11 +225,9 @@ public class BowlingGameTest {
 
         playGame(rolls);
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, game::score);
-
-        assertThat(expected)
-            .hasMessage("Score cannot be taken until the end of the game");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(game::score)
+            .withMessage("Score cannot be taken until the end of the game");
     }
 
     @Ignore("Remove to run test")
@@ -246,11 +237,9 @@ public class BowlingGameTest {
 
         playGame(rolls);
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, game::score);
-
-        assertThat(expected)
-            .hasMessage("Score cannot be taken until the end of the game");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(game::score)
+            .withMessage("Score cannot be taken until the end of the game");
     }
 
     @Ignore("Remove to run test")
@@ -258,10 +247,9 @@ public class BowlingGameTest {
     public void canNotRollIfGameAlreadyHasTenFrames() {
         int[] rolls = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, () -> playGame(rolls));
-
-        assertThat(expected).hasMessage("Cannot roll after game is over");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> playGame(rolls))
+            .withMessage("Cannot roll after game is over");
     }
 
     @Ignore("Remove to run test")
@@ -271,11 +259,9 @@ public class BowlingGameTest {
 
         playGame(rolls);
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, game::score);
-
-        assertThat(expected)
-            .hasMessage("Score cannot be taken until the end of the game");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(game::score)
+            .withMessage("Score cannot be taken until the end of the game");
     }
 
     @Ignore("Remove to run test")
@@ -285,11 +271,9 @@ public class BowlingGameTest {
 
         playGame(rolls);
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, game::score);
-
-        assertThat(expected)
-            .hasMessage("Score cannot be taken until the end of the game");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(game::score)
+            .withMessage("Score cannot be taken until the end of the game");
     }
 
     @Ignore("Remove to run test")
@@ -299,11 +283,9 @@ public class BowlingGameTest {
 
         playGame(rolls);
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, game::score);
-
-        assertThat(expected)
-            .hasMessage("Score cannot be taken until the end of the game");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(game::score)
+            .withMessage("Score cannot be taken until the end of the game");
     }
 
     @Ignore("Remove to run test")
@@ -311,10 +293,9 @@ public class BowlingGameTest {
     public void canNotRollAfterBonusRollForSpare() {
         int[] rolls = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 2, 2};
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, () -> playGame(rolls));
-
-        assertThat(expected).hasMessage("Cannot roll after game is over");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> playGame(rolls))
+            .withMessage("Cannot roll after game is over");
     }
 
     @Ignore("Remove to run test")
@@ -322,9 +303,8 @@ public class BowlingGameTest {
     public void canNotRollAfterBonusRollForStrike() {
         int[] rolls = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 3, 2, 2};
 
-        IllegalStateException expected =
-            assertThrows(IllegalStateException.class, () -> playGame(rolls));
-
-        assertThat(expected).hasMessage("Cannot roll after game is over");
+        assertThatExceptionOfType(IllegalStateException.class)
+            .isThrownBy(() -> playGame(rolls))
+            .withMessage("Cannot roll after game is over");
     }
 }


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->
Convert `assertThrows` to `assertThatExceptionOfType` in classes starting with 'A' and 'B'.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
