### PR TITLE
Numbers: Cars, Assemble! Refactored unit tests in a way that ignores machine epsilon

### DIFF
--- a/exercises/concept/cars-assemble/src/test/java/CarsAssembleTest.java
+++ b/exercises/concept/cars-assemble/src/test/java/CarsAssembleTest.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.*;
 public class CarsAssembleTest {
 
     private CarsAssemble carsAssemble;
+    private double epsilon = 0.0000001d;
 
     @Before
     public void setUp() {
@@ -15,32 +16,32 @@ public class CarsAssembleTest {
 
     @Test
     public void productionRatePerHourForSpeedZero() {
-        assertThat(carsAssemble.productionRatePerHour(0)).isEqualTo(0.0);
+        assertThat(Math.abs(carsAssemble.productionRatePerHour(0)-0.0) < epsilon).isTrue();
     }
-    
+
     @Test
     public void productionRatePerHourForSpeedOne() {
-        assertThat(carsAssemble.productionRatePerHour(1)).isEqualTo(221.0);
+        assertThat(Math.abs(carsAssemble.productionRatePerHour(1)-221.0) < epsilon).isTrue();
     }
 
     @Test
     public void productionRatePerHourForSpeedFour() {
-        assertThat(carsAssemble.productionRatePerHour(4)).isEqualTo(884.0);
+        assertThat(Math.abs(carsAssemble.productionRatePerHour(4)-884.0) < epsilon).isTrue();
     }
 
     @Test
     public void productionRatePerHourForSpeedSeven() {
-        assertThat(carsAssemble.productionRatePerHour(7)).isEqualTo(1392.3);
+        assertThat(Math.abs(carsAssemble.productionRatePerHour(7)-1392.3) < epsilon).isTrue();
     }
 
     @Test
     public void productionRatePerHourForSpeedNine() {
-        assertThat(carsAssemble.productionRatePerHour(9)).isEqualTo(1591.2);
+        assertThat(Math.abs(carsAssemble.productionRatePerHour(9)-1591.2) < epsilon).isTrue();
     }
 
     @Test
     public void productionRatePerHourForSpeedTen() {
-        assertThat(carsAssemble.productionRatePerHour(10)).isEqualTo(1701.7);
+        assertThat(Math.abs(carsAssemble.productionRatePerHour(10)-1701.7) < epsilon).isTrue();
     }
 
     @Test

--- a/exercises/concept/cars-assemble/src/test/java/CarsAssembleTest.java
+++ b/exercises/concept/cars-assemble/src/test/java/CarsAssembleTest.java
@@ -16,32 +16,32 @@ public class CarsAssembleTest {
 
     @Test
     public void productionRatePerHourForSpeedZero() {
-        assertThat(Math.abs(carsAssemble.productionRatePerHour(0)-0.0) < epsilon).isTrue();
+        assertThat(Math.abs(carsAssemble.productionRatePerHour(0) - 0.0) < epsilon).isTrue();
     }
 
     @Test
     public void productionRatePerHourForSpeedOne() {
-        assertThat(Math.abs(carsAssemble.productionRatePerHour(1)-221.0) < epsilon).isTrue();
+        assertThat(Math.abs(carsAssemble.productionRatePerHour(1) - 221.0) < epsilon).isTrue();
     }
 
     @Test
     public void productionRatePerHourForSpeedFour() {
-        assertThat(Math.abs(carsAssemble.productionRatePerHour(4)-884.0) < epsilon).isTrue();
+        assertThat(Math.abs(carsAssemble.productionRatePerHour(4) - 884.0) < epsilon).isTrue();
     }
 
     @Test
     public void productionRatePerHourForSpeedSeven() {
-        assertThat(Math.abs(carsAssemble.productionRatePerHour(7)-1392.3) < epsilon).isTrue();
+        assertThat(Math.abs(carsAssemble.productionRatePerHour(7) - 1392.3) < epsilon).isTrue();
     }
 
     @Test
     public void productionRatePerHourForSpeedNine() {
-        assertThat(Math.abs(carsAssemble.productionRatePerHour(9)-1591.2) < epsilon).isTrue();
+        assertThat(Math.abs(carsAssemble.productionRatePerHour(9) - 1591.2) < epsilon).isTrue();
     }
 
     @Test
     public void productionRatePerHourForSpeedTen() {
-        assertThat(Math.abs(carsAssemble.productionRatePerHour(10)-1701.7) < epsilon).isTrue();
+        assertThat(Math.abs(carsAssemble.productionRatePerHour(10) - 1701.7) < epsilon).isTrue();
     }
 
     @Test


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->
### Background:
I am creating this pull request as one of my students stumble upon a test case where it failed due to machine epsilon and in this pr, I have refactored the unit tests in a way that it ignores machine epsilon as i think it's too early to challenge students with this kind of errors and it was probably unintentional for this particular exercise.

### Reproduction:
While this issue can be avoided by calculating productionRatePerHour function as follows:
```defaultProductionRate  * speed * successRate(speed) ```

The issue can be reproduced by calculating productionRatePerHour function as follows which confuses students:
```defaultProductionRate * successRate(speed) * speed```



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
