### PR TITLE
Doubly linked list

### DIFF
--- a/exercises/practice/linked-list/src/main/java/DoublyLinkedList.java
+++ b/exercises/practice/linked-list/src/main/java/DoublyLinkedList.java
@@ -2,19 +2,19 @@ class DoublyLinkedList<T> {
     private Element<T> head;
 
     void push(T value) {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+        throw new UnsupportedOperationException("Please implement the DoublyLinkedList.push() method.");
     }
 
     T pop() {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+        throw new UnsupportedOperationException("Please implement the DoublyLinkedList.pop() method.");
     }
 
     void unshift(T value) {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+        throw new UnsupportedOperationException("Please implement the DoublyLinkedList.unshift() method.");
     }
 
     T shift() {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+        throw new UnsupportedOperationException("Please implement the DoublyLinkedList.shift() method.");
     }
 
     private static final class Element<T> {
@@ -23,7 +23,7 @@ class DoublyLinkedList<T> {
         private Element<T> next;
 
         Element(T value, Element<T> prev, Element<T> next) {
-            throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+            throw new UnsupportedOperationException("Please implement the Element constructor.");
         }
     }
 }

--- a/exercises/practice/linked-list/src/main/java/DoublyLinkedList.java
+++ b/exercises/practice/linked-list/src/main/java/DoublyLinkedList.java
@@ -1,10 +1,29 @@
-/*
+class DoublyLinkedList<T> {
+    private Element<T> head;
 
-Since this exercise has a difficulty of > 4 it doesn't come
-with any starter implementation.
-This is so that you get to practice creating classes and methods
-which is an important part of programming in Java.
+    void push(T value) {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
 
-Please remove this comment when submitting your solution.
+    T pop() {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
 
-*/
+    void unshift(T value) {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    T shift() {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    private static final class Element<T> {
+        private final T value;
+        private Element<T> prev;
+        private Element<T> next;
+
+        Element(T value, Element<T> prev, Element<T> next) {
+            throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+        }
+    }
+}


### PR DESCRIPTION
# pull request

See discussion on
https://github.com/exercism/java/issues/2133#issuecomment-1281543458

Original issue:
Right now for some exercises, a student is required to read the tests to know which functions they should implement. This is annoying, time consuming and might discourage people from doing the exercise entirely. We should provide stubs for all exercises. Stubs should provide the signature of functions and classes, just so the student is immediately ready to start writing the custom logic. This is an example of a stub, from the [Raindrops exercise](https://github.com/exercism/java/blob/main/exercises/practice/raindrops/src/main/java/RaindropConverter.java):

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
