### PR TITLE
Remove references to gitter and replace them with references to the forum

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@
 
 This guide covers contributing to the Java track.  If you are new to the exercism Java track, this guide is for you.
 
-If, at any point, you're having any trouble, pop in the [Gitter exercism/java room](https://gitter.im/exercism/java) or the [Gitter exercism/dev room](https://gitter.im/exercism/dev) for help.
+If, at any point, you're having any trouble, pop in [Exercism Forum: Java](https://forum.exercism.org/c/programming/java/91) or [Exercism Forum: Support](https://forum.exercism.org/c/support/8) for help.
 
 For general guidelines about contributing to Exercism see the [Exercism contributing guide](https://exercism.org/docs/building).
 
@@ -208,7 +208,7 @@ See other exercises, e.g. [acronym](https://github.com/exercism/java/tree/main/e
 * Make sure you've followed the [track policies](https://github.com/exercism/java/blob/main/POLICIES.md), especially the ones for exercise added/updated.
 
 Hopefully that should be enough information to help you port an exercise to the Java track.
-Feel free to open an issue or post in the [Gitter exercism/java room](https://gitter.im/exercism/java) if you have any questions and we'll try and answer as soon as we can.
+Feel free to open an issue or post in [Exercism Forum: Java](https://forum.exercism.org/c/programming/java/91) or [Exercism Forum: Support](https://forum.exercism.org/c/support/8) if you have any questions and we'll try and answer as soon as we can.
 
 ## Updating the READMEs
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ![Java CI with Gradle](https://github.com/exercism/java/workflows/Java%20CI%20with%20Gradle/badge.svg)
 [![Configlet](https://github.com/exercism/java/actions/workflows/configlet.yml/badge.svg)](https://github.com/exercism/java/actions/workflows/configlet.yml)
-[![Join the chat at https://gitter.im/exercism/xjava](https://badges.gitter.im/exercism/java.svg)](https://gitter.im/exercism/java?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Source for Exercism Exercises in Java.
+
+- [Exercism Forum: Java](https://forum.exercism.org/c/programming/java/91)
 
 ## Contributing Guide
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -43,7 +43,7 @@ Choose your operating system:
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
+If you get stuck, at any point, don't forget to reach out for help in [Exercism Forum: Java](https://forum.exercism.org/c/programming/java/91) or [Exercism Forum: Support](https://forum.exercism.org/c/support/8).
 
 ----
 
@@ -77,7 +77,7 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
+If you get stuck, at any point, don't forget to reach out for help in [Exercism Forum: Java](https://forum.exercism.org/c/programming/java/91) or [Exercism Forum: Support](https://forum.exercism.org/c/support/8).
 
 ----
 
@@ -112,4 +112,4 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
+If you get stuck, at any point, don't forget to reach out for help in [Exercism Forum: Java](https://forum.exercism.org/c/programming/java/91) or [Exercism Forum: Support](https://forum.exercism.org/c/support/8).

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -91,9 +91,10 @@ From here, there are a number of paths you can take.
 
 Regardless of what you decide to do next, we sincerely hope you learn
 and enjoy being part of this community.  If at any time you need assistance
-do not hesitate to ask for help:
+do not hesitate to ask for help in our forum:
 
-https://gitter.im/exercism/support
+- [Exercism Forum: Java](https://forum.exercism.org/c/programming/java/91) - for Java related questions
+- [Exercism Forum: Support](https://forum.exercism.org/c/programming/java/91) - for Exercism related questions
 
 Cheers!
 

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -43,7 +43,7 @@ Choose your operating system:
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
+If you get stuck, at any point, don't forget to reach out for [help](https://forum.exercism.org/c/programming/java/91).
 
 ----
 
@@ -77,7 +77,7 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
+If you get stuck, at any point, don't forget to reach out for help in [Exercism Forum: Java](https://forum.exercism.org/c/programming/java/91) or [Exercism Forum: Support](https://forum.exercism.org/c/support/8).
 
 ----
 
@@ -112,4 +112,4 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
+If you get stuck, at any point, don't forget to reach out for help in [Exercism Forum: Java](https://forum.exercism.org/c/programming/java/91) or [Exercism Forum: Support](https://forum.exercism.org/c/support/8).


### PR DESCRIPTION
Refer people to the forum instead of Gitter.

Since I think I'm the only active maintainer on the Java track, also requesting reviews from @ErikSchierboom and @exercism/reviewers.