### PR TITLE
Remove reference to Gitter

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@
 
 This guide covers contributing to the Java track.  If you are new to the exercism Java track, this guide is for you.
 
-If, at any point, you're having any trouble, pop in the [Gitter exercism/java room](https://gitter.im/exercism/java) or the [Gitter exercism/dev room](https://gitter.im/exercism/dev) for help.
+If, at any point, you're having any trouble, pop in the [Exercism forum][forum] for help.
 
 For general guidelines about contributing to Exercism see the [Exercism contributing guide](https://exercism.org/docs/building).
 
@@ -208,7 +208,7 @@ See other exercises, e.g. [acronym](https://github.com/exercism/java/tree/main/e
 * Make sure you've followed the [track policies](https://github.com/exercism/java/blob/main/POLICIES.md), especially the ones for exercise added/updated.
 
 Hopefully that should be enough information to help you port an exercise to the Java track.
-Feel free to open an issue or post in the [Gitter exercism/java room](https://gitter.im/exercism/java) if you have any questions and we'll try and answer as soon as we can.
+Feel free to open an issue or post in the [Building Exercism](https://forum.exercism.org/c/exercism/building-exercism/125) category of the [Exercism forum](https://forum.exercism.org/) if you have any questions and we'll try and answer as soon as we can.
 
 ## Updating the READMEs
 
@@ -294,3 +294,5 @@ To run this script:
   4. Run `./scripts/create_issues_new_exercise.sh -t . -s --spec-path path_to_problem_specifications` from the root of this repository and follow the directions.
   
   5. If you decide to submit a new issue you can find the opened issue on the [issues page](https://github.com/exercism/java/issues).
+
+[forum]: https://forum.exercism.org/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![Java CI with Gradle](https://github.com/exercism/java/workflows/Java%20CI%20with%20Gradle/badge.svg)
 [![Configlet](https://github.com/exercism/java/actions/workflows/configlet.yml/badge.svg)](https://github.com/exercism/java/actions/workflows/configlet.yml)
-[![Join the chat at https://gitter.im/exercism/xjava](https://badges.gitter.im/exercism/java.svg)](https://gitter.im/exercism/java?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 Source for Exercism Exercises in Java.
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -43,8 +43,6 @@ Choose your operating system:
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
-
 ----
 
 # macOS
@@ -76,8 +74,6 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
 4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 Good luck!  Have fun!
-
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
 
 ----
 
@@ -111,5 +107,3 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
 4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 Good luck!  Have fun!
-
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -91,9 +91,7 @@ From here, there are a number of paths you can take.
 
 Regardless of what you decide to do next, we sincerely hope you learn
 and enjoy being part of this community.  If at any time you need assistance
-do not hesitate to ask for help:
-
-https://gitter.im/exercism/support
+do not hesitate to ask for help.
 
 Cheers!
 

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -43,8 +43,6 @@ Choose your operating system:
 
 Good luck!  Have fun!
 
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
-
 ----
 
 # macOS
@@ -76,8 +74,6 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
 4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 Good luck!  Have fun!
-
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).
 
 ----
 
@@ -111,5 +107,3 @@ If you get stuck, at any point, don't forget to reach out for [help](https://git
 4. Solve the exercise.  Find and work through the `instructions.append.md` guide ([view on GitHub](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)).
 
 Good luck!  Have fun!
-
-If you get stuck, at any point, don't forget to reach out for [help](https://gitter.im/exercism/support).


### PR DESCRIPTION
The Exerism Forum (https://forum.exercism.org/) has now made Gitter redundant.
We're directing everyone there.

# pull request

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
