### PR TITLE
Add stubs to practice exercises S to V

### DIFF
--- a/exercises/practice/satellite/src/main/java/Satellite.java
+++ b/exercises/practice/satellite/src/main/java/Satellite.java
@@ -1,10 +1,7 @@
-/*
+import java.util.List;
 
-Since this exercise has a difficulty of > 4 it doesn't come
-with any starter implementation.
-This is so that you get to practice creating classes and methods
-which is an important part of programming in Java.
-
-Please remove this comment when submitting your solution.
-
-*/
+public class Satellite {
+    public Tree treeFromTraversals(List<Character> preorderInput, List<Character> inorderInput) {
+        throw new UnsupportedOperationException("Please implement the Satellite.treeFromTraversals() method.");
+    }
+}

--- a/exercises/practice/series/src/main/java/Series.java
+++ b/exercises/practice/series/src/main/java/Series.java
@@ -1,10 +1,11 @@
-/*
+import java.util.List;
 
-Since this exercise has a difficulty of > 4 it doesn't come
-with any starter implementation.
-This is so that you get to practice creating classes and methods
-which is an important part of programming in Java.
+class Series {
+    Series(String string) {
+        throw new UnsupportedOperationException("Please implement the Series(string) constructor.");
+    }
 
-Please remove this comment when submitting your solution.
-
-*/
+    List<String> slices(int num) {
+        throw new UnsupportedOperationException("Please implement the Series.slices() method.");
+    }
+}

--- a/exercises/practice/sgf-parsing/src/main/java/SgfParsing.java
+++ b/exercises/practice/sgf-parsing/src/main/java/SgfParsing.java
@@ -1,10 +1,5 @@
-/*
-
-Since this exercise has a difficulty of > 4 it doesn't come
-with any starter implementation.
-This is so that you get to practice creating classes and methods
-which is an important part of programming in Java.
-
-Please remove this comment when submitting your solution.
-
-*/
+public class SgfParsing {
+    public SgfNode parse(String input) throws SgfParsingException {
+        throw new UnsupportedOperationException("Please implement the SgfParsing.parse method.");
+    }
+}

--- a/exercises/practice/simple-cipher/src/main/java/Cipher.java
+++ b/exercises/practice/simple-cipher/src/main/java/Cipher.java
@@ -1,10 +1,21 @@
-/*
+public class Cipher {
+    public Cipher() {
+        throw new UnsupportedOperationException("Please implement the Cipher() constructor.");
+    }
 
-Since this exercise has a difficulty of > 4 it doesn't come
-with any starter implementation.
-This is so that you get to practice creating classes and methods
-which is an important part of programming in Java.
+    public Cipher(String key) {
+        throw new UnsupportedOperationException("Please implement the Cipher(String) constructor.");
+    }
 
-Please remove this comment when submitting your solution.
+    public String getKey() {
+        throw new UnsupportedOperationException("Please implement the Cipher.getKey() method.");
+    }
 
-*/
+    public String encode(String plainText) {
+        throw new UnsupportedOperationException("Please implement the Cipher.encode() method.");
+    }
+
+    public String decode(String cipherText) {
+        throw new UnsupportedOperationException("Please implement the Cipher.decode() method.");
+    }
+}

--- a/exercises/practice/simple-linked-list/src/main/java/SimpleLinkedList.java
+++ b/exercises/practice/simple-linked-list/src/main/java/SimpleLinkedList.java
@@ -1,10 +1,29 @@
-/*
+class SimpleLinkedList<T> {
+    SimpleLinkedList() {
+        throw new UnsupportedOperationException("Please implement the SimpleLinkedList() constructor.");
+    }
 
-Since this exercise has a difficulty of > 4 it doesn't come
-with any starter implementation.
-This is so that you get to practice creating classes and methods
-which is an important part of programming in Java.
+    SimpleLinkedList(T[] values) {
+        throw new UnsupportedOperationException("Please implement the SimpleLinkedList(T[]) constructor.");
+    }
 
-Please remove this comment when submitting your solution.
+    void push(T value) {
+        throw new UnsupportedOperationException("Please implement the SimpleLinkedList.push() method.");
+    }
 
-*/
+    T pop() {
+        throw new UnsupportedOperationException("Please implement the SimpleLinkedList.pop() method.");
+    }
+
+    void reverse() {
+        throw new UnsupportedOperationException("Please implement the SimpleLinkedList.reverse() method.");
+    }
+
+    T[] asArray(Class<T> clazz) {
+        throw new UnsupportedOperationException("Please implement the SimpleLinkedList.asArray() method.");
+    }
+
+    int size() {
+        throw new UnsupportedOperationException("Please implement the SimpleLinkedList.size() method.");
+    }
+}

--- a/exercises/practice/spiral-matrix/src/main/java/SpiralMatrixBuilder.java
+++ b/exercises/practice/spiral-matrix/src/main/java/SpiralMatrixBuilder.java
@@ -1,10 +1,5 @@
-/*
-
-Since this exercise has a difficulty of > 4 it doesn't come
-with any starter implementation.
-This is so that you get to practice creating classes and methods
-which is an important part of programming in Java.
-
-Please remove this comment when submitting your solution.
-
-*/
+class SpiralMatrixBuilder {
+    int[][] buildMatrixOfSize(int size) {
+        throw new UnsupportedOperationException("Please implement the SpiralMatrixBuilder.buildMatrixOfSize() method.");
+    }
+}

--- a/exercises/practice/sublist/src/main/java/RelationshipComputer.java
+++ b/exercises/practice/sublist/src/main/java/RelationshipComputer.java
@@ -1,10 +1,7 @@
-/*
+import java.util.List;
 
-Since this exercise has a difficulty of > 4 it doesn't come
-with any starter implementation.
-This is so that you get to practice creating classes and methods
-which is an important part of programming in Java.
-
-Please remove this comment when submitting your solution.
-
-*/
+class RelationshipComputer<T> {
+    Relationship computeRelationship(List<T> firstList, List<T> secondList) {
+        throw new UnsupportedOperationException("Please implement the RelationshipComputer.computeRelationship() method.");
+    }
+}

--- a/exercises/practice/tournament/src/main/java/Tournament.java
+++ b/exercises/practice/tournament/src/main/java/Tournament.java
@@ -1,10 +1,9 @@
-/*
+class Tournament {
+    String printTable() {
+        throw new UnsupportedOperationException("Please implement the Tournament.printTable() method.");
+    }
 
-Since this exercise has a difficulty of > 4 it doesn't come
-with any starter implementation.
-This is so that you get to practice creating classes and methods
-which is an important part of programming in Java.
-
-Please remove this comment when submitting your solution.
-
-*/
+    void applyResults(String resultString) {
+        throw new UnsupportedOperationException("Please implement the Tournament.applyResults() method.");
+    }
+}

--- a/exercises/practice/transpose/src/main/java/Transpose.java
+++ b/exercises/practice/transpose/src/main/java/Transpose.java
@@ -1,10 +1,5 @@
-/*
-
-Since this exercise has a difficulty of > 4 it doesn't come
-with any starter implementation.
-This is so that you get to practice creating classes and methods
-which is an important part of programming in Java.
-
-Please remove this comment when submitting your solution.
-
-*/
+public class Transpose {
+    public String transpose(String toTranspose) {
+        throw new UnsupportedOperationException("Please implement the Transpose.transpose() method.");
+    }
+}

--- a/exercises/practice/two-bucket/src/main/java/TwoBucket.java
+++ b/exercises/practice/two-bucket/src/main/java/TwoBucket.java
@@ -1,10 +1,17 @@
-/*
+class TwoBucket {
+    TwoBucket(int bucketOneCap, int bucketTwoCap, int desiredLiters, String startBucket) {
+        throw new UnsupportedOperationException("Please implement the TwoBucket(int, int, int, String) constructor.");
+    }
 
-Since this exercise has a difficulty of > 4 it doesn't come
-with any starter implementation.
-This is so that you get to practice creating classes and methods
-which is an important part of programming in Java.
+    int getTotalMoves() {
+        throw new UnsupportedOperationException("Please implement the TwoBucket.getTotalMoves() method.");
+    }
 
-Please remove this comment when submitting your solution.
+    String getFinalBucket() {
+        throw new UnsupportedOperationException("Please implement the TwoBucket.getFinalBucket() method.");
+    }
 
-*/
+    int getOtherBucket() {
+        throw new UnsupportedOperationException("Please implement the TwoBucket.getOtherBucket() method.");
+    }
+}


### PR DESCRIPTION
# pull request

Related to #2133 

This PR adds stubs for practice exercises starting with letters S through to V. 

The following exercises have been omitted from this PR as they already have stubs defined:
- saddle-points - ([Matrix.java](https://github.com/exercism/java/blob/main/exercises/practice/saddle-points/src/main/java/Matrix.java))
- say - ([Say.java](https://github.com/exercism/java/blob/main/exercises/practice/say/src/main/java/Say.java))
- scrabble-score - ([Scrabble.java](https://github.com/exercism/java/blob/main/exercises/practice/scrabble-score/src/main/java/Scrabble.java))
- secret-handshake - ([HandshakeCalculator.java](https://github.com/exercism/java/blob/main/exercises/practice/secret-handshake/src/main/java/HandshakeCalculator.java))
- sieve - ([Sieve.java](https://github.com/exercism/java/blob/main/exercises/practice/sieve/src/main/java/Sieve.java))
- space-age - ([SpaceAge.java](https://github.com/exercism/java/blob/main/exercises/practice/space-age/src/main/java/SpaceAge.java))
- sum-of-multiples - ([SumOfMultiples.java](https://github.com/exercism/java/blob/main/exercises/practice/sum-of-multiples/src/main/java/SumOfMultiples.java))
- tree-building - Looks like it has a stub defined? ([BuildTree.java](https://github.com/exercism/java/blob/main/exercises/practice/tree-building/src/main/java/BuildTree.java))
- triangle - ([Triangle.java](https://github.com/exercism/java/blob/main/exercises/practice/triangle/src/main/java/Triangle.java))
- twelve-days - ([TwelveDays.java](https://github.com/exercism/java/blob/main/exercises/practice/twelve-days/src/main/java/TwelveDays.java))
- two-fer - ([Twofer.java](https://github.com/exercism/java/blob/main/exercises/practice/two-fer/src/main/java/Twofer.java))
- variable-length-quantity - ([VariableLengthQuantity.java](https://github.com/exercism/java/blob/main/exercises/practice/variable-length-quantity/src/main/java/VariableLengthQuantity.java))

The following two exercises have been skipped as they are marked as deprecated in [`config.json`](https://github.com/exercism/java/blob/main/config.json)
- strain
- trinary

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
