### PR TITLE
Expose all files in online editor

### DIFF
--- a/bin/site-editor-check.sh
+++ b/bin/site-editor-check.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# checks whether all classes and solution stubs are visible in the editor
+# (via mentioning in the .meta/config.json)
+
+set -e
+
+root=$(git rev-parse --show-toplevel)
+
+for exercise_type in 'concept' 'practice'; do
+  group="${root}/exercises/${exercise_type}"
+  mapfile -t exercises < <(ls "${group}")
+  for exercise in "${exercises[@]}"; do
+    exercise_path="${group}/${exercise}"
+    config_files=$(jq '.files' < "${exercise_path}/.meta/config.json")
+    declare -A files
+    for file_type in 'editor' 'solution'; do
+      for file in $(echo "${config_files}" | jq -r ".${file_type} | @sh"); do
+        files[${file}]=true
+      done
+    done
+    mapfile -t java_files < <(find "${exercise_path}/src/main" -type f -name '*.java')
+    for java_file in "${java_files[@]}"; do
+      file_location=${java_file//${exercise_path}\//}
+      if [[ "${files["'${file_location}'"]}" != 'true' ]]; then
+        echo "${exercise_type}/${exercise}/${file_location} is not available in the editor"
+        exit 1
+      fi
+    done
+  done
+done

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -31,6 +31,9 @@
     "solution": [
       "src/main/java/Allergies.java"
     ],
+    "editor": [
+      "src/main/java/Allergen.java"
+    ],
     "test": [
       "src/test/java/AllergiesTest.java"
     ],

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -20,6 +20,9 @@
     "solution": [
       "src/main/java/Alphametics.java"
     ],
+    "editor": [
+      "src/main/java/UnsolvablePuzzleException.java"
+    ],
     "test": [
       "src/test/java/AlphameticsTest.java"
     ],

--- a/exercises/practice/bank-account/.meta/config.json
+++ b/exercises/practice/bank-account/.meta/config.json
@@ -18,6 +18,9 @@
     "solution": [
       "src/main/java/BankAccount.java"
     ],
+    "editor": [
+      "src/main/java/BankAccountActionInvalidException.java"
+    ],
     "test": [
       "src/test/java/BankAccountTest.java"
     ],

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -29,6 +29,9 @@
     "solution": [
       "src/main/java/BinarySearch.java"
     ],
+    "editor": [
+      "src/main/java/ValueNotFoundException.java"
+    ],
     "test": [
       "src/test/java/BinarySearchTest.java"
     ],

--- a/exercises/practice/circular-buffer/.meta/config.json
+++ b/exercises/practice/circular-buffer/.meta/config.json
@@ -24,6 +24,9 @@
     "solution": [
       "src/main/java/CircularBuffer.java"
     ],
+    "editor": [
+      "src/main/java/BufferIOException.java"
+    ],
     "test": [
       "src/test/java/CircularBufferTest.java"
     ],

--- a/exercises/practice/dominoes/.meta/config.json
+++ b/exercises/practice/dominoes/.meta/config.json
@@ -19,6 +19,10 @@
     "solution": [
       "src/main/java/Dominoes.java"
     ],
+    "editor": [
+      "src/main/java/ChainNotFoundException.java",
+      "src/main/java/Domino.java"
+    ],
     "test": [
       "src/test/java/DominoesTest.java"
     ],

--- a/exercises/practice/error-handling/.meta/config.json
+++ b/exercises/practice/error-handling/.meta/config.json
@@ -19,6 +19,10 @@
     "solution": [
       "src/main/java/ErrorHandling.java"
     ],
+    "editor": [
+      "src/main/java/CustomCheckedException.java",
+      "src/main/java/CustomUncheckedException.java"
+    ],
     "test": [
       "src/test/java/ErrorHandlingTest.java"
     ],

--- a/exercises/practice/go-counting/.meta/config.json
+++ b/exercises/practice/go-counting/.meta/config.json
@@ -20,6 +20,9 @@
     "solution": [
       "src/main/java/GoCounting.java"
     ],
+    "editor": [
+      "src/main/java/Player.java"
+    ],
     "test": [
       "src/test/java/GoCountingTest.java"
     ],

--- a/exercises/practice/hangman/.meta/config.json
+++ b/exercises/practice/hangman/.meta/config.json
@@ -12,6 +12,11 @@
     "solution": [
       "src/main/java/Hangman.java"
     ],
+    "editor": [
+      "src/main/java/Output.java",
+      "src/main/java/Part.java",
+      "src/main/java/Status.java"
+    ],
     "test": [
       "src/test/java/HangmanTest.java"
     ],

--- a/exercises/practice/kindergarten-garden/.meta/config.json
+++ b/exercises/practice/kindergarten-garden/.meta/config.json
@@ -25,6 +25,9 @@
     "solution": [
       "src/main/java/KindergartenGarden.java"
     ],
+    "editor": [
+      "src/main/java/Plant.java"
+    ],
     "test": [
       "src/test/java/KindergartenGardenTest.java"
     ],

--- a/exercises/practice/meetup/.meta/config.json
+++ b/exercises/practice/meetup/.meta/config.json
@@ -28,6 +28,9 @@
     "solution": [
       "src/main/java/Meetup.java"
     ],
+    "editor": [
+      "src/main/java/MeetupSchedule.java"
+    ],
     "test": [
       "src/test/java/MeetupTest.java"
     ],

--- a/exercises/practice/perfect-numbers/.meta/config.json
+++ b/exercises/practice/perfect-numbers/.meta/config.json
@@ -24,6 +24,9 @@
     "solution": [
       "src/main/java/NaturalNumber.java"
     ],
+    "editor": [
+      "src/main/java/Classification.java"
+    ],
     "test": [
       "src/test/java/NaturalNumberTest.java"
     ],

--- a/exercises/practice/rest-api/.meta/config.json
+++ b/exercises/practice/rest-api/.meta/config.json
@@ -12,6 +12,10 @@
     "solution": [
       "src/main/java/RestApi.java"
     ],
+    "editor": [
+      "src/main/java/Iou.java",
+      "src/main/java/User.java"
+    ],
     "test": [
       "src/test/java/RestApiTest.java"
     ],

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -29,6 +29,10 @@
     "solution": [
       "src/main/java/Robot.java"
     ],
+    "editor": [
+      "src/main/java/GridPosition.java",
+      "src/main/java/Orientation.java"
+    ],
     "test": [
       "src/test/java/RobotTest.java"
     ],

--- a/exercises/practice/saddle-points/.meta/config.json
+++ b/exercises/practice/saddle-points/.meta/config.json
@@ -27,6 +27,9 @@
     "solution": [
       "src/main/java/Matrix.java"
     ],
+    "editor": [
+      "src/main/java/MatrixCoordinate.java"
+    ],
     "test": [
       "src/test/java/MatrixTest.java"
     ],

--- a/exercises/practice/satellite/.meta/config.json
+++ b/exercises/practice/satellite/.meta/config.json
@@ -11,6 +11,10 @@
     "solution": [
       "src/main/java/Satellite.java"
     ],
+    "editor": [
+      "src/main/java/Node.java",
+      "src/main/java/Tree.java"
+    ],
     "test": [
       "src/test/java/SatelliteTest.java"
     ],

--- a/exercises/practice/sgf-parsing/.meta/config.json
+++ b/exercises/practice/sgf-parsing/.meta/config.json
@@ -4,6 +4,10 @@
     "solution": [
       "src/main/java/SgfParsing.java"
     ],
+    "editor": [
+      "src/main/java/SgfNode.java",
+      "src/main/java/SgfParsingException.java"
+    ],
     "test": [
       "src/test/java/SgfParsingTest.java"
     ],

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -26,6 +26,9 @@
     "solution": [
       "src/main/java/RelationshipComputer.java"
     ],
+    "editor": [
+      "src/main/java/Relationship.java"
+    ],
     "test": [
       "src/test/java/RelationshipComputerTest.java"
     ],

--- a/exercises/practice/tree-building/.meta/config.json
+++ b/exercises/practice/tree-building/.meta/config.json
@@ -14,6 +14,11 @@
     "solution": [
       "src/main/java/BuildTree.java"
     ],
+    "editor": [
+      "src/main/java/InvalidRecordsException.java",
+      "src/main/java/Record.java",
+      "src/main/java/TreeNode.java"
+    ],
     "test": [
       "src/test/java/BuildTreeTest.java"
     ],

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -28,6 +28,9 @@
     "solution": [
       "src/main/java/Triangle.java"
     ],
+    "editor": [
+      "src/main/java/TriangleException.java"
+    ],
     "test": [
       "src/test/java/TriangleTest.java"
     ],

--- a/exercises/practice/word-search/.meta/config.json
+++ b/exercises/practice/word-search/.meta/config.json
@@ -24,6 +24,10 @@
     "solution": [
       "src/main/java/WordSearcher.java"
     ],
+    "editor": [
+      "src/main/java/Pair.java",
+      "src/main/java/WordLocation.java"
+    ],
     "test": [
       "src/test/java/WordSearcherTest.java"
     ],

--- a/exercises/practice/yacht/.meta/config.json
+++ b/exercises/practice/yacht/.meta/config.json
@@ -16,6 +16,9 @@
     "solution": [
       "src/main/java/Yacht.java"
     ],
+    "editor": [
+      "src/main/java/YachtCategory.java"
+    ],
     "test": [
       "src/test/java/YachtTest.java"
     ],


### PR DESCRIPTION
# pull request

As per discussion here: https://github.com/exercism/java/issues/2157#issuecomment-1295851262

There are some classes that are not visible in the online editor, making it hard to solve it and causing obscure compilation errors if the student re-declares the class.

<!-- Your content goes here: -->

PR content:
- extra files exposed as read-only via editor
- a script to check missing files

Further possible actions:
- include the script into CI workflow
- since the script is pretty generic already, it can probably be used in other tracks too after minimal modifictions
- check for orphan files in `config.json`

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
