### PR TITLE
assertEquals converted to assertThat for MarkdownTest

### DIFF
--- a/exercises/practice/markdown/src/test/java/MarkdownTest.java
+++ b/exercises/practice/markdown/src/test/java/MarkdownTest.java
@@ -2,7 +2,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MarkdownTest {
 
@@ -18,7 +18,7 @@ public class MarkdownTest {
         String input = "This will be a paragraph";
         String expected = "<p>This will be a paragraph</p>";
 
-        assertEquals(expected, markdown.parse(input));
+        assertThat(markdown.parse(input)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -27,7 +27,7 @@ public class MarkdownTest {
         String input = "_This will be italic_";
         String expected = "<p><em>This will be italic</em></p>";
 
-        assertEquals(expected, markdown.parse(input));
+        assertThat(markdown.parse(input)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -36,7 +36,7 @@ public class MarkdownTest {
         String input = "__This will be bold__";
         String expected = "<p><strong>This will be bold</strong></p>";
 
-        assertEquals(expected, markdown.parse(input));
+        assertThat(markdown.parse(input)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -45,7 +45,7 @@ public class MarkdownTest {
         String input = "This will _be_ __mixed__";
         String expected = "<p>This will <em>be</em> <strong>mixed</strong></p>";
 
-        assertEquals(expected, markdown.parse(input));
+        assertThat(markdown.parse(input)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -54,7 +54,7 @@ public class MarkdownTest {
         String input = "# This will be an h1";
         String expected = "<h1>This will be an h1</h1>";
 
-        assertEquals(expected, markdown.parse(input));
+        assertThat(markdown.parse(input)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -63,7 +63,7 @@ public class MarkdownTest {
         String input = "## This will be an h2";
         String expected = "<h2>This will be an h2</h2>";
 
-        assertEquals(expected, markdown.parse(input));
+        assertThat(markdown.parse(input)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -72,7 +72,7 @@ public class MarkdownTest {
         String input = "###### This will be an h6";
         String expected = "<h6>This will be an h6</h6>";
 
-        assertEquals(expected, markdown.parse(input));
+        assertThat(markdown.parse(input)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -81,7 +81,7 @@ public class MarkdownTest {
         String input = "* Item 1\n* Item 2";
         String expected = "<ul><li>Item 1</li><li>Item 2</li></ul>";
 
-        assertEquals(expected, markdown.parse(input));
+        assertThat(markdown.parse(input)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -90,7 +90,7 @@ public class MarkdownTest {
         String input = "# Header!\n* __Bold Item__\n* _Italic Item_";
         String expected = "<h1>Header!</h1><ul><li><strong>Bold Item</strong></li><li><em>Italic Item</em></li></ul>";
 
-        assertEquals(expected, markdown.parse(input));
+        assertThat(markdown.parse(input)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -99,7 +99,7 @@ public class MarkdownTest {
         String input = "# This is a header with # and * in the text";
         String expected = "<h1>This is a header with # and * in the text</h1>";
 
-        assertEquals(expected, markdown.parse(input));
+        assertThat(markdown.parse(input)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -108,7 +108,7 @@ public class MarkdownTest {
         String input = "* Item 1 with a # in the text\n* Item 2 with * in the text";
         String expected = "<ul><li>Item 1 with a # in the text</li><li>Item 2 with * in the text</li></ul>";
 
-        assertEquals(expected, markdown.parse(input));
+        assertThat(markdown.parse(input)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -117,7 +117,7 @@ public class MarkdownTest {
         String input = "This is a paragraph with # and * in the text";
         String expected = "<p>This is a paragraph with # and * in the text</p>";
 
-        assertEquals(expected, markdown.parse(input));
+        assertThat(markdown.parse(input)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -126,7 +126,7 @@ public class MarkdownTest {
         String input = "# Start a list\n* Item 1\n* Item 2\nEnd a list";
         String expected = "<h1>Start a list</h1><ul><li>Item 1</li><li>Item 2</li></ul><p>End a list</p>";
 
-        assertEquals(expected, markdown.parse(input));
+        assertThat(markdown.parse(input)).isEqualTo(expected);
     }
 
 }


### PR DESCRIPTION
related to #2147 
Importing AssertJ and changing all assertEquals to assertThat.

Example of Change:

assertEquals(expected, markdown.parse(input));

To

assertThat(markdown.parse(input)).isEqualTo(expected);


