### PR TITLE
Update score method to use double values

### DIFF
--- a/exercises/practice/darts/src/main/java/Darts.java
+++ b/exercises/practice/darts/src/main/java/Darts.java
@@ -1,5 +1,5 @@
 class Darts {
-    int score(int xOfDart, int yOfDart) {
+    int score(double xOfDart, double yOfDart) {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
     }
 }


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->

Test cases call a method with signature int score(double, double), but default method in the main file has a signature of int score(int, int). This commit resolves that issue by changing the default method signature to int score(double, double).

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
