### PR TITLE
Fix typo in the Dig Deeper text for Grains

### DIFF
--- a/exercises/practice/grains/.approaches/introduction.md
+++ b/exercises/practice/grains/.approaches/introduction.md
@@ -18,7 +18,7 @@ You can see that the exponent, or power, that `2` is raised by is always one les
 | 1      | 0     | 2 to the power of 0 = 1 |
 | 2      | 1     | 2 to the power of 1 = 2 |
 | 3      | 2     | 2 to the power of 2 = 4 |
-| 4      | 3     | 2 to the power of 4 = 8 |
+| 4      | 3     | 2 to the power of 3 = 8 |
 
 ## Approach: `BigInteger.pow()`
 


### PR DESCRIPTION
Fixed the wrong power of two that gives us 8.
https://exercism.org/tracks/java/exercises/grains/dig_deeper

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
