### PR TITLE
Implementation of script to automatically add java files to files.editor of config.json

### DIFF
--- a/exercises/practice/error-handling/.meta/config.json
+++ b/exercises/practice/error-handling/.meta/config.json
@@ -25,7 +25,8 @@
     ],
     "example": [
       ".meta/src/reference/java/ErrorHandling.java"
-    ]
+    ],
+    "editor": []
   },
   "blurb": "Implement various kinds of error handling and resource management."
 }

--- a/exercises/practice/error-handling/.meta/config.json
+++ b/exercises/practice/error-handling/.meta/config.json
@@ -25,8 +25,7 @@
     ],
     "example": [
       ".meta/src/reference/java/ErrorHandling.java"
-    ],
-    "editor": []
+    ]
   },
   "blurb": "Implement various kinds of error handling and resource management."
 }

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -31,8 +31,7 @@
     ],
     "example": [
       ".meta/src/reference/java/RelationshipComputer.java"
-    ],
-    "editor": []
+    ]
   },
   "blurb": "Write a function to determine if a list is a sublist of another list."
 }

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -23,7 +23,8 @@
   ],
   "files": {
     "solution": [
-      "src/main/java/RelationshipComputer.java"
+      "src/main/java/RelationshipComputer.java",
+      "src/main/java/Relationship.java"
     ],
     "test": [
       "src/test/java/RelationshipComputerTest.java"
@@ -31,9 +32,7 @@
     "example": [
       ".meta/src/reference/java/RelationshipComputer.java"
     ],
-    "editor": [
-      "src/main/java/Relationship.java"
-    ]
+    "editor": []
   },
   "blurb": "Write a function to determine if a list is a sublist of another list."
 }

--- a/scripts/add_extra_files_to_editor.sh
+++ b/scripts/add_extra_files_to_editor.sh
@@ -9,7 +9,7 @@ command -v jq >/dev/null 2>&1 || {
 ################### HELP ##############################
 print_usage() {
         echo -e "\nDescription:\n"
-        echo -e "This script goes through each exercise directory, picks all the java files in the src directory, except the main editable solution file, and adds them to 'fonts.editor' section of the config.json file present in the .meta folder of the exercise" 
+        echo -e "This script goes through each exercise directory, picks all the java files in the src directory, except the main editable solution file, and adds them to 'fonts.editor' section of the config.json file present in the .meta folder of the exercise"
         echo -e "This makes sure that there is no need to manually configure the config.json for subsequent exercises. Just running this script will resolve all those tasks on their own."
 
         echo -e "\nSyntax: ./add_extra_files_to_editor.sh [-a|-h|-d <exercise_name>]"
@@ -17,7 +17,7 @@ print_usage() {
         echo -e "\nOptions:\n"
         echo -e "h                      Display the usage of the script"
         echo -e "a                      Processes all the exercises present inside ./exercise/practice directory"
-        echo -e "d <exercise_name>      Processes only the directory specified by the argument <exercise_name>." 
+        echo -e "d <exercise_name>      Processes only the directory specified by the argument <exercise_name>."
         echo -e "                       Do note that you only need to give the name of the exercise. Do not give the path to the exercise folder."
         echo -e "                       For example: if you need to process only the exercise 'triangle' then type '<script_name>.sh -d triangle'"
 }
@@ -25,10 +25,8 @@ print_usage() {
 #######################################################
 #######################################################
 
-
 #######################################################
 ################### MAIN ##############################
-
 
 # get the current location
 current_location=$PWD
@@ -46,36 +44,32 @@ process_current_directory() {
         json_file="$exercises_location/$1/.meta/config.json"
 
         # this is the solution file here
-        solution_file=$(jq '.| .files.solution[0]' $json_file)
-        solution_file=${solution_file:1:-1} # removing the quotes
+        solution_stream=$(jq -r '.files.solution | .[] | tostring' $json_file)
+        solution_files=($(echo "$solution_stream" | tr " " .))
 
-        # editor_files array being created here so that it will be storing the list of
-        # files that will be present in the editor
         editor_files=()
 
         # now adding only those files to the editor which are not present in the solution
         for VAL in $data; do
                 # getting the file name in a valid format so that it can be used in the json
                 file_name="src/main/java/$(echo $VAL | sed "s/.*\///")"
-                if [ $file_name != $solution_file ]; then
+                if [[ ! " ${solution_files[*]} " =~ " ${file_name} " ]]; then
                         editor_files+=($file_name)
                 fi
         done
 
-        total_files=${#editor_files[*]}
+        # total_files=${#editor_files[*]}
 
-        if [ $total_files -gt 0 ] 
-        then
 
-            tmp=$(mktemp)
+        tmp=$(mktemp)
 
-            # this one basically clears the editor portion of the json file
-            # and assigns it with an empty list if it exists
-            jq '.files.editor = []' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
+        # this one basically clears the editor portion of the json file
+        # and assigns it with an empty list if it exists
+        jq '.files.editor = []' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
 
-            # this one updates the editor portion of the json
-            jq '.files.editor += $ARGS.positional' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
-        fi
+        # this one updates the editor portion of the json
+        jq '.files.editor += $ARGS.positional' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
+        
 
         echo "Successfully processed $(basename $1)"
 }
@@ -88,14 +82,12 @@ process_all_directories() {
         done
 }
 
-
 # getting the commands here
 num_args=$#
 
-if [ $num_args -eq 0 ]
-then
-    print_usage
-    exit 0
+if [ $num_args -eq 0 ]; then
+        print_usage
+        exit 0
 fi
 
 # processing the script here

--- a/scripts/add_extra_files_to_editor.sh
+++ b/scripts/add_extra_files_to_editor.sh
@@ -62,14 +62,20 @@ process_current_directory() {
                 fi
         done
 
-        tmp=$(mktemp)
+        total_files=${#editor_files[*]}
 
-        # this one basically clears the editor portion of the json file
-        # and assigns it with an empty list if it exists
-        jq '.files.editor = []' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
+        if [ $total_files -gt 0 ] 
+        then
 
-        # this one updates the editor portion of the json
-        jq '.files.editor += $ARGS.positional' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
+            tmp=$(mktemp)
+
+            # this one basically clears the editor portion of the json file
+            # and assigns it with an empty list if it exists
+            jq '.files.editor = []' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
+
+            # this one updates the editor portion of the json
+            jq '.files.editor += $ARGS.positional' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
+        fi
 
         echo "Successfully processed $(basename $1)"
 }

--- a/scripts/add_extra_files_to_editor.sh
+++ b/scripts/add_extra_files_to_editor.sh
@@ -58,18 +58,18 @@ process_current_directory() {
                 fi
         done
 
-        # total_files=${#editor_files[*]}
+        total_files=${#editor_files[*]}
 
+        if (($total_files > 0)); then
+                tmp=$(mktemp)
 
-        tmp=$(mktemp)
+                # this one basically clears the editor portion of the json file
+                # and assigns it with an empty list if it exists
+                jq '.files.editor = []' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
 
-        # this one basically clears the editor portion of the json file
-        # and assigns it with an empty list if it exists
-        jq '.files.editor = []' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
-
-        # this one updates the editor portion of the json
-        jq '.files.editor += $ARGS.positional' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
-        
+                # this one updates the editor portion of the json
+                jq '.files.editor += $ARGS.positional' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
+        fi
 
         echo "Successfully processed $(basename $1)"
 }

--- a/scripts/add_extra_files_to_editor.sh
+++ b/scripts/add_extra_files_to_editor.sh
@@ -1,0 +1,120 @@
+#! /usr/bin/env bash
+
+command -v jq >/dev/null 2>&1 || {
+        echo >&2 ">>>>> This script requires jq but it's not installed. Aborting."
+        exit 1
+}
+
+#######################################################
+################### HELP ##############################
+print_usage() {
+        echo -e "\nDescription:\n"
+        echo -e "This script goes through each exercise directory, picks all the java files in the src directory, except the main editable solution file, and adds them to 'fonts.editor' section of the config.json file present in the .meta folder of the exercise" 
+        echo -e "This makes sure that there is no need to manually configure the config.json for subsequent exercises. Just running this script will resolve all those tasks on their own."
+
+        echo -e "\nSyntax: ./add_extra_files_to_editor.sh [-a|-h|-d <exercise_name>]"
+
+        echo -e "\nOptions:\n"
+        echo -e "h                      Display the usage of the script"
+        echo -e "a                      Processes all the exercises present inside ./exercise/practice directory"
+        echo -e "d <exercise_name>      Processes only the directory specified by the argument <exercise_name>." 
+        echo -e "                       Do note that you only need to give the name of the exercise. Do not give the path to the exercise folder."
+        echo -e "                       For example: if you need to process only the exercise 'triangle' then type '<script_name>.sh -d triangle'"
+}
+
+#######################################################
+#######################################################
+
+
+#######################################################
+################### MAIN ##############################
+
+
+# get the current location
+current_location=$PWD
+
+# get the exercises location
+exercises_location="$current_location/exercises/practice"
+
+process_current_directory() {
+
+        java_source_dir="$exercises_location/$1/src/main/java"
+
+        data=$(find "$java_source_dir" -type f -name "*.java")
+
+        # now getting the config.json file and here getting the details of the solution file
+        json_file="$exercises_location/$1/.meta/config.json"
+
+        # this is the solution file here
+        solution_file=$(jq '.| .files.solution[0]' $json_file)
+        solution_file=${solution_file:1:-1} # removing the quotes
+
+        # editor_files array being created here so that it will be storing the list of
+        # files that will be present in the editor
+        editor_files=()
+
+        # now adding only those files to the editor which are not present in the solution
+        for VAL in $data; do
+                # getting the file name in a valid format so that it can be used in the json
+                file_name="src/main/java/$(echo $VAL | sed "s/.*\///")"
+                if [ $file_name != $solution_file ]; then
+                        editor_files+=($file_name)
+                fi
+        done
+
+        tmp=$(mktemp)
+
+        # this one basically clears the editor portion of the json file
+        # and assigns it with an empty list if it exists
+        jq '.files.editor = []' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
+
+        # this one updates the editor portion of the json
+        jq '.files.editor += $ARGS.positional' $json_file --args "${editor_files[@]}" >"$tmp" && mv "$tmp" "$json_file"
+
+        echo "Successfully processed $(basename $1)"
+}
+
+process_all_directories() {
+        cd $exercises_location
+
+        for directory in *; do
+                process_current_directory $directory
+        done
+}
+
+
+# getting the commands here
+num_args=$#
+
+if [ $num_args -eq 0 ]
+then
+    print_usage
+    exit 0
+fi
+
+# processing the script here
+while getopts ":had:" option; do
+        case $option in
+        h)
+                print_usage
+                exit 0
+                ;;
+        a)
+                process_all_directories
+                exit 0
+                ;;
+        d)
+                process_current_directory $OPTARG
+                exit 0
+                ;;
+        \?)
+                echo "Error: Invalid operation"
+                print_usage
+                exit 0
+                ;;
+
+        esac
+done
+
+#######################################################
+#######################################################


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->
This pull request is implementation of the script as discussed in #2170 .  As per the discussions, it was desired to create a script that identifies all the exercises having extra java files and adds them to the `files.editor` keys of `config.json`.

This PR basically has created such a script that implements the feature as stated in the discussion. Thus for subsequent exercises there is no need to manually configure the additional java files in the `config.json`.

The script gives the ability to
1. Update all folders
2. Select a folder name and then the script will update the `config.json` file present in that folder _(This feature will help to update future exercises that involve multiple java files)_.

PS: _The script has been tried and tested with all the folders involving multiple java files and works flawlessly._

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
