### PR TITLE
fixes unit test in Remote Control Competition

### DIFF
--- a/exercises/concept/remote-control-competition/src/test/java/RemoteControlCarTest.java
+++ b/exercises/concept/remote-control-competition/src/test/java/RemoteControlCarTest.java
@@ -28,6 +28,6 @@ public class RemoteControlCarTest {
 
     @Test
     public void ensureCarsAreComparable() {
-        assertThat(RemoteControlCar.class).isAssignableFrom(ProductionRemoteControlCar.class);
+        assertThat(Comparable.class).isAssignableFrom(ProductionRemoteControlCar.class);
     }
 }


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->
closes #2228 

In the Remote Control Competition concept, instruction 3 specifies:

> 3. Allow the production cars to be ranked
Please implement the Comparable<T> interface in the ProductionRemoteControlCar class. ...

This PR fixes the unit test `ensureCarsAreComparable` to allign with the intention of the instruction and the name of the unit test.
<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
