### PR TITLE
need-for-speed: add a conner case test

### DIFF
--- a/exercises/concept/need-for-speed/.meta/config.json
+++ b/exercises/concept/need-for-speed/.meta/config.json
@@ -3,7 +3,8 @@
     "ystromm"
   ],
   "contributors": [
-    "mirkoperillo"
+    "mirkoperillo",
+    "nirvanaflame"
   ],
   "files": {
     "solution": [

--- a/exercises/concept/need-for-speed/src/test/java/NeedForSpeedTest.java
+++ b/exercises/concept/need-for-speed/src/test/java/NeedForSpeedTest.java
@@ -137,6 +137,22 @@ public class NeedForSpeedTest {
     }
 
     @Test
+    public void car_can_finish_with_distance_driven() {
+        int speed = 2;
+        int batteryDrain = 10;
+        var car = new NeedForSpeed(speed, batteryDrain);
+
+        car.drive();
+        car.drive();
+        car.drive();
+
+        int distance = 20;
+        var race = new RaceTrack(distance);
+
+        assertThat(race.tryFinishTrack(car)).isTrue();
+    }
+
+    @Test
     public void car_can_finish_with_car_that_just_cannot_finish() {
         int speed = 3;
         int batteryDrain = 20;


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->
The reference solution assumes that people will call drive() method to check if car can finish, but based on my observation some people calculate it eg: `battery / batteryDrain * speed`. The test will add check that formula includes driven distance.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
