### PR TITLE
Improve instructions and tests for Remote Control Competition exercise

### DIFF
--- a/exercises/concept/remote-control-competition/.docs/instructions.md
+++ b/exercises/concept/remote-control-competition/.docs/instructions.md
@@ -6,19 +6,19 @@ An experimental car has been developed and the test track needs to be adapted to
 
 In addition, production cars are beginning to have some success. The team boss is keen to maintain the competitive spirit by publishing a ranking of the production cars.
 
-## 1. Enable cars to be driven on the same test track
+## 1. Race!
 
-Please add a method to the `RemoteControlCar` interface to encapsulate the behavior of `drive()` for the two types of car.
+Please add two methods to the `RemoteControlCar` interface:
+- `drive()`, returning nothing, and
+- `getDistanceTravelled()`, returning an `int`.
 
-```java
-TestTrack.race(new ProductionRemoteControlCar());
-TestTrack.race(new ExperimentalRemoteControlCar());
-// this should execute without an exception being thrown
-```
+Then make `ProductionRemoteControlCar` and `ExperimentalRemoteControlCar` implement the `RemoteControlCar` interface. This includes implementing all methods required by the interface. 
 
-## 2. Enable the distance travelled by different models on the test track to be compared
+Each call of `.drive()` should make the car travel a certain distance:
+- a `ProductionRemoteControlCar` drives 10 units,
+- an `ExperimentalRemoteControlCar` drives 20 units.
 
-Please add a method to the `RemoteControlCar` interface to encapsulate the behavior of the `getDistanceTravelled()` method for the two types of car. Notice that the Experimental model has a different speed than the Production model. 
+The `.getDistanceTravelled()` method should return the number of units that
 
 ```java
 ProductionRemoteControlCar prod = new ProductionRemoteControlCar();
@@ -31,7 +31,14 @@ exp.getDistanceTravelled();
 // => 20
 ```
 
-## 3. Allow the production cars to be ranked
+Implement the `TestTrack.race(RemoteControlCar car)` method in which the `car`s get to `drive()`.
+```java
+TestTrack.race(new ProductionRemoteControlCar());
+TestTrack.race(new ExperimentalRemoteControlCar());
+// this should execute without an exception being thrown
+```
+
+## 2. Allow the production cars to be sorted
 
 Please implement the `Comparable<T>` interface in the `ProductionRemoteControlCar` class. The default sort order for cars should be ascending order of victories.
 
@@ -42,6 +49,7 @@ ProductionRemoteControlCar prc1 = new ProductionRemoteControlCar();
 ProductionRemoteControlCar prc2 = new ProductionRemoteControlCar();
 prc1.setNumberOfVictories(3);
 prc2.setNumberOfVictories(2);
-int rankings = TestTrack.getRankedCars(prc1, prc2);
-// => rankings[1] == prc1
+List<ProductionRemoteControlCar> rankings = TestTrack.getRankedCars(prc1, prc2);
+// => rankings.get(0) == prc2
+// => rankings.get(1) == prc1
 ```

--- a/exercises/concept/remote-control-competition/.docs/instructions.md
+++ b/exercises/concept/remote-control-competition/.docs/instructions.md
@@ -12,7 +12,8 @@ Please add two methods to the `RemoteControlCar` interface:
 - `drive()`, returning nothing, and
 - `getDistanceTravelled()`, returning an `int`.
 
-Then make `ProductionRemoteControlCar` and `ExperimentalRemoteControlCar` implement the `RemoteControlCar` interface. This includes implementing all methods required by the interface. 
+Then make `ProductionRemoteControlCar` and `ExperimentalRemoteControlCar` implement the `RemoteControlCar` interface.
+This includes implementing all methods required by the interface. 
 
 ## 2. Drive.
 
@@ -45,7 +46,8 @@ TestTrack.race(new ExperimentalRemoteControlCar());
 
 ## 4. Allow the production cars to be sorted
 
-Please implement the `Comparable<T>` interface in the `ProductionRemoteControlCar` class. The default sort order for cars should be descending order of victories.
+Please implement the `Comparable<T>` interface in the `ProductionRemoteControlCar` class.
+The default sort order for cars should be descending order of victories.
 
 Implement the static `TestTrack.getRankedCars()` to return the cars passed in, sorted in descending order of number of victories.
 

--- a/exercises/concept/remote-control-competition/.docs/instructions.md
+++ b/exercises/concept/remote-control-competition/.docs/instructions.md
@@ -6,7 +6,7 @@ An experimental car has been developed and the test track needs to be adapted to
 
 In addition, production cars are beginning to have some success. The team boss is keen to maintain the competitive spirit by publishing a ranking of the production cars.
 
-## 1. Race!
+## 1. Implement the Interface
 
 Please add two methods to the `RemoteControlCar` interface:
 - `drive()`, returning nothing, and
@@ -14,22 +14,27 @@ Please add two methods to the `RemoteControlCar` interface:
 
 Then make `ProductionRemoteControlCar` and `ExperimentalRemoteControlCar` implement the `RemoteControlCar` interface. This includes implementing all methods required by the interface. 
 
+## 2. Drive.
+
 Each call of `.drive()` should make the car travel a certain distance:
 - a `ProductionRemoteControlCar` drives 10 units,
 - an `ExperimentalRemoteControlCar` drives 20 units.
 
-The `.getDistanceTravelled()` method should return the number of units that
+The `.getDistanceTravelled()` method should return the number of units that the car has travelled in its lifetime.
 
 ```java
 ProductionRemoteControlCar prod = new ProductionRemoteControlCar();
-TestTrack.race(prod);
-ExperimentalRemoteControlCar exp = new ExperimentalRemoteControlCar();
-TestTrack.race(exp);
+prod.drive();
 prod.getDistanceTravelled();
 // => 10
+        
+ExperimentalRemoteControlCar exp = new ExperimentalRemoteControlCar();
+exp.drive();
 exp.getDistanceTravelled();
 // => 20
 ```
+
+## 3. Race!
 
 Implement the `TestTrack.race(RemoteControlCar car)` method in which the `car`s get to `drive()`.
 ```java
@@ -38,17 +43,20 @@ TestTrack.race(new ExperimentalRemoteControlCar());
 // this should execute without an exception being thrown
 ```
 
-## 2. Allow the production cars to be sorted
+## 4. Allow the production cars to be sorted
 
-Please implement the `Comparable<T>` interface in the `ProductionRemoteControlCar` class. The default sort order for cars should be ascending order of victories.
+Please implement the `Comparable<T>` interface in the `ProductionRemoteControlCar` class. The default sort order for cars should be descending order of victories.
 
-Implement the static `TestTrack.getRankedCars()` to return the cars passed in, sorted in ascending order of number of victories.
+Implement the static `TestTrack.getRankedCars()` to return the cars passed in, sorted in descending order of number of victories.
 
 ```java
 ProductionRemoteControlCar prc1 = new ProductionRemoteControlCar();
 ProductionRemoteControlCar prc2 = new ProductionRemoteControlCar();
 prc1.setNumberOfVictories(3);
 prc2.setNumberOfVictories(2);
+List<ProductionRemoteControlCar> unsortedCars = new ArrayList<>();
+unsortedCars.add(prc1);
+unsortedCars.add(prc2);
 List<ProductionRemoteControlCar> rankings = TestTrack.getRankedCars(prc1, prc2);
 // => rankings.get(0) == prc2
 // => rankings.get(1) == prc1

--- a/exercises/concept/remote-control-competition/src/test/java/RemoteControlCarTest.java
+++ b/exercises/concept/remote-control-competition/src/test/java/RemoteControlCarTest.java
@@ -1,10 +1,39 @@
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class RemoteControlCarTest {
+    @Test
+    public void productionRccIsRemoteControlCar() {
+        ProductionRemoteControlCar productionCar = new ProductionRemoteControlCar();
+        assertThat(productionCar instanceof RemoteControlCar).isTrue();
+    }
+
+    @Test
+    public void experimentalRccIsRemoteControlCar() {
+        ExperimentalRemoteControlCar experimentalCar = new ExperimentalRemoteControlCar();
+        assertThat(experimentalCar instanceof RemoteControlCar).isTrue();
+    }
+
+    @Test
+    public void productionCarTravels10UnitsPerDrive() {
+        ProductionRemoteControlCar car = new ProductionRemoteControlCar();
+        assertThat(car.getDistanceTravelled()).isEqualTo(0);
+        car.drive();
+        assertThat(car.getDistanceTravelled()).isEqualTo(10);
+    }
+
+    @Test
+    public void experimentalCarTravels20UnitsPerDrive() {
+        ExperimentalRemoteControlCar car = new ExperimentalRemoteControlCar();
+        assertThat(car.getDistanceTravelled()).isEqualTo(0);
+        car.drive();
+        assertThat(car.getDistanceTravelled()).isEqualTo(20);
+    }
+
     @Test
     public void race() {
         ProductionRemoteControlCar productionCar = new ProductionRemoteControlCar();
@@ -17,17 +46,47 @@ public class RemoteControlCarTest {
     }
 
     @Test
-    public void rankCars() {
+    public void ensureCarsAreComparable() {
+        assertThat(Comparable.class).isAssignableFrom(ProductionRemoteControlCar.class);
+    }
+
+    private static ProductionRemoteControlCar getCarWithVictories(int numberOfVictories) {
         ProductionRemoteControlCar prc1 = new ProductionRemoteControlCar();
-        ProductionRemoteControlCar prc2 = new ProductionRemoteControlCar();
-        prc1.setNumberOfVictories(3);
-        prc2.setNumberOfVictories(2);
-        List<ProductionRemoteControlCar> rankings = TestTrack.getRankedCars(prc1, prc2);
-        assertThat(rankings.get(1)).isEqualTo(prc1);
+        prc1.setNumberOfVictories(numberOfVictories);
+        return prc1;
     }
 
     @Test
-    public void ensureCarsAreComparable() {
-        assertThat(Comparable.class).isAssignableFrom(ProductionRemoteControlCar.class);
+    public void rankTwoCars() {
+        List<ProductionRemoteControlCar> unsortedCars = new ArrayList<>() {
+            {
+                add(getCarWithVictories(2));
+                add(getCarWithVictories(3));
+            }
+        };
+        List<ProductionRemoteControlCar> rankings = TestTrack.getRankedCars(unsortedCars);
+        assertThat(rankings.get(0).getNumberOfVictories()).isEqualTo(3);
+        assertThat(rankings.get(1).getNumberOfVictories()).isEqualTo(2);
+    }
+
+    @Test
+    public void rankManyCars() {
+        List<ProductionRemoteControlCar> unsortedCars = new ArrayList<>() {
+            {
+                add(getCarWithVictories(0));
+                add(getCarWithVictories(3));
+                add(getCarWithVictories(5));
+                add(getCarWithVictories(7));
+                add(getCarWithVictories(2));
+                add(getCarWithVictories(1));
+            }
+        };
+        List<ProductionRemoteControlCar> rankings = TestTrack.getRankedCars(unsortedCars);
+        assertThat(rankings.get(0).getNumberOfVictories()).isEqualTo(7);
+        assertThat(rankings.get(1).getNumberOfVictories()).isEqualTo(5);
+        assertThat(rankings.get(2).getNumberOfVictories()).isEqualTo(3);
+        assertThat(rankings.get(3).getNumberOfVictories()).isEqualTo(2);
+        assertThat(rankings.get(4).getNumberOfVictories()).isEqualTo(1);
+        assertThat(rankings.get(5).getNumberOfVictories()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
# Improve instructions and tests for Remote Control Competition exercise

Issue #2164 points out that Remote Control Competition's instructions don't match its tests very well. This PR is an attempt to improve this.

Completing each instruction subsection now increases the number of passing tests, which wasn't given previously.

## Open Questions
- I have not yet touched the tests themselves, as I feel this would be too big a change for a single (first) PR. Would you agree?
  - **Update**: Since @SleeplessByte disagreed with this assessment, I have now introduced more tests that gradually guide the student to a complete solution. 
- The way I understand the [Updating the README](https://github.com/exercism/java/blob/6ef04c4cd2ab62bca7f8d821ff18c5e81390eedd/CONTRIBUTING.md#updating-the-readmes) section of the CONTRIBUTING.md, I should be running `configlet` to maintain README files. Am I understanding correctly that this isn't really applicable here because this exercise is not part of the more generic problem specifications? :thinking: 



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
