### PR TITLE
changed tasks in squeaky-clean: change tasks to not include unicode handling #2049

### DIFF
--- a/exercises/concept/squeaky-clean/.docs/hints.md
+++ b/exercises/concept/squeaky-clean/.docs/hints.md
@@ -1,4 +1,4 @@
-# Hints
+ # Hints
 
 ## 1. Replace any spaces encountered with underscores
 

--- a/exercises/concept/squeaky-clean/.docs/instructions.md
+++ b/exercises/concept/squeaky-clean/.docs/instructions.md
@@ -31,8 +31,8 @@ SqueakyClean.clean("my\0Id");
 Modify the (_static_) `SqueakyClean.clean()` method to convert kebab-case to camelCase.
 
 ```java
-SqueakyClean.clean("à-ḃç");
-// => "àḂç"
+SqueakyClean.clean("à-ëç");
+// => "àËç"
 ```
 
 ## 4. Omit characters that are not letters
@@ -40,15 +40,8 @@ SqueakyClean.clean("à-ḃç");
 Modify the (_static_) `SqueakyClean.clean()` method to omit any characters that are not letters.
 
 ```java
-SqueakyClean.clean("a1😀2😀3😀b");
+SqueakyClean.clean("a1<2?3@b");
 // => "ab"
 ```
 
-## 5. Omit Greek lower case letters
 
-Modify the (_static_) `SqueakyClean.clean()` method to omit any Greek letters in the range 'α' to 'ω'.
-
-```java
-SqueakyClean.clean("MyΟβιεγτFinder");
-// => "MyΟFinder"
-```

--- a/exercises/concept/squeaky-clean/.meta/src/reference/java/SqueakyClean.java
+++ b/exercises/concept/squeaky-clean/.meta/src/reference/java/SqueakyClean.java
@@ -22,4 +22,4 @@ class SqueakyClean {
     private static boolean isLetter(char ch) {
         return Character.isLetter(ch) && !(ch >= 'α' && ch <= 'ω');
     }
-}
+    }

--- a/exercises/concept/squeaky-clean/src/test/java/SqueakyCleanTest.java
+++ b/exercises/concept/squeaky-clean/src/test/java/SqueakyCleanTest.java
@@ -56,6 +56,6 @@ public class SqueakyCleanTest {
 
     @Test
     public void combine_conversions() {
-        assertThat(SqueakyClean.clean("9 -abcĐ\uD83D\uDE00ω\0")).isEqualTo("_AbcĐCTRL");
+        assertThat(SqueakyClean.clean("9 -abcË\uD83D\uDE00ω\0")).isEqualTo("_AbcËCTRL");
     }
 }

--- a/exercises/concept/squeaky-clean/src/test/java/SqueakyCleanTest.java
+++ b/exercises/concept/squeaky-clean/src/test/java/SqueakyCleanTest.java
@@ -46,17 +46,12 @@ public class SqueakyCleanTest {
 
     @Test
     public void kebab_to_camel_case() {
-        assertThat(SqueakyClean.clean("à-ḃç")).isEqualTo("àḂç");
+        assertThat(SqueakyClean.clean("à-ëç")).isEqualTo("àËç");
     }
 
     @Test
     public void kebab_to_camel_case_no_letter() {
         assertThat(SqueakyClean.clean("a-1C")).isEqualTo("aC");
-    }
-
-    @Test
-    public void omit_lower_case_greek_letters() {
-        assertThat(SqueakyClean.clean("MyΟβιεγτFinder")).isEqualTo("MyΟFinder");
     }
 
     @Test


### PR DESCRIPTION
may close #2049 

Updated the current tasks and their examples to not include non-ascii characters.
Removed the final task concerning greek letters.
I didn't change the tests to include non-ascii characters too, because the tests already included non-ascii characters.
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
