### PR TITLE
Convert uses of JUnit's assertThrows to use AssertJ's assertThatExceptionOfType

### DIFF
--- a/exercises/concept/calculator-conundrum/src/test/java/CalculatorConundrumTest.java
+++ b/exercises/concept/calculator-conundrum/src/test/java/CalculatorConundrumTest.java
@@ -43,6 +43,10 @@ public class CalculatorConundrumTest {
         );
         assertThat(thrown.getCause()).isInstanceOf(ArithmeticException.class);
         assertThat(thrown).hasMessage("Divide by zero operation illegal");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingIllegalArgumentExceptionWithDetailMessage(
+                        "This is the detail message."))
+                .withMessage("This is the detail message.");
     }
 
     @Test

--- a/exercises/concept/calculator-conundrum/src/test/java/CalculatorConundrumTest.java
+++ b/exercises/concept/calculator-conundrum/src/test/java/CalculatorConundrumTest.java
@@ -43,10 +43,6 @@ public class CalculatorConundrumTest {
         );
         assertThat(thrown.getCause()).isInstanceOf(ArithmeticException.class);
         assertThat(thrown).hasMessage("Divide by zero operation illegal");
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> errorHandling.handleErrorByThrowingIllegalArgumentExceptionWithDetailMessage(
-                        "This is the detail message."))
-                .withMessage("This is the detail message.");
     }
 
     @Test

--- a/exercises/concept/squeaky-clean/.docs/hints.md
+++ b/exercises/concept/squeaky-clean/.docs/hints.md
@@ -1,4 +1,4 @@
-# Hints
+ # Hints
 
 ## 1. Replace any spaces encountered with underscores
 

--- a/exercises/concept/squeaky-clean/.docs/instructions.md
+++ b/exercises/concept/squeaky-clean/.docs/instructions.md
@@ -31,8 +31,8 @@ SqueakyClean.clean("my\0Id");
 Modify the (_static_) `SqueakyClean.clean()` method to convert kebab-case to camelCase.
 
 ```java
-SqueakyClean.clean("à-ëç");
-// => "àËç"
+SqueakyClean.clean("à-ḃç");
+// => "àḂç"
 ```
 
 ## 4. Omit characters that are not letters
@@ -40,8 +40,15 @@ SqueakyClean.clean("à-ëç");
 Modify the (_static_) `SqueakyClean.clean()` method to omit any characters that are not letters.
 
 ```java
-SqueakyClean.clean("a1<2?3@b");
+SqueakyClean.clean("a1😀2😀3😀b");
 // => "ab"
 ```
 
+## 5. Omit Greek lower case letters
 
+Modify the (_static_) `SqueakyClean.clean()` method to omit any Greek letters in the range 'α' to 'ω'.
+
+```java
+SqueakyClean.clean("MyΟβιεγτFinder");
+// => "MyΟFinder"
+```

--- a/exercises/concept/squeaky-clean/.docs/instructions.md
+++ b/exercises/concept/squeaky-clean/.docs/instructions.md
@@ -31,8 +31,8 @@ SqueakyClean.clean("my\0Id");
 Modify the (_static_) `SqueakyClean.clean()` method to convert kebab-case to camelCase.
 
 ```java
-SqueakyClean.clean("à-ḃç");
-// => "àḂç"
+SqueakyClean.clean("à-ëç");
+// => "àËç"
 ```
 
 ## 4. Omit characters that are not letters
@@ -40,15 +40,8 @@ SqueakyClean.clean("à-ḃç");
 Modify the (_static_) `SqueakyClean.clean()` method to omit any characters that are not letters.
 
 ```java
-SqueakyClean.clean("a1😀2😀3😀b");
+SqueakyClean.clean("a1<2?3@b");
 // => "ab"
 ```
 
-## 5. Omit Greek lower case letters
 
-Modify the (_static_) `SqueakyClean.clean()` method to omit any Greek letters in the range 'α' to 'ω'.
-
-```java
-SqueakyClean.clean("MyΟβιεγτFinder");
-// => "MyΟFinder"
-```

--- a/exercises/concept/squeaky-clean/.meta/src/reference/java/SqueakyClean.java
+++ b/exercises/concept/squeaky-clean/.meta/src/reference/java/SqueakyClean.java
@@ -22,4 +22,4 @@ class SqueakyClean {
     private static boolean isLetter(char ch) {
         return Character.isLetter(ch) && !(ch >= 'α' && ch <= 'ω');
     }
-}
+    }

--- a/exercises/concept/squeaky-clean/src/test/java/SqueakyCleanTest.java
+++ b/exercises/concept/squeaky-clean/src/test/java/SqueakyCleanTest.java
@@ -46,12 +46,17 @@ public class SqueakyCleanTest {
 
     @Test
     public void kebab_to_camel_case() {
-        assertThat(SqueakyClean.clean("à-ëç")).isEqualTo("àËç");
+        assertThat(SqueakyClean.clean("à-ḃç")).isEqualTo("àḂç");
     }
 
     @Test
     public void kebab_to_camel_case_no_letter() {
         assertThat(SqueakyClean.clean("a-1C")).isEqualTo("aC");
+    }
+
+    @Test
+    public void omit_lower_case_greek_letters() {
+        assertThat(SqueakyClean.clean("MyΟβιεγτFinder")).isEqualTo("MyΟFinder");
     }
 
     @Test

--- a/exercises/concept/squeaky-clean/src/test/java/SqueakyCleanTest.java
+++ b/exercises/concept/squeaky-clean/src/test/java/SqueakyCleanTest.java
@@ -46,17 +46,12 @@ public class SqueakyCleanTest {
 
     @Test
     public void kebab_to_camel_case() {
-        assertThat(SqueakyClean.clean("à-ḃç")).isEqualTo("àḂç");
+        assertThat(SqueakyClean.clean("à-ëç")).isEqualTo("àËç");
     }
 
     @Test
     public void kebab_to_camel_case_no_letter() {
         assertThat(SqueakyClean.clean("a-1C")).isEqualTo("aC");
-    }
-
-    @Test
-    public void omit_lower_case_greek_letters() {
-        assertThat(SqueakyClean.clean("MyΟβιεγτFinder")).isEqualTo("MyΟFinder");
     }
 
     @Test

--- a/exercises/practice/error-handling/src/test/java/ErrorHandlingTest.java
+++ b/exercises/practice/error-handling/src/test/java/ErrorHandlingTest.java
@@ -1,8 +1,8 @@
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -15,105 +15,83 @@ public class ErrorHandlingTest {
 
     @Test
     public void testThrowIllegalArgumentException() {
-        assertThrows(
-            IllegalArgumentException.class,
-            errorHandling::handleErrorByThrowingIllegalArgumentException);
+        assertThatExceptionOfType(Exception.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingIllegalArgumentException());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowIllegalArgumentExceptionWithDetailMessage() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> errorHandling
-                    .handleErrorByThrowingIllegalArgumentExceptionWithDetailMessage(
-                        "This is the detail message."));
-
-        assertThat(expected).hasMessage("This is the detail message.");
+       assertThatExceptionOfType(IllegalArgumentException.class)
+               .isThrownBy(() -> errorHandling.handleErrorByThrowingIllegalArgumentExceptionWithDetailMessage(
+                        "This is the detail message."))
+                .withMessage("This is the detail message.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowAnyCheckedException() {
-        Exception expected =
-            assertThrows(
-                Exception.class,
-                errorHandling::handleErrorByThrowingAnyCheckedException);
-        assertThat(expected).isNotInstanceOf(RuntimeException.class);
+        assertThatExceptionOfType(Exception.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingAnyCheckedException())
+                .isNotInstanceOf(RuntimeException.class);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowAnyCheckedExceptionWithDetailMessage() {
-        Exception expected =
-            assertThrows(
-                Exception.class,
-                () -> errorHandling
-                    .handleErrorByThrowingAnyCheckedExceptionWithDetailMessage(
-                        "This is the detail message."));
-        assertThat(expected).isNotInstanceOf(RuntimeException.class);
-        assertThat(expected).hasMessage("This is the detail message.");
+        assertThatExceptionOfType(Exception.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingAnyCheckedExceptionWithDetailMessage(
+                        "This is the detail message."))
+                .isNotInstanceOf(RuntimeException.class)
+                .withMessage("This is the detail message.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowAnyUncheckedException() {
-        assertThrows(
-            RuntimeException.class,
-            errorHandling::handleErrorByThrowingAnyUncheckedException);
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingAnyUncheckedException());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowAnyUncheckedExceptionWithDetailMessage() {
-        RuntimeException expected =
-            assertThrows(
-                RuntimeException.class,
-                () -> errorHandling
-                    .handleErrorByThrowingAnyUncheckedExceptionWithDetailMessage(
-                        "This is the detail message."));
-        assertThat(expected).hasMessage("This is the detail message.");
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingAnyUncheckedExceptionWithDetailMessage(
+                        "This is the detail message."))
+                .withMessage("This is the detail message.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowCustomCheckedException() {
-        assertThrows(
-            CustomCheckedException.class,
-            errorHandling::handleErrorByThrowingCustomCheckedException);
+        assertThatExceptionOfType(CustomCheckedException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingCustomCheckedException());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowCustomCheckedExceptionWithDetailMessage() {
-        CustomCheckedException expected =
-            assertThrows(
-                CustomCheckedException.class,
-                () -> errorHandling
-                    .handleErrorByThrowingCustomCheckedExceptionWithDetailMessage(
-                        "This is the detail message."));
-        assertThat(expected).hasMessage("This is the detail message.");
+        assertThatExceptionOfType(CustomCheckedException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingCustomCheckedExceptionWithDetailMessage(
+                        "This is the detail message."))
+                .withMessage("This is the detail message.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowCustomUncheckedException() {
-        assertThrows(
-            CustomUncheckedException.class,
-            errorHandling::handleErrorByThrowingCustomUncheckedException);
+        assertThatExceptionOfType(CustomUncheckedException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingCustomUncheckedException());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowCustomUncheckedExceptionWithDetailMessage() {
-        CustomUncheckedException expected =
-            assertThrows(
-                CustomUncheckedException.class,
-                () -> errorHandling
-                    .handleErrorByThrowingCustomUncheckedExceptionWithDetailMessage(
-                        "This is the detail message."));
-        assertThat(expected).hasMessage("This is the detail message.");
+        assertThatExceptionOfType(CustomUncheckedException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingCustomUncheckedExceptionWithDetailMessage(
+                        "This is the detail message."))
+                .withMessage("This is the detail message.");
     }
 
     @Ignore("Remove to run test")

--- a/exercises/practice/forth/src/test/java/ForthEvaluatorTest.java
+++ b/exercises/practice/forth/src/test/java/ForthEvaluatorTest.java
@@ -1,6 +1,6 @@
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -30,29 +30,18 @@ public class ForthEvaluatorTest {
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfAdditionAttemptedWithNothingOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("+")));
 
-        assertThat(expected)
-            .hasMessage(
-                "Addition requires that the stack contain at least 2 values");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("+")))
+                .withMessage("Addition requires that the stack contain at least 2 values");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfAdditionAttemptedWithOneNumberOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("1 +")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Addition requires that the stack contain at least 2 values");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("1 +")))
+                .withMessage("Addition requires that the stack contain at least 2 values");
     }
 
     @Ignore("Remove to run test")
@@ -66,29 +55,17 @@ public class ForthEvaluatorTest {
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfSubtractionAttemptedWithNothingOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("-")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Subtraction requires that the stack contain at least 2 values");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("-")))
+                .withMessage("Subtraction requires that the stack contain at least 2 values");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfSubtractionAttemptedWithOneNumberOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("1 -")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Subtraction requires that the stack contain at least 2 values");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("1 -")))
+                .withMessage("Subtraction requires that the stack contain at least 2 values");
     }
 
     @Ignore("Remove to run test")
@@ -102,29 +79,17 @@ public class ForthEvaluatorTest {
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfMultiplicationAttemptedWithNothingOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("*")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Multiplication requires that the stack contain at least 2 values");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("*")))
+                .withMessage("Multiplication requires that the stack contain at least 2 values");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfMultiplicationAttemptedWithOneNumberOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("1 *")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Multiplication requires that the stack contain at least 2 values");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("1 *")))
+                .withMessage("Multiplication requires that the stack contain at least 2 values");
     }
 
     @Ignore("Remove to run test")
@@ -146,42 +111,25 @@ public class ForthEvaluatorTest {
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfDividingByZero() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("4 0 /")));
-
-        assertThat(expected)
-            .hasMessage("Division by 0 is not allowed");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("4 0 /")))
+                .withMessage("Division by 0 is not allowed");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfDivisionAttemptedWithNothingOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("/")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Division requires that the stack contain at least 2 values");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("/")))
+                .withMessage("Division requires that the stack contain at least 2 values");
     }
 
-    @Ignore("Remove to run test")
+    //@Ignore("Remove to run test")
     @Test
     public void testErrorIfDivisionAttemptedWithOneNumberOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("1 /")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Division requires that the stack contain at least 2 values");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("1 /")))
+                .withMessage("Division requires that the stack contain at least 2 values");
     }
 
     @Ignore("Remove to run test")
@@ -219,15 +167,9 @@ public class ForthEvaluatorTest {
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfDuplicatingAttemptedWithNothingOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("dup")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Duplicating requires that the stack contain at least 1 value");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("dup")))
+                .withMessage("Duplicating requires that the stack contain at least 1 value");
     }
 
     @Ignore("Remove to run test")
@@ -249,15 +191,9 @@ public class ForthEvaluatorTest {
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfDroppingAttemptedWithNothingOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("drop")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Dropping requires that the stack contain at least 1 value");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("drop")))
+                .withMessage("Dropping requires that the stack contain at least 1 value");
     }
 
     @Ignore("Remove to run test")
@@ -279,29 +215,17 @@ public class ForthEvaluatorTest {
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfSwappingAttemptedWithNothingOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("swap")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Swapping requires that the stack contain at least 2 values");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("swap")))
+                .withMessage("Swapping requires that the stack contain at least 2 values");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfSwappingAttemptedWithOneNumberOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("1 swap")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Swapping requires that the stack contain at least 2 values");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("1 swap")))
+                .withMessage("Swapping requires that the stack contain at least 2 values");
     }
 
     @Ignore("Remove to run test")
@@ -323,29 +247,17 @@ public class ForthEvaluatorTest {
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfOveringAttemptedWithNothingOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("over")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Overing requires that the stack contain at least 2 values");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("over")))
+                .withMessage("Overing requires that the stack contain at least 2 values");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfOveringAttemptedWithOneNumberOnTheStack() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("1 over")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Overing requires that the stack contain at least 2 values");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("1 over")))
+                .withMessage("Overing requires that the stack contain at least 2 values");
     }
 
     @Ignore("Remove to run test")
@@ -407,26 +319,18 @@ public class ForthEvaluatorTest {
     @Ignore("Remove to run test")
     @Test
     public void testCannotRedefineNumbers() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList(": 1 2 ;")));
-
-        assertThat(expected).hasMessage("Cannot redefine numbers");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList(": 1 2 ;")))
+                .withMessage("Cannot redefine numbers");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testErrorIfEvaluatingAnUndefinedOperator() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> forthEvaluator
-                    .evaluateProgram(Collections.singletonList("foo")));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> forthEvaluator.evaluateProgram(Collections.singletonList("foo")))
+                .withMessage("No definition available for operator \"foo\"");
 
-        assertThat(expected)
-            .hasMessage("No definition available for operator \"foo\"");
     }
 
     @Ignore("Remove to run test")

--- a/exercises/practice/ledger/src/test/java/LedgerTest.java
+++ b/exercises/practice/ledger/src/test/java/LedgerTest.java
@@ -4,7 +4,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class LedgerTest {
 
@@ -227,13 +227,9 @@ public class LedgerTest {
         var entries = new Ledger.LedgerEntry[0];
         var locale = "it-IT";
 
-        // when
-        IllegalArgumentException illegalArgumentException = assertThrows(
-            IllegalArgumentException.class,
-            () -> ledger.format(EUR_CURRENCY, locale, entries));
-
-        // then
-        assertEquals("Invalid locale", illegalArgumentException.getMessage());
+        assertThatExceptionOfType( IllegalArgumentException.class)
+                .isThrownBy(() -> ledger.format(EUR_CURRENCY, locale, entries))
+                .withMessage("Invalid locale");
 
     }
 
@@ -244,12 +240,8 @@ public class LedgerTest {
         var entries = new Ledger.LedgerEntry[0];
         var currency = "Pieces o' Eight";
 
-        // when
-        IllegalArgumentException illegalArgumentException = assertThrows(
-            IllegalArgumentException.class,
-            () -> ledger.format(currency, US_LOCALE, entries));
-
-        // then
-        assertEquals("Invalid currency", illegalArgumentException.getMessage());
+        assertThatExceptionOfType( IllegalArgumentException.class)
+                .isThrownBy(() -> ledger.format(currency, US_LOCALE, entries))
+                .withMessage("Invalid currency");
     }
 }

--- a/exercises/practice/nth-prime/src/test/java/PrimeCalculatorTest.java
+++ b/exercises/practice/nth-prime/src/test/java/PrimeCalculatorTest.java
@@ -1,5 +1,5 @@
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -34,9 +34,8 @@ public class PrimeCalculatorTest {
     @Ignore("Remove to run test")
     @Test
     public void testUndefinedPrime() {
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> primeCalculator.nth(0));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> primeCalculator.nth(0));
     }
 
 }

--- a/exercises/practice/nucleotide-count/src/test/java/NucleotideCounterTest.java
+++ b/exercises/practice/nucleotide-count/src/test/java/NucleotideCounterTest.java
@@ -1,5 +1,5 @@
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -51,8 +51,7 @@ public class NucleotideCounterTest {
     @Ignore("Remove to run test")
     @Test
     public void testDnaStringHasInvalidNucleotides() {
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new NucleotideCounter("AGXXACT"));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new NucleotideCounter("AGXXACT"));
     }
 }

--- a/exercises/practice/ocr-numbers/src/test/java/OpticalCharacterReaderTest.java
+++ b/exercises/practice/ocr-numbers/src/test/java/OpticalCharacterReaderTest.java
@@ -1,6 +1,6 @@
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -50,38 +50,28 @@ public class OpticalCharacterReaderTest {
     @Ignore("Remove to run test")
     @Test
     public void testReaderThrowsExceptionWhenNumberOfInputLinesIsNotAMultipleOf4() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new OpticalCharacterReader()
-                    .parse(
-                        Arrays.asList(
-                            " _ ",
-                            "| |",
-                            "   ")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Number of input rows must be a positive multiple of 4");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new OpticalCharacterReader()
+                        .parse(
+                                Arrays.asList(
+                                        " _ ",
+                                        "| |",
+                                        "   ")))
+                .withMessage( "Number of input rows must be a positive multiple of 4");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testReaderThrowsExceptionWhenNumberOfInputColumnsIsNotAMultipleOf3() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new OpticalCharacterReader()
-                    .parse(
-                        Arrays.asList(
-                            "    ",
-                            "   |",
-                            "   |",
-                            "    ")));
-
-        assertThat(expected)
-            .hasMessage(
-                "Number of input columns must be a positive multiple of 3");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new OpticalCharacterReader()
+                        .parse(
+                                Arrays.asList(
+                                        "    ",
+                                        "   |",
+                                        "   |",
+                                        "    ")))
+                .withMessage( "Number of input columns must be a positive multiple of 3");
     }
 
     @Ignore("Remove to run test")

--- a/exercises/practice/palindrome-products/src/test/java/PalindromeCalculatorTest.java
+++ b/exercises/practice/palindrome-products/src/test/java/PalindromeCalculatorTest.java
@@ -1,6 +1,6 @@
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -165,27 +165,17 @@ public class PalindromeCalculatorTest {
     @Ignore("Remove to run test")
     @Test
     public void errorSmallestMinIsMoreThanMax() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> palindromeCalculator
-                    .getPalindromeProductsWithFactors(10000, 1));
-
-        assertThat(expected)
-            .hasMessage("invalid input: min must be <= max");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> palindromeCalculator.getPalindromeProductsWithFactors(10000, 1))
+                .withMessage("invalid input: min must be <= max");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void errorLargestMinIsMoreThanMax() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> palindromeCalculator
-                    .getPalindromeProductsWithFactors(2, 1));
-
-        assertThat(expected)
-            .hasMessage("invalid input: min must be <= max");
+         assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> palindromeCalculator.getPalindromeProductsWithFactors(2, 1))
+                .withMessage("invalid input: min must be <= max");
     }
 
 

--- a/exercises/practice/phone-number/src/test/java/PhoneNumberTest.java
+++ b/exercises/practice/phone-number/src/test/java/PhoneNumberTest.java
@@ -1,6 +1,6 @@
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -42,25 +42,17 @@ public class PhoneNumberTest {
     @Ignore("Remove to run test")
     @Test
     public void invalidWhen9Digits() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new PhoneNumber("123456789"));
-
-        assertThat(expected)
-            .hasMessage("incorrect number of digits");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new PhoneNumber("123456789"))
+                .withMessage("incorrect number of digits");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void invalidWhen11DigitsDoesNotStartWith1() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new PhoneNumber("22234567890"));
-
-        assertThat(expected)
-            .hasMessage("11 digits must start with 1");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new PhoneNumber("22234567890"))
+                .withMessage("11 digits must start with 1");
     }
 
     @Ignore("Remove to run test")
@@ -88,132 +80,88 @@ public class PhoneNumberTest {
     @Ignore("Remove to run test")
     @Test
     public void invalidWhenMoreThan11Digits() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new PhoneNumber("321234567890"));
-
-        assertThat(expected)
-            .hasMessage("more than 11 digits");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new PhoneNumber("321234567890"))
+                .withMessage("more than 11 digits");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void invalidWithLetters() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new PhoneNumber("123-abc-7890"));
-
-        assertThat(expected)
-            .hasMessage("letters not permitted");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new PhoneNumber("123-abc-7890"))
+                .withMessage("letters not permitted");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void invalidWithPunctuations() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new PhoneNumber("123-@:!-7890"));
-
-        assertThat(expected)
-            .hasMessage("punctuations not permitted");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new PhoneNumber("123-@:!-7890"))
+                .withMessage("punctuations not permitted");
     }
     
     @Ignore("Remove to run test")
     @Test
     public void invalidIfAreaCodeStartsWith0() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new PhoneNumber("(023) 456-7890"));
-
-        assertThat(expected)
-            .hasMessage("area code cannot start with zero");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new PhoneNumber("(023) 456-7890"))
+                .withMessage("area code cannot start with zero");
     }
     
     @Ignore("Remove to run test")
     @Test
     public void invalidIfAreaCodeStartsWith1() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new PhoneNumber("(123) 456-7890"));
-
-        assertThat(expected)
-            .hasMessage("area code cannot start with one");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new PhoneNumber("(123) 456-7890"))
+                .withMessage("area code cannot start with one");
     }
     
     @Ignore("Remove to run test")
     @Test
     public void invalidIfExchangeCodeStartsWith0() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new PhoneNumber("(223) 056-7890"));
-
-        assertThat(expected)
-            .hasMessage("exchange code cannot start with zero");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new PhoneNumber("(223) 056-7890"))
+                .withMessage("exchange code cannot start with zero");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void invalidIfExchangeCodeStartsWith1() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new PhoneNumber("(223) 156-7890"));
-
-        assertThat(expected)
-            .hasMessage("exchange code cannot start with one");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new PhoneNumber("(223) 156-7890"))
+                .withMessage("exchange code cannot start with one");
     }
     
     @Ignore("Remove to run test")
     @Test
     public void invalidIfAreaCodeStartsWith0OnValid11DigitNumber() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new PhoneNumber("1 (023) 456-7890"));
-
-        assertThat(expected)
-            .hasMessage("area code cannot start with zero");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() ->  new PhoneNumber("1 (023) 456-7890"))
+                .withMessage("area code cannot start with zero");
     }
     
     @Ignore("Remove to run test")
     @Test
     public void invalidIfAreaCodeStartsWith1OnValid11DigitNumber() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new PhoneNumber("1 (123) 456-7890"));
-
-        assertThat(expected)
-            .hasMessage("area code cannot start with one");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() ->  new PhoneNumber("1 (123) 456-7890"))
+                .withMessage("area code cannot start with one");
     }
     
     @Ignore("Remove to run test")
     @Test
     public void invalidIfExchangeCodeStartsWith0OnValid11DigitNumber() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new PhoneNumber("1 (223) 056-7890"));
-
-        assertThat(expected)
-            .hasMessage("exchange code cannot start with zero");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() ->  new PhoneNumber("1 (223) 056-7890"))
+                .withMessage("exchange code cannot start with zero");
     }
     
     @Ignore("Remove to run test")
     @Test
     public void invalidIfExchangeCodeStartsWith1OnValid11DigitNumber() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> new PhoneNumber("1 (223) 156-7890"));
-
-        assertThat(expected)
-            .hasMessage("exchange code cannot start with one");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() ->  new PhoneNumber("1 (223) 156-7890"))
+                .withMessage("exchange code cannot start with one");
     }
 }

--- a/exercises/practice/sgf-parsing/src/test/java/SgfParsingTest.java
+++ b/exercises/practice/sgf-parsing/src/test/java/SgfParsingTest.java
@@ -1,5 +1,5 @@
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.List;
 import java.util.Map;
@@ -12,27 +12,27 @@ public class SgfParsingTest {
     @Test
     public void emptyInput() {
         String input = "";
-        assertThrows("tree missing",
-            SgfParsingException.class,
-            () -> new SgfParsing().parse(input));
+        assertThatExceptionOfType(SgfParsingException.class)
+                .isThrownBy(() -> new SgfParsing().parse(input))
+                .withMessage("tree missing");
     }
 
     @Test
     @Ignore("Remove to run test")
     public void treeWithNoNodes() {
         String input = "()";
-        assertThrows("tree with no nodes",
-            SgfParsingException.class,
-            () -> new SgfParsing().parse(input));
+        assertThatExceptionOfType(SgfParsingException.class)
+                .isThrownBy(() -> new SgfParsing().parse(input))
+                .withMessage("tree with no nodes");
     }
 
     @Test
     @Ignore("Remove to run test")
     public void nodeWithoutTree() {
         String input = ";";
-        assertThrows("tree missing",
-            SgfParsingException.class,
-            () -> new SgfParsing().parse(input));
+        assertThatExceptionOfType(SgfParsingException.class)
+                .isThrownBy(() -> new SgfParsing().parse(input))
+                .withMessage("tree missing");
     }
 
     @Test
@@ -67,27 +67,27 @@ public class SgfParsingTest {
     @Ignore("Remove to run test")
     public void propertiesWithoutDelimiter() {
         String input = "(;A)";
-        assertThrows("properties without delimiter",
-            SgfParsingException.class,
-            () -> new SgfParsing().parse(input));
+         assertThatExceptionOfType(SgfParsingException.class)
+                .isThrownBy(() -> new SgfParsing().parse(input))
+                .withMessage("properties without delimiter");
     }
 
     @Test
     @Ignore("Remove to run test")
     public void allLowercaseProperty() {
         String input = "(;a[b])";
-        assertThrows("property must be in uppercase",
-            SgfParsingException.class,
-            () -> new SgfParsing().parse(input));
+        assertThatExceptionOfType(SgfParsingException.class)
+                .isThrownBy(() -> new SgfParsing().parse(input))
+                .withMessage("property must be in uppercase");
     }
 
     @Test
     @Ignore("Remove to run test")
     public void upperAndLowercaseProperty() {
         String input = "(;Aa[b])";
-        assertThrows("property must be in uppercase",
-            SgfParsingException.class,
-            () -> new SgfParsing().parse(input));
+        assertThatExceptionOfType(SgfParsingException.class)
+                .isThrownBy(() -> new SgfParsing().parse(input))
+                .withMessage("property must be in uppercase");
     }
 
     @Test

--- a/exercises/practice/simple-linked-list/src/test/java/SimpleLinkedListTest.java
+++ b/exercises/practice/simple-linked-list/src/test/java/SimpleLinkedListTest.java
@@ -1,6 +1,6 @@
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -28,9 +28,9 @@ public class SimpleLinkedListTest {
     public void popOnEmptyListWillThrow() {
         SimpleLinkedList<String> list = new SimpleLinkedList<String>();
 
-        assertThrows(
-            NoSuchElementException.class,
-            list::pop);
+
+        assertThatExceptionOfType(NoSuchElementException.class)
+                .isThrownBy(() -> list.pop());
     }
 
     @Ignore("Remove to run test")

--- a/exercises/practice/triangle/src/test/java/TriangleTest.java
+++ b/exercises/practice/triangle/src/test/java/TriangleTest.java
@@ -1,6 +1,6 @@
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.Test;
 import org.junit.Ignore;
@@ -33,9 +33,8 @@ public class TriangleTest {
     @Ignore("Remove to run test")
     @Test
     public void trianglesWithNoSizeAreIllegal() {
-        assertThrows(
-            TriangleException.class,
-            () -> new Triangle(0, 0, 0));
+        assertThatExceptionOfType(TriangleException.class)
+                .isThrownBy(() ->  new Triangle(0, 0, 0));
     }
 
     @Ignore("Remove to run test")
@@ -89,25 +88,23 @@ public class TriangleTest {
     @Ignore("Remove to run test")
     @Test
     public void firstTriangleInequalityViolation() {
-        assertThrows(
-            TriangleException.class,
-            () -> new Triangle(1, 1, 3));
+        assertThatExceptionOfType(TriangleException.class)
+                .isThrownBy(() ->  new Triangle(1, 1, 3));
+
     }
     
     @Ignore("Remove to run test")
     @Test
     public void secondTriangleInequalityViolation() {
-        assertThrows(
-            TriangleException.class,
-            () -> new Triangle(1, 3, 1));
+        assertThatExceptionOfType(TriangleException.class)
+                .isThrownBy(() -> new Triangle(1, 3, 1));
     }
     
     @Ignore("Remove to run test")
     @Test
     public void thirdTriangleInequalityViolation() {
-        assertThrows(
-            TriangleException.class,
-            () -> new Triangle(3, 1, 1));
+        assertThatExceptionOfType(TriangleException.class)
+                .isThrownBy(() -> new Triangle(3, 1, 1));
     }
 
     @Ignore("Remove to run test")
@@ -145,9 +142,8 @@ public class TriangleTest {
     @Ignore("Remove to run test")
     @Test
     public void mayNotViolateTriangleInequality() {
-        assertThrows(
-            TriangleException.class,
-            () -> new Triangle(7, 3, 2));
+        assertThatExceptionOfType(TriangleException.class)
+                .isThrownBy(() -> new Triangle(7, 3, 2));
     }
 
     @Ignore("Remove to run test")


### PR DESCRIPTION
# pull request

changed assertThrows to assertThatExceptionOfType in:

- nth-prime (PrimeCalculatorTest)
- triangle (TriangleTest)
- simple-linked-list (SimpleLinkedListTest)
- ocr-numbers (OpticalCharacterReaderTest)
- error-handling (ErrorHandlingTest)
- palindrome-products (PalindromeCalculatorTest)
- ledger (LedgerTest)
- sgf-parsing (SgfParsingTest)
- phone-number (PhoneNumberTest)
- forth (ForthEvaluatorTest)

Contributes to #2147 

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
