### PR TITLE
Update HighScoresTest.java

### DIFF
--- a/exercises/practice/high-scores/src/test/java/HighScoresTest.java
+++ b/exercises/practice/high-scores/src/test/java/HighScoresTest.java
@@ -1,4 +1,6 @@
 import java.util.Arrays;
+
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,56 +10,56 @@ public class HighScoresTest {
     @Test
     public void shouldReturnListOfScores() {
         HighScores highScores = new HighScores(Arrays.asList(30, 50, 20, 70));
-        assertThat(Arrays.asList(30, 50, 20, 70)).isEqualTo(highScores.scores());
+        assertThat(highScores.scores()).isEqualTo(Arrays.asList(30, 50, 20, 70));
     }
 
     @Test
     @Ignore("Remove to run test")
     public void shouldReturnLatestAddedScore() {
         HighScores highScores = new HighScores(Arrays.asList(100, 0, 90, 30));
-        assertThat(30).isEqualTo(highScores.latest());
+        assertThat(highScores.latest()).isEqualTo(30);
     }
 
     @Test
     @Ignore("Remove to run test")
     public void shouldReturnPersonalBest() {
         HighScores highScores = new HighScores(Arrays.asList(40, 100, 70));
-        assertThat(100).isEqualTo(highScores.personalBest());
+        assertThat(highScores.personalBest()).isEqualTo(100);
     }
 
     @Test
     @Ignore("Remove to run test")
     public void shouldReturnPersonalTopThreeFromListOfScores() {
         HighScores highScores = new HighScores(Arrays.asList(10, 30, 90, 30, 100, 20, 10, 0, 30, 40, 40, 70, 70));
-        assertThat(Arrays.asList(100, 90, 70)).isEqualTo(highScores.personalTopThree());
+        assertThat(highScores.personalTopThree()).isEqualTo(Arrays.asList(100, 90, 70));
     }
 
     @Test
     @Ignore("Remove to run test")
     public void shouldReturnPersonalTopThreeSortedHighestToLowest() {
         HighScores highScores = new HighScores(Arrays.asList(20, 10, 30));
-        assertThat(Arrays.asList(30, 20, 10)).isEqualTo(highScores.personalTopThree());
+        assertThat(highScores.personalTopThree()).isEqualTo(Arrays.asList(30, 20, 10));
     }
 
     @Test
     @Ignore("Remove to run test")
     public void shouldReturnPersonalTopThreeWhenThereIsATie() {
         HighScores highScores = new HighScores(Arrays.asList(40, 20, 40, 30));
-        assertThat(Arrays.asList(40, 40, 30)).isEqualTo(highScores.personalTopThree());
+        assertThat(highScores.personalTopThree()).isEqualTo(Arrays.asList(40, 40, 30));
     }
 
     @Test
     @Ignore("Remove to run test")
     public void shouldReturnPersonalTopWhenThereIsLessThanThreeScores() {
         HighScores highScores = new HighScores(Arrays.asList(30, 70));
-        assertThat(Arrays.asList(70, 30)).isEqualTo(highScores.personalTopThree());
+        assertThat(highScores.personalTopThree()).isEqualTo(Arrays.asList(70, 30));
     }
 
     @Test
     @Ignore("Remove to run test")
     public void shouldReturnPersonalTopWhenThereIsOnlyOneScore() {
         HighScores highScores = new HighScores(Arrays.asList(40));
-        assertThat(Arrays.asList(40)).isEqualTo(highScores.personalTopThree());
+        assertThat(highScores.personalTopThree()).isEqualTo(Arrays.asList(40));
     }
 
     @Test
@@ -65,7 +67,7 @@ public class HighScoresTest {
     public void callingLatestAfterPersonalTopThree() {
         HighScores highScores = new HighScores(Arrays.asList(70, 50, 20, 30));
         highScores.personalTopThree();
-        assertThat(30).isEqualTo(highScores.latest());
+        assertThat(highScores.latest()).isEqualTo(30);
     }
 
     @Test
@@ -73,7 +75,7 @@ public class HighScoresTest {
     public void callingScoresAfterPersonalTopThree() {
         HighScores highScores = new HighScores(Arrays.asList(30, 50, 20, 70));
         highScores.personalTopThree();
-        assertThat(Arrays.asList(30, 50, 20, 70)).isEqualTo(highScores.scores());
+        assertThat(highScores.scores()).isEqualTo(Arrays.asList(30, 50, 20, 70));
     }
 
     @Test
@@ -81,7 +83,7 @@ public class HighScoresTest {
     public void callingLatestAfterPersonalBest() {
         HighScores highScores = new HighScores(Arrays.asList(20, 70, 15, 25, 30));
         highScores.personalBest();
-        assertThat(30).isEqualTo(highScores.latest());
+        assertThat(highScores.latest()).isEqualTo(30);
     }
 
     @Test
@@ -89,6 +91,6 @@ public class HighScoresTest {
     public void callingScoresAfterPersonalBest() {
         HighScores highScores = new HighScores(Arrays.asList(20, 70, 15, 25, 30));
         highScores.personalBest();
-        assertThat(Arrays.asList(20, 70, 15, 25, 30)).isEqualTo(highScores.scores());
+        assertThat(highScores.scores()).isEqualTo(Arrays.asList(20, 70, 15, 25, 30));
     }
 }


### PR DESCRIPTION
fixed JUnit tests so that "Expected" and "Actual" are not reversed.

# pull request

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
