### PR TITLE
Fix Remote Control Competition TestTrack parameters

### DIFF
--- a/exercises/concept/remote-control-competition/src/main/java/TestTrack.java
+++ b/exercises/concept/remote-control-competition/src/main/java/TestTrack.java
@@ -6,8 +6,7 @@ public class TestTrack {
         throw new UnsupportedOperationException("Please implement the (static) TestTrack.race() method");
     }
 
-    public static List<ProductionRemoteControlCar> getRankedCars(ProductionRemoteControlCar prc1,
-                                                                 ProductionRemoteControlCar prc2) {
+    public static List<ProductionRemoteControlCar> getRankedCars(List<ProductionRemoteControlCar> prcs) {
         throw new UnsupportedOperationException("Please implement the (static) TestTrack.getRankedCars() method");
     }
 }


### PR DESCRIPTION
# pull request

This PR addresses an issue in the Remote Control Competition concept exercise where the `TestTrack.getRankedCars` method starts out with a different set of parameters than the tests pass in. It does so by making the initial method signature match what the tests expect.

Fixes #2330 



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
