### PR TITLE
Fix compile error in Remote Control Competition

### DIFF
--- a/exercises/concept/remote-control-competition/.docs/instructions.md
+++ b/exercises/concept/remote-control-competition/.docs/instructions.md
@@ -59,7 +59,7 @@ prc2.setNumberOfVictories(2);
 List<ProductionRemoteControlCar> unsortedCars = new ArrayList<>();
 unsortedCars.add(prc1);
 unsortedCars.add(prc2);
-List<ProductionRemoteControlCar> rankings = TestTrack.getRankedCars(prc1, prc2);
+List<ProductionRemoteControlCar> rankings = TestTrack.getRankedCars(unsortedCars);
 // => rankings.get(0) == prc2
 // => rankings.get(1) == prc1
 ```

--- a/exercises/concept/remote-control-competition/.meta/config.json
+++ b/exercises/concept/remote-control-competition/.meta/config.json
@@ -2,6 +2,9 @@
   "authors": [
     "mikedamay"
   ],
+  "contributors": [
+    "sanderploegsma"
+  ],
   "files": {
     "solution": [
       "src/main/java/ExperimentalRemoteControlCar.java",

--- a/exercises/concept/remote-control-competition/.meta/src/reference/java/TestTrack.java
+++ b/exercises/concept/remote-control-competition/.meta/src/reference/java/TestTrack.java
@@ -8,13 +8,9 @@ public class TestTrack {
         car.drive();
     }
 
-    public static List<ProductionRemoteControlCar> getRankedCars(ProductionRemoteControlCar prc1,
-                                                                 ProductionRemoteControlCar prc2) {
-        List<ProductionRemoteControlCar> rankings = new ArrayList<>();
-        rankings.add(prc1);
-        rankings.add(prc1);
+    public static List<ProductionRemoteControlCar> getRankedCars(List<ProductionRemoteControlCar> cars) {
+        List<ProductionRemoteControlCar> rankings = new ArrayList<>(cars);
         Collections.sort(rankings);
-
         return rankings;
     }
 }

--- a/exercises/concept/remote-control-competition/src/main/java/TestTrack.java
+++ b/exercises/concept/remote-control-competition/src/main/java/TestTrack.java
@@ -6,8 +6,7 @@ public class TestTrack {
         throw new UnsupportedOperationException("Please implement the (static) TestTrack.race() method");
     }
 
-    public static List<ProductionRemoteControlCar> getRankedCars(ProductionRemoteControlCar prc1,
-                                                                 ProductionRemoteControlCar prc2) {
+    public static List<ProductionRemoteControlCar> getRankedCars(List<ProductionRemoteControlCar> cars) {
         throw new UnsupportedOperationException("Please implement the (static) TestTrack.getRankedCars() method");
     }
 }


### PR DESCRIPTION
The default implementation of the `TestTrack` class in Remote Control Competition doesn't match the expected signature in the unit tests, causing the compilation to fail until the student updates the dummy method to match the correct signature.

It looks like this was introduced in #2283 where the unit tests were updated but the stub implementation wasn't.

Note that this is a duplicate of #2331, #2336 and #2337, but the former updates the assertions in a way that doesn't make a lot of sense, and the latter two update the stub but not the exemplar implementation nor the instructions.

Fixes #2330, #2318

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
