### PR TITLE
Fix CI silently not running exercise tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,33 +7,31 @@ on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-    - name: Set up JDK 1.17
-      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2
-      with:
-        java-version: 17
-        distribution: 'temurin'
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Compile and checkstyle with Gradle
-      run: cd exercises && ../gradlew check compileStarterSourceJava --parallel --continue --info
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+      - name: Set up JDK 1.17
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2
+        with:
+          java-version: 17
+          distribution: "temurin"
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Compile and checkstyle with Gradle
+        run: cd exercises && ../gradlew check compileStarterSourceJava --parallel --continue --info
 
   test:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
-    - name: Set up JDK 1.17
-      uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2
-      with:
-        java-version: 17
-        distribution: 'temurin'
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Journey test
-      run: bin/journey-test.sh
+      - uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3
+      - name: Set up JDK 1.17
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2
+        with:
+          java-version: 17
+          distribution: "temurin"
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Test all exercises with Gradle
+        run: cd exercises && ../gradlew test --continue

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Compile and checkstyle with Gradle
-        run: cd exercises && ../gradlew check compileStarterSourceJava --parallel --continue --info
+        run: cd exercises && ../gradlew check compileStarterSourceJava --exclude-task test --continue
 
   test:
     runs-on: ubuntu-latest

--- a/exercises/build.gradle
+++ b/exercises/build.gradle
@@ -73,7 +73,7 @@ subprojects {
 
     // When running the standard test task, make sure we prepopulate the test source set with the
     // @Ignore-stripped tests.
-    test.dependsOn(copyTestsFilteringIgnores)
+    compileTestJava.dependsOn(copyTestsFilteringIgnores)
   }
 
 

--- a/exercises/build.gradle
+++ b/exercises/build.gradle
@@ -74,10 +74,14 @@ subprojects {
     // When running the standard test task, make sure we prepopulate the test source set with the
     // @Ignore-stripped tests.
     compileTestJava.dependsOn(copyTestsFilteringIgnores)
+
+    // Enable test logging when running test task from the console
+    test {
+      testLogging {
+        events "passed", "skipped", "failed"
+      }
+    }
   }
-
-
-
 }
 
 def logCompileTaskSourcePath(Project project, String taskName) {

--- a/exercises/concept/calculator-conundrum/.meta/src/reference/java/IllegalOperationException.java
+++ b/exercises/concept/calculator-conundrum/.meta/src/reference/java/IllegalOperationException.java
@@ -1,0 +1,11 @@
+public class IllegalOperationException extends RuntimeException {
+
+    public IllegalOperationException(String errorMessage) {
+        super(errorMessage);
+    }
+
+    public IllegalOperationException(String errorMessage, Throwable cause) {
+        super(errorMessage, cause);
+    }
+}
+

--- a/exercises/concept/calculator-conundrum/.meta/src/reference/java/IllegalOperationException.java
+++ b/exercises/concept/calculator-conundrum/.meta/src/reference/java/IllegalOperationException.java
@@ -1,11 +1,1 @@
-public class IllegalOperationException extends RuntimeException {
-
-    public IllegalOperationException(String errorMessage) {
-        super(errorMessage);
-    }
-
-    public IllegalOperationException(String errorMessage, Throwable cause) {
-        super(errorMessage, cause);
-    }
-}
-
+../../../../src/main/java/IllegalOperationException.java

--- a/exercises/concept/calculator-conundrum/.meta/src/reference/java/SimpleOperation.java
+++ b/exercises/concept/calculator-conundrum/.meta/src/reference/java/SimpleOperation.java
@@ -1,0 +1,17 @@
+class SimpleOperation {
+    public static int division(int operand1, int operand2)
+    {
+        return operand1 / operand2;
+    }
+
+    public static int multiplication(int operand1, int operand2)
+    {
+        return operand1 * operand2;
+    }
+
+    public static int addition(int operand1, int operand2)
+    {
+        return operand1 + operand2;
+    }
+}
+

--- a/exercises/concept/calculator-conundrum/.meta/src/reference/java/SimpleOperation.java
+++ b/exercises/concept/calculator-conundrum/.meta/src/reference/java/SimpleOperation.java
@@ -1,16 +1,13 @@
 class SimpleOperation {
-    public static int division(int operand1, int operand2)
-    {
+    public static int division(int operand1, int operand2) {
         return operand1 / operand2;
     }
 
-    public static int multiplication(int operand1, int operand2)
-    {
+    public static int multiplication(int operand1, int operand2) {
         return operand1 * operand2;
     }
 
-    public static int addition(int operand1, int operand2)
-    {
+    public static int addition(int operand1, int operand2) {
         return operand1 + operand2;
     }
 }

--- a/exercises/concept/calculator-conundrum/.meta/src/reference/java/SimpleOperation.java
+++ b/exercises/concept/calculator-conundrum/.meta/src/reference/java/SimpleOperation.java
@@ -1,14 +1,1 @@
-class SimpleOperation {
-    public static int division(int operand1, int operand2) {
-        return operand1 / operand2;
-    }
-
-    public static int multiplication(int operand1, int operand2) {
-        return operand1 * operand2;
-    }
-
-    public static int addition(int operand1, int operand2) {
-        return operand1 + operand2;
-    }
-}
-
+../../../../src/main/java/SimpleOperation.java

--- a/exercises/concept/calculator-conundrum/src/main/java/SimpleOperation.java
+++ b/exercises/concept/calculator-conundrum/src/main/java/SimpleOperation.java
@@ -1,16 +1,13 @@
 class SimpleOperation {
-    public static int division(int operand1, int operand2)
-    {
+    public static int division(int operand1, int operand2) {
         return operand1 / operand2;
     }
 
-    public static int multiplication(int operand1, int operand2)
-    {
+    public static int multiplication(int operand1, int operand2) {
         return operand1 * operand2;
     }
 
-    public static int addition(int operand1, int operand2)
-    {
+    public static int addition(int operand1, int operand2) {
         return operand1 + operand2;
     }
 }

--- a/exercises/concept/remote-control-competition/.meta/src/reference/java/ProductionRemoteControlCar.java
+++ b/exercises/concept/remote-control-competition/.meta/src/reference/java/ProductionRemoteControlCar.java
@@ -4,7 +4,7 @@ class ProductionRemoteControlCar implements RemoteControlCar, Comparable<Product
     private int numberOfVictories;
 
     public int compareTo(ProductionRemoteControlCar other) {
-        return Integer.compare(this.getNumberOfVictories(), other.getNumberOfVictories());
+        return Integer.compare(other.getNumberOfVictories(), this.getNumberOfVictories());
     }
 
     public void drive() {

--- a/exercises/concept/wizards-and-warriors/.meta/src/reference/java/Fighter.java
+++ b/exercises/concept/wizards-and-warriors/.meta/src/reference/java/Fighter.java
@@ -35,6 +35,11 @@ class Wizard extends Fighter {
     boolean isSpellPrepared = false;
 
     @Override
+    public String toString() {
+        return "Fighter is a Wizard";
+    }
+
+    @Override
     boolean isVulnerable() {
         if (isSpellPrepared == false) {
             return true;

--- a/exercises/practice/pythagorean-triplet/.meta/src/reference/java/PythagoreanTriplet.java
+++ b/exercises/practice/pythagorean-triplet/.meta/src/reference/java/PythagoreanTriplet.java
@@ -1,7 +1,6 @@
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 public class PythagoreanTriplet {
 
@@ -35,8 +34,9 @@ public class PythagoreanTriplet {
         }
 
         public List<PythagoreanTriplet> build() {
-            if (limit == 0)
+            if (limit == 0) {
                 limit = sum / 2;
+            }
             int start = (int) Math.sqrt(sum);
             for (int a = start; a <= limit; a++) {
                 for (int b = a; b <= limit; b++) {

--- a/exercises/practice/pythagorean-triplet/.meta/src/reference/java/PythagoreanTriplet.java
+++ b/exercises/practice/pythagorean-triplet/.meta/src/reference/java/PythagoreanTriplet.java
@@ -1,4 +1,3 @@
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -6,9 +5,9 @@ import java.util.stream.Collectors;
 
 public class PythagoreanTriplet {
 
-    private int a;
-    private int b;
-    private int c;
+    private final int a;
+    private final int b;
+    private final int c;
 
     public PythagoreanTriplet(final int a, final int b, final int c) {
         this.a = a;
@@ -16,20 +15,40 @@ public class PythagoreanTriplet {
         this.c = c;
     }
 
-    public static TripletListBuilder makeTripletsList() {
-        return new TripletListBuilder();
+    public static PythagoreanTripletBuilder makeTripletsList() {
+        return new PythagoreanTripletBuilder();
     }
 
-    public int calculateSum() {
-        return this.a + this.b + this.c;
-    }
+    public static class PythagoreanTripletBuilder {
+        private final List<PythagoreanTriplet> triplets = new ArrayList<>();
+        private int limit = 0;
+        private int sum = 0;
 
-    public long calculateProduct() {
-        return this.a * this.b * this.c;
-    }
+        public PythagoreanTripletBuilder withFactorsLessThanOrEqualTo(int limit) {
+            this.limit = limit;
+            return this;
+        }
 
-    public boolean isPythagorean() {
-        return this.a * this.a + this.b * this.b == this.c * this.c;
+        public PythagoreanTripletBuilder thatSumTo(int sum) {
+            this.sum = sum;
+            return this;
+        }
+
+        public List<PythagoreanTriplet> build() {
+            if (limit == 0)
+                limit = sum / 2;
+            int start = (int) Math.sqrt(sum);
+            for (int a = start; a <= limit; a++) {
+                for (int b = a; b <= limit; b++) {
+                    double c = Math.sqrt(a * a + b * b);
+                    if (c % 1 == 0 && c <= limit && a + b + c == sum) {
+                        triplets.add(new PythagoreanTriplet(a, b, (int) c));
+                    }
+                }
+            }
+
+            return triplets;
+        }
     }
 
     @Override
@@ -39,79 +58,10 @@ public class PythagoreanTriplet {
 
     @Override
     public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-        final PythagoreanTriplet other = (PythagoreanTriplet) obj;
-        if (this.a != other.a) {
-            return false;
-        }
-        if (this.b != other.b) {
-            return false;
-        }
-        if (this.c != other.c) {
-            return false;
-        }
-        return true;
-    }
-
-    public static class TripletListBuilder {
-
-        private static final int MAX_FACTOR_DEFAULT_VALUE = 0;
-        private static final int SUM_DEFAULT_VALUE = -1;
-
-        private int maxFactor = MAX_FACTOR_DEFAULT_VALUE;
-        private int minFactor = 1;
-        private int sum = SUM_DEFAULT_VALUE;
-
-        public TripletListBuilder() {
+        if (obj instanceof PythagoreanTriplet other) {
+            return this.hashCode() == other.hashCode();
         }
 
-        public TripletListBuilder withFactorsLessThanOrEqualTo(
-                final int maxFactor) {
-            this.maxFactor = maxFactor;
-            return this;
-        }
-
-        public TripletListBuilder withFactorsGreaterThanOrEqualTo(
-                final int minFactor) {
-            this.minFactor = minFactor;
-            return this;
-        }
-
-        public TripletListBuilder thatSumTo(final int sum) {
-            this.sum = sum;
-            return this;
-        }
-
-        public List<PythagoreanTriplet> build() {
-            List<PythagoreanTriplet> triplets = new ArrayList<>();
-            if (this.maxFactor == MAX_FACTOR_DEFAULT_VALUE) {
-                return triplets;
-            }
-            double sqrt;
-            int floor;
-            for (int n = minFactor; n < maxFactor; n++) {
-                for (int m = n + 1; m < maxFactor; m++) {
-                    sqrt = Math.sqrt(n * n + m * m);
-                    floor = (int) Math.floor(sqrt);
-                    if (sqrt == floor) {
-                        triplets.add(new PythagoreanTriplet(n, m, floor));
-                    }
-                }
-            }
-            if (sum != SUM_DEFAULT_VALUE) {
-                return triplets.stream()
-                        .filter(t -> t.calculateSum() == sum)
-                        .collect(Collectors.toList());
-            }
-            return triplets;
-        }
+        return false;
     }
 }

--- a/exercises/practice/sgf-parsing/.meta/src/reference/java/SgfParsing.java
+++ b/exercises/practice/sgf-parsing/.meta/src/reference/java/SgfParsing.java
@@ -107,9 +107,6 @@ public class SgfParsing {
         while (character == '\\') {
             character = input.charAt(++index);
         }
-        if (character == '\t') {
-            character = ' ';
-        }
         buffer.append(character);
         return index;
     }

--- a/exercises/settings.gradle
+++ b/exercises/settings.gradle
@@ -15,6 +15,7 @@ include 'concept:salary-calculator'
 include 'concept:remote-control-competition'
 include 'concept:football-match-reports'
 include 'concept:wizards-and-warriors'
+include 'concept:calculator-conundrum'
 
 // practice exercises
 include 'practice:accumulate'


### PR DESCRIPTION
I was investigating why the bug in #2330 didn't cause a failure in CI, and apparently the exercises aren't tested at all due to an error in the test script!

```
>>> solve_all_exercises(exercism_exercises_dir="/home/runner/work/java/java/build/exercism")
+ solve_all_exercises /home/runner/work/java/java/build/exercism
+ local exercism_exercises_dir=/home/runner/work/java/java/build/exercism
+ echo '>>> solve_all_exercises(exercism_exercises_dir="/home/runner/work/java/java/build/exercism")'
++ pwd
+ local track_root=/home/runner/work/java/java
++ jq '.exercises[].slug + " "' --join-output
++ cat config.json
jq: error (at <stdin>:2069): Cannot index array with string "slug"
```

It appears there are multiple things wrong with this script:
- It ignores errors from commands in a pipe, causing it to swallow the failure
- Apparently the `bin/journey-test.sh` script wasn't updated to parse `config.json` correctly after the addition of concept exercises, so none of the tests even ran

After some fiddling with the script I noticed that the `exercises/build.gradle` script is configured to do exactly what is required in CI: it pre-processes the test files to remove any `@Ignore` tags and then runs the tests against the exemplar/example implementation. So I figured the easiest way to fix the CI pipeline is to just run `gradle test`.

Note that because the CI pipeline has probably been broken for a while, there were a few exercises of which the example implementation doesn't pass their own test cases. I fixed the easy ones, but the following practice exercises seem to require a bit more attention to get their tests passing:

- Pythagorean Triplet
- SGF Parsing



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
