### PR TITLE
Update phone number exercise

### DIFF
--- a/exercises/practice/phone-number/.docs/instructions.append.md
+++ b/exercises/practice/phone-number/.docs/instructions.append.md
@@ -1,9 +1,8 @@
 # Instructions append
 
-Since this exercise has difficulty 5 it doesn't come with any starter implementation.
-This is so that you get to practice creating classes and methods which is an important part of programming in Java.
-It does mean that when you first try to run the tests, they won't compile.
-They will give you an error similar to:
+This exercise doesn't come with any starter implementation.  This is so that you get to practice creating classes and
+methods, which is an important part of programming in Java.  That means that when you first try to run the tests, they
+won't compile.  They will give you an error similar to:
 ```
  path-to-exercism-dir\exercism\java\name-of-exercise\src\test\java\ExerciseClassNameTest.java:14: error: cannot find symbol
         ExerciseClassName exerciseClassName = new ExerciseClassName();
@@ -11,12 +10,11 @@ They will give you an error similar to:
  symbol:   class ExerciseClassName
  location: class ExerciseClassNameTest
 ```
-This error occurs because the test refers to a class that hasn't been created yet (`ExerciseClassName`).
-To resolve the error you need to add a file matching the class name in the error to the `src/main/java` directory.
-For example, for the error above you would add a file called `ExerciseClassName.java`.
+This error occurs because the test refers to a class that hasn't been created yet (`ExerciseClassName`).  To resolve the
+error you need to add a file matching the class name in the error to the `src/main/java` directory.  For example, for
+the error above you would add a file called `ExerciseClassName.java`.
 
-When you try to run the tests again you will get slightly different errors.
-You might get an error similar to:
+When you try to run the tests again you will get slightly different errors.  You might get an error similar to:
 ```
   constructor ExerciseClassName in class ExerciseClassName cannot be applied to given types;
         ExerciseClassName exerciseClassName = new ExerciseClassName("some argument");
@@ -25,11 +23,11 @@ You might get an error similar to:
   found: String
   reason: actual and formal argument lists differ in length
 ```
-This error means that you need to add a [constructor](https://docs.oracle.com/javase/tutorial/java/javaOO/constructors.html) to your new class.
-If you don't add a constructor, Java will add a default one for you.
-This default constructor takes no arguments.
-So if the tests expect your class to have a constructor which takes arguments, then you need to create this constructor yourself.
-In the example above you could add:
+This error means that you need to add a
+[constructor](https://docs.oracle.com/javase/tutorial/java/javaOO/constructors.html) to your new class.  If you don't
+add a constructor, Java will add a default one for you.  This default constructor takes no arguments.  So if the tests
+expect your class to have a constructor which takes arguments, then you need to create this constructor yourself.  In
+the example above you could add:
 ```
 ExerciseClassName(String input) {
 
@@ -45,16 +43,15 @@ You might also get an error similar to:
   symbol:   method someMethod()
   location: variable exerciseClassName of type ExerciseClassName
 ```
-This error means that you need to add a method called `someMethod` to your new class.
-In the example above you would add:
+This error means that you need to add a method called `someMethod` to your new class.  In the example above you would
+add:
 ```
 String someMethod() {
   return "";
 }
 ```
-Make sure the return type matches what the test is expecting.
-You can find out which return type it should have by looking at the type of object it's being compared to in the tests.
-Or you could set your method to return some random type (e.g. `void`), and run the tests again.
-The new error should tell you which type it's expecting.
+Make sure the return type matches what the test is expecting.  You can find out which return type it should have by
+looking at the type of object it's being compared to in the tests.  Or you could set your method to return some random
+type (e.g. `void`), and run the tests again.  The new error should tell you which type it's expecting.
 
 After having resolved these errors you should be ready to start making the tests pass!

--- a/exercises/practice/phone-number/src/test/java/PhoneNumberTest.java
+++ b/exercises/practice/phone-number/src/test/java/PhoneNumberTest.java
@@ -10,7 +10,7 @@ public class PhoneNumberTest {
     @Test
     public void cleansTheNumber() {
         String expectedNumber = "2234567890";
-        String actualNumber = new PhoneNumber("(223) 456-7890").getNumber();
+        String actualNumber = new PhoneNumber("(223) 456-7890").toString();
 
         assertEquals(
                 expectedNumber, actualNumber
@@ -21,7 +21,7 @@ public class PhoneNumberTest {
     @Test
     public void cleansNumbersWithDots() {
         String expectedNumber = "2234567890";
-        String actualNumber = new PhoneNumber("223.456.7890").getNumber();
+        String actualNumber = new PhoneNumber("223.456.7890").toString();
 
         assertEquals(
                 expectedNumber, actualNumber
@@ -32,7 +32,7 @@ public class PhoneNumberTest {
     @Test
     public void cleansNumbersWithMultipleSpaces() {
         String expectedNumber = "2234567890";
-        String actualNumber = new PhoneNumber("223 456   7890   ").getNumber();
+        String actualNumber = new PhoneNumber("223 456   7890   ").toString();
 
         assertEquals(
                 expectedNumber, actualNumber
@@ -67,7 +67,7 @@ public class PhoneNumberTest {
     @Test
     public void validWhen11DigitsAndStartingWith1() {
         String expectedNumber = "2234567890";
-        String actualNumber = new PhoneNumber("12234567890").getNumber();
+        String actualNumber = new PhoneNumber("12234567890").toString();
 
         assertEquals(
                 expectedNumber, actualNumber
@@ -78,7 +78,7 @@ public class PhoneNumberTest {
     @Test
     public void validWhen11DigitsAndStartingWith1EvenWithPunctuation() {
         String expectedNumber = "2234567890";
-        String actualNumber = new PhoneNumber("+1 (223) 456-7890").getNumber();
+        String actualNumber = new PhoneNumber("+1 (223) 456-7890").toString();
 
         assertEquals(
                 expectedNumber, actualNumber


### PR DESCRIPTION
# pull request

The main change here is to rename the `.getNumber()` method implied by the tests to be called `.toString()` instead.

A phone number either warrants its own type or it does not. If it does, then what this method is returning is the canonical string representation of a given phone number, and in Java we call methods that do that `.toString()`.

(If a phone number does _not_ warrant its own type, then this exercise should be significantly restructured to use a `PhoneNumberFormatter` class that works with Strings, or some such, but that doesn't really seem necessary and would be a much larger change.)

The other minor changes are to clean up the formatting of the description a bit, and remove a reference to the exercise being "difficulty 5", which to the best of my knowledge does not mean anything in the context of Exercism.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
