### PR TITLE
Remove '(static)' in default exception messages for non-static method…

### DIFF
--- a/exercises/concept/elons-toy-car/src/main/java/ElonsToyCar.java
+++ b/exercises/concept/elons-toy-car/src/main/java/ElonsToyCar.java
@@ -4,14 +4,14 @@ public class ElonsToyCar {
     }
 
     public String distanceDisplay() {
-        throw new UnsupportedOperationException("Please implement the (static) RemoteControlCar.distanceDisplay()  method");
+        throw new UnsupportedOperationException("Please implement the RemoteControlCar.distanceDisplay()  method");
     }
 
     public String batteryDisplay() {
-        throw new UnsupportedOperationException("Please implement the (static) RemoteControlCar.batteryDisplay()  method");
+        throw new UnsupportedOperationException("Please implement the RemoteControlCar.batteryDisplay()  method");
     }
 
     public void drive() {
-        throw new UnsupportedOperationException("Please implement the (static) RemoteControlCar.drive()  method");
+        throw new UnsupportedOperationException("Please implement the RemoteControlCar.drive()  method");
     }
 }


### PR DESCRIPTION
…s, as represented in ElonsToyCarTest.java.

# pull request

<!-- Your content goes here: -->

This pull request revises the stub's exception messages to match behavior in the test file. Three methods were referred to as "static" but are instance methods in the test file.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
