### PR TITLE
Deprecate `beer-song` and `diffie-hellman`

### DIFF
--- a/config.json
+++ b/config.json
@@ -680,14 +680,10 @@
         "slug": "beer-song",
         "name": "Beer Song",
         "uuid": "56943095-de76-40bf-b42b-fa3e70f8df5e",
-        "practices": [
-          "strings"
-        ],
-        "prerequisites": [
-          "for-loops",
-          "classes"
-        ],
-        "difficulty": 6
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6,
+        "status": "deprecated"
       },
       {
         "slug": "food-chain",

--- a/config.json
+++ b/config.json
@@ -1667,12 +1667,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "algorithms",
-          "integers",
-          "math",
-          "transforming"
-        ]
+        "status": "deprecated"
       },
       {
         "slug": "hangman",


### PR DESCRIPTION
Both practice exercises have been deprecated in the problem specifications. I opened #2357 to get the replacement of `beer-song` added.

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
