### PR TITLE
Use AssertJ for exceptions

### DIFF
--- a/exercises/practice/error-handling/src/test/java/ErrorHandlingTest.java
+++ b/exercises/practice/error-handling/src/test/java/ErrorHandlingTest.java
@@ -1,7 +1,4 @@
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -97,11 +94,11 @@ public class ErrorHandlingTest {
     @Test
     public void testReturnOptionalInstance() {
         Optional<Integer> successfulResult = errorHandling.handleErrorByReturningOptionalInstance("1");
-        assertTrue(successfulResult.isPresent());
-        assertEquals(1, (int) successfulResult.get());
+        assertThat(successfulResult).isPresent().hasValue(1);
 
         Optional<Integer> failureResult = errorHandling.handleErrorByReturningOptionalInstance("a");
-        assertFalse(failureResult.isPresent());
+        assertThat(failureResult).isNotPresent();
+
     }
 
 }

--- a/exercises/practice/error-handling/src/test/java/ErrorHandlingTest.java
+++ b/exercises/practice/error-handling/src/test/java/ErrorHandlingTest.java
@@ -14,8 +14,8 @@ public class ErrorHandlingTest {
 
     @Test
     public void testThrowIllegalArgumentException() {
-        assertThatExceptionOfType(Exception.class).
-                isThrownBy(() -> errorHandling.handleErrorByThrowingIllegalArgumentException());
+        assertThatExceptionOfType(Exception.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingIllegalArgumentException());
     }
 
     @Ignore("Remove to run test")

--- a/exercises/practice/error-handling/src/test/java/ErrorHandlingTest.java
+++ b/exercises/practice/error-handling/src/test/java/ErrorHandlingTest.java
@@ -1,8 +1,7 @@
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -15,105 +14,83 @@ public class ErrorHandlingTest {
 
     @Test
     public void testThrowIllegalArgumentException() {
-        assertThrows(
-            IllegalArgumentException.class,
-            errorHandling::handleErrorByThrowingIllegalArgumentException);
+        assertThatExceptionOfType(Exception.class).
+                isThrownBy(() -> errorHandling.handleErrorByThrowingIllegalArgumentException());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowIllegalArgumentExceptionWithDetailMessage() {
-        IllegalArgumentException expected =
-            assertThrows(
-                IllegalArgumentException.class,
-                () -> errorHandling
-                    .handleErrorByThrowingIllegalArgumentExceptionWithDetailMessage(
-                        "This is the detail message."));
-
-        assertThat(expected).hasMessage("This is the detail message.");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingIllegalArgumentExceptionWithDetailMessage(
+                        "This is the detail message."))
+                .withMessage("This is the detail message.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowAnyCheckedException() {
-        Exception expected =
-            assertThrows(
-                Exception.class,
-                errorHandling::handleErrorByThrowingAnyCheckedException);
-        assertThat(expected).isNotInstanceOf(RuntimeException.class);
+        assertThatExceptionOfType(Exception.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingAnyCheckedException())
+                .isNotInstanceOf(RuntimeException.class);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowAnyCheckedExceptionWithDetailMessage() {
-        Exception expected =
-            assertThrows(
-                Exception.class,
-                () -> errorHandling
-                    .handleErrorByThrowingAnyCheckedExceptionWithDetailMessage(
-                        "This is the detail message."));
-        assertThat(expected).isNotInstanceOf(RuntimeException.class);
-        assertThat(expected).hasMessage("This is the detail message.");
+        assertThatExceptionOfType(Exception.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingAnyCheckedExceptionWithDetailMessage(
+                        "This is the detail message."))
+                .isNotInstanceOf(RuntimeException.class)
+                .withMessage("This is the detail message.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowAnyUncheckedException() {
-        assertThrows(
-            RuntimeException.class,
-            errorHandling::handleErrorByThrowingAnyUncheckedException);
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingAnyUncheckedException());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowAnyUncheckedExceptionWithDetailMessage() {
-        RuntimeException expected =
-            assertThrows(
-                RuntimeException.class,
-                () -> errorHandling
-                    .handleErrorByThrowingAnyUncheckedExceptionWithDetailMessage(
-                        "This is the detail message."));
-        assertThat(expected).hasMessage("This is the detail message.");
+        assertThatExceptionOfType(RuntimeException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingAnyUncheckedExceptionWithDetailMessage(
+                        "This is the detail message."))
+                .withMessage("This is the detail message.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowCustomCheckedException() {
-        assertThrows(
-            CustomCheckedException.class,
-            errorHandling::handleErrorByThrowingCustomCheckedException);
+        assertThatExceptionOfType(CustomCheckedException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingCustomCheckedException());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowCustomCheckedExceptionWithDetailMessage() {
-        CustomCheckedException expected =
-            assertThrows(
-                CustomCheckedException.class,
-                () -> errorHandling
-                    .handleErrorByThrowingCustomCheckedExceptionWithDetailMessage(
-                        "This is the detail message."));
-        assertThat(expected).hasMessage("This is the detail message.");
+        assertThatExceptionOfType(CustomCheckedException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingCustomCheckedExceptionWithDetailMessage(
+                        "This is the detail message."))
+                .withMessage("This is the detail message.");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowCustomUncheckedException() {
-        assertThrows(
-            CustomUncheckedException.class,
-            errorHandling::handleErrorByThrowingCustomUncheckedException);
+        assertThatExceptionOfType(CustomUncheckedException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingCustomUncheckedException());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrowCustomUncheckedExceptionWithDetailMessage() {
-        CustomUncheckedException expected =
-            assertThrows(
-                CustomUncheckedException.class,
-                () -> errorHandling
-                    .handleErrorByThrowingCustomUncheckedExceptionWithDetailMessage(
-                        "This is the detail message."));
-        assertThat(expected).hasMessage("This is the detail message.");
+        assertThatExceptionOfType(CustomUncheckedException.class)
+                .isThrownBy(() -> errorHandling.handleErrorByThrowingCustomUncheckedExceptionWithDetailMessage(
+                        "This is the detail message."))
+                .withMessage("This is the detail message.");
     }
 
     @Ignore("Remove to run test")


### PR DESCRIPTION
# pull request

The changes of this PR make the  `ErrorHandlingTest` exercise use AssertJ in the tests. 

This is related to #2147. As this is my first pull request for Exercism, I only changed the assertions for a single test case. If this merge request is fine, I'd like to also update the missing exercises as well.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
