### PR TITLE
Updates tests to use assertThat instead of assertEquals

### DIFF
--- a/exercises/practice/complex-numbers/src/test/java/ComplexNumberTest.java
+++ b/exercises/practice/complex-numbers/src/test/java/ComplexNumberTest.java
@@ -1,7 +1,8 @@
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.withPrecision;
 
 public class ComplexNumberTest {
 
@@ -12,7 +13,7 @@ public class ComplexNumberTest {
     private void assertDoublesEqual(double d1, double d2, String numberPart) {
         String errorMessage = "While testing " + numberPart + " part of number,";
 
-        assertEquals(errorMessage, d1, d2, DOUBLE_EQUALITY_TOLERANCE);
+        assertThat(d1).withFailMessage(errorMessage).isCloseTo(d2, withPrecision(DOUBLE_EQUALITY_TOLERANCE));
     }
 
     private void assertComplexNumbersEqual(ComplexNumber c1, ComplexNumber c2) {

--- a/exercises/practice/etl/src/test/java/EtlTest.java
+++ b/exercises/practice/etl/src/test/java/EtlTest.java
@@ -1,9 +1,13 @@
-import org.junit.Test;
 import org.junit.Ignore;
+import org.junit.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class EtlTest {
@@ -25,7 +29,7 @@ public class EtlTest {
         };
         expected = Collections.unmodifiableMap(expected);
 
-        assertEquals(expected, etl.transform(old));
+        assertThat(etl.transform(old)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -49,7 +53,7 @@ public class EtlTest {
         };
         expected = Collections.unmodifiableMap(expected);
 
-        assertEquals(expected, etl.transform(old));
+        assertThat(etl.transform(old)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -73,7 +77,7 @@ public class EtlTest {
         };
         expected = Collections.unmodifiableMap(expected);
 
-        assertEquals(expected, etl.transform(old));
+        assertThat(etl.transform(old)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -124,6 +128,6 @@ public class EtlTest {
         };
         expected = Collections.unmodifiableMap(expected);
 
-        assertEquals(expected, etl.transform(old));
+        assertThat(etl.transform(old)).isEqualTo(expected);
     }
 }

--- a/exercises/practice/flatten-array/src/test/java/FlattenerTest.java
+++ b/exercises/practice/flatten-array/src/test/java/FlattenerTest.java
@@ -1,11 +1,10 @@
 import org.junit.Before;
-import org.junit.Test;
 import org.junit.Ignore;
+import org.junit.Test;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FlattenerTest {
 
@@ -18,67 +17,63 @@ public class FlattenerTest {
 
     @Test
     public void testFlatListIsPreserved() {
-        assertEquals(asList(0, '1', "two"), flattener.flatten(asList(0, '1', "two")));
+        assertThat(flattener.flatten(asList(0, '1', "two")))
+            .containsExactly(0, '1', "two");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testASingleLevelOfNestingWithNoNulls() {
-        assertEquals(
-            asList(1, '2', 3, 4, 5, "six", "7", 8),
-            flattener.flatten(asList(1, asList('2', 3, 4, 5, "six", "7"), 8)));
+        assertThat(flattener.flatten(asList(1, asList('2', 3, 4, 5, "six", "7"), 8)))
+            .containsExactly(1, '2', 3, 4, 5, "six", "7", 8);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testFiveLevelsOfNestingWithNoNulls() {
-        assertEquals(
-            asList(0, '2', 2, "three", '8', 100, "four", 50, "-2"),
-            flattener.flatten(asList(0, 
+        assertThat(flattener.flatten(asList(0,
                               '2', 
                               asList(asList(2, "three"), 
                                      '8', 
                                      100, 
                                      "four",
-                                     singletonList(singletonList(singletonList(50)))), "-2")));
+                                     singletonList(singletonList(singletonList(50)))), "-2")))
+            .containsExactly(0, '2', 2, "three", '8', 100, "four", 50, "-2");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSixLevelsOfNestingWithNoNulls() {
-        assertEquals(
-            asList("one", '2', 3, '4', 5, "six", 7, "8"),
-            flattener.flatten(asList("one", 
-                                     asList('2', 
+        assertThat(flattener.flatten(asList("one",
+                                     asList('2',
                                             singletonList(singletonList(3)),
-                                                          asList('4', 
-                                                                 singletonList(singletonList(5))), "six", 7), "8")));
+                                                          asList('4',
+                                                                 singletonList(singletonList(5))), "six", 7), "8")))
+            .containsExactly("one", '2', 3, '4', 5, "six", 7, "8");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSixLevelsOfNestingWithNulls() {
-        assertEquals(
-            asList("0", 2, "two", '3', "8", "one hundred", "negative two"),
-            flattener.flatten(asList("0",
+        assertThat(flattener.flatten(asList("0",
                                      2,
                                      asList(asList("two", '3'),
                                             "8",
                                             singletonList(singletonList("one hundred")),
-                                            null, 
-                                            singletonList(singletonList(null))), 
-                                                          "negative two")));
+                                            null,
+                                            singletonList(singletonList(null))),
+                                                          "negative two")))
+            .containsExactly("0", 2, "two", '3', "8", "one hundred", "negative two");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testNestedListsFullOfNullsOnly() {
-        assertEquals(emptyList(),
-                     flattener.flatten(asList(null, 
+        assertThat(flattener.flatten(asList(null,
                                               singletonList(singletonList(singletonList(null))),
-                                                            null, 
-                                                            null, 
-                                                            asList(asList(null, null), null), null)));
+                                                            null,
+                                                            null,
+                                                            asList(asList(null, null), null), null))).isEmpty();
     }
 
 }

--- a/exercises/practice/food-chain/src/test/java/FoodChainTest.java
+++ b/exercises/practice/food-chain/src/test/java/FoodChainTest.java
@@ -1,8 +1,8 @@
 import org.junit.Before;
-import org.junit.Test;
 import org.junit.Ignore;
+import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class FoodChainTest {
     private FoodChain foodChain;
@@ -18,7 +18,7 @@ public class FoodChainTest {
         String expected = "I know an old lady who swallowed a fly.\n" +
                           "I don't know why she swallowed the fly. Perhaps she'll die.";
 
-        assertEquals(expected, foodChain.verse(verse));
+        assertThat(foodChain.verse(verse)).isEqualTo(expected);
     }
 
     @Test
@@ -30,7 +30,7 @@ public class FoodChainTest {
                           "She swallowed the spider to catch the fly.\n" +
                           "I don't know why she swallowed the fly. Perhaps she'll die.";
 
-        assertEquals(expected, foodChain.verse(verse));
+        assertThat(foodChain.verse(verse)).isEqualTo(expected);
     }
 
     @Test
@@ -44,7 +44,7 @@ public class FoodChainTest {
                           "She swallowed the spider to catch the fly.\n" +
                           "I don't know why she swallowed the fly. Perhaps she'll die.";
 
-        assertEquals(expected, foodChain.verse(verse));
+        assertThat(foodChain.verse(verse)).isEqualTo(expected);
     }
 
     @Test
@@ -59,7 +59,7 @@ public class FoodChainTest {
                           "She swallowed the spider to catch the fly.\n" +
                           "I don't know why she swallowed the fly. Perhaps she'll die.";
 
-        assertEquals(expected, foodChain.verse(verse));
+        assertThat(foodChain.verse(verse)).isEqualTo(expected);
     }
 
 
@@ -76,7 +76,7 @@ public class FoodChainTest {
                           "She swallowed the spider to catch the fly.\n" +
                           "I don't know why she swallowed the fly. Perhaps she'll die.";
 
-        assertEquals(expected, foodChain.verse(verse));
+        assertThat(foodChain.verse(verse)).isEqualTo(expected);
     }
 
     @Test
@@ -93,7 +93,7 @@ public class FoodChainTest {
                           "She swallowed the spider to catch the fly.\n" +
                           "I don't know why she swallowed the fly. Perhaps she'll die.";
 
-        assertEquals(expected, foodChain.verse(verse));
+        assertThat(foodChain.verse(verse)).isEqualTo(expected);
     }
 
     @Test
@@ -111,7 +111,7 @@ public class FoodChainTest {
                           "She swallowed the spider to catch the fly.\n" +
                           "I don't know why she swallowed the fly. Perhaps she'll die.";
 
-        assertEquals(expected, foodChain.verse(verse));
+        assertThat(foodChain.verse(verse)).isEqualTo(expected);
     }
 
     @Test
@@ -121,7 +121,7 @@ public class FoodChainTest {
         String expected = "I know an old lady who swallowed a horse.\n" +
                           "She's dead, of course!";
 
-        assertEquals(expected, foodChain.verse(verse));
+        assertThat(foodChain.verse(verse)).isEqualTo(expected);
     }
 
 
@@ -145,7 +145,7 @@ public class FoodChainTest {
                           "She swallowed the spider to catch the fly.\n" +
                           "I don't know why she swallowed the fly. Perhaps she'll die.";
 
-        assertEquals(expected, foodChain.verses(startVerse, endVerse));
+        assertThat(foodChain.verses(startVerse, endVerse)).isEqualTo(expected);
     }
 
 
@@ -210,6 +210,6 @@ public class FoodChainTest {
                           "I know an old lady who swallowed a horse.\n" +
                           "She's dead, of course!";
 
-        assertEquals(expected, foodChain.verses(startVerse, endVerse));
+        assertThat(foodChain.verses(startVerse, endVerse)).isEqualTo(expected);
     }
 }

--- a/exercises/practice/gigasecond/src/test/java/GigasecondTest.java
+++ b/exercises/practice/gigasecond/src/test/java/GigasecondTest.java
@@ -1,11 +1,11 @@
-import org.junit.Test;
 import org.junit.Ignore;
+import org.junit.Test;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GigasecondTest {
 
@@ -13,7 +13,7 @@ public class GigasecondTest {
     public void modernTime() {
         Gigasecond gigaSecond = new Gigasecond(LocalDate.of(2011, Month.APRIL, 25));
 
-        assertEquals(LocalDateTime.of(2043, Month.JANUARY, 1, 1, 46, 40), gigaSecond.getDateTime());
+        assertThat(gigaSecond.getDateTime()).isEqualTo(LocalDateTime.of(2043, Month.JANUARY, 1, 1, 46, 40));
     }
 
     @Ignore("Remove to run test")
@@ -21,7 +21,7 @@ public class GigasecondTest {
     public void afterEpochTime() {
         Gigasecond gigaSecond = new Gigasecond(LocalDate.of(1977, Month.JUNE, 13));
 
-        assertEquals(LocalDateTime.of(2009, Month.FEBRUARY, 19, 1, 46, 40), gigaSecond.getDateTime());
+        assertThat(gigaSecond.getDateTime()).isEqualTo(LocalDateTime.of(2009, Month.FEBRUARY, 19, 1, 46, 40));
     }
 
     @Ignore("Remove to run test")
@@ -29,7 +29,7 @@ public class GigasecondTest {
     public void beforeEpochTime() {
         Gigasecond gigaSecond = new Gigasecond(LocalDate.of(1959, Month.JULY, 19));
 
-        assertEquals(LocalDateTime.of(1991, Month.MARCH, 27, 1, 46, 40), gigaSecond.getDateTime());
+        assertThat(gigaSecond.getDateTime()).isEqualTo(LocalDateTime.of(1991, Month.MARCH, 27, 1, 46, 40));
     }
 
     @Ignore("Remove to run test")
@@ -37,7 +37,7 @@ public class GigasecondTest {
     public void withFullTimeSpecified() {
         Gigasecond gigaSecond = new Gigasecond(LocalDateTime.of(2015, Month.JANUARY, 24, 22, 0, 0));
 
-        assertEquals(LocalDateTime.of(2046, Month.OCTOBER, 2, 23, 46, 40), gigaSecond.getDateTime());
+        assertThat(gigaSecond.getDateTime()).isEqualTo(LocalDateTime.of(2046, Month.OCTOBER, 2, 23, 46, 40));
     }
 
     @Ignore("Remove to run test")
@@ -45,6 +45,6 @@ public class GigasecondTest {
     public void withFullTimeSpecifiedAndDayRollover() {
         Gigasecond gigaSecond = new Gigasecond(LocalDateTime.of(2015, Month.JANUARY, 24, 23, 59, 59));
 
-        assertEquals(LocalDateTime.of(2046, Month.OCTOBER, 3, 1, 46, 39), gigaSecond.getDateTime());
+        assertThat(gigaSecond.getDateTime()).isEqualTo(LocalDateTime.of(2046, Month.OCTOBER, 3, 1, 46, 39));
     }
 }

--- a/exercises/practice/go-counting/src/test/java/GoCountingTest.java
+++ b/exercises/practice/go-counting/src/test/java/GoCountingTest.java
@@ -1,13 +1,13 @@
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.awt.Point;
+import java.awt.*;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class GoCountingTest {
 
@@ -26,8 +26,8 @@ public class GoCountingTest {
         territory.add(new Point(0, 1));
         territory.add(new Point(1, 0));
 
-        assertEquals(Player.BLACK, gocounting.getTerritoryOwner(0, 1));
-        assertEquals(territory, gocounting.getTerritory(0, 1));
+        assertThat(gocounting.getTerritoryOwner(0, 1)).isEqualTo(Player.BLACK);
+        assertThat(gocounting.getTerritory(0, 1)).isEqualTo(territory);
     }
 
     @Ignore("Remove to run test")
@@ -38,8 +38,8 @@ public class GoCountingTest {
         Set<Point> territory = new HashSet<>();
         territory.add(new Point(2, 3));
 
-        assertEquals(Player.WHITE, gocounting.getTerritoryOwner(2, 3));
-        assertEquals(territory, gocounting.getTerritory(2, 3));
+        assertThat(gocounting.getTerritoryOwner(2, 3)).isEqualTo(Player.WHITE);
+        assertThat(gocounting.getTerritory(2, 3)).isEqualTo(territory);
     }
 
     @Ignore("Remove to run test")
@@ -52,8 +52,8 @@ public class GoCountingTest {
         territory.add(new Point(0, 4));
         territory.add(new Point(1, 4));
 
-        assertEquals(Player.NONE, gocounting.getTerritoryOwner(1, 4));
-        assertEquals(territory, gocounting.getTerritory(1, 4));
+        assertThat(gocounting.getTerritoryOwner(1, 4)).isEqualTo(Player.NONE);
+        assertThat(gocounting.getTerritory(1, 4)).isEqualTo(territory);
     }
 
     @Ignore("Remove to run test")
@@ -63,8 +63,8 @@ public class GoCountingTest {
 
         Set<Point> territory = new HashSet<>();
 
-        assertEquals(Player.NONE, gocounting.getTerritoryOwner(1, 1));
-        assertEquals(territory, gocounting.getTerritory(1, 1));
+        assertThat(gocounting.getTerritoryOwner(1, 1)).isEqualTo(Player.NONE);
+        assertThat(gocounting.getTerritory(1, 1)).isEqualTo(territory);
     }
 
     @Ignore("Remove to run test")
@@ -122,7 +122,7 @@ public class GoCountingTest {
         territories.put(Player.WHITE, whiteTerritory);
         territories.put(Player.NONE, noneTerritory);
 
-        assertEquals(territories, gocounting.getTerritories());
+        assertThat(gocounting.getTerritories()).isEqualTo(territories);
     }
 
     @Ignore("Remove to run test")
@@ -145,7 +145,7 @@ public class GoCountingTest {
         territories.put(Player.WHITE, whiteTerritory);
         territories.put(Player.NONE, noneTerritory);
 
-        assertEquals(territories, gocounting.getTerritories());
+        assertThat(gocounting.getTerritories()).isEqualTo(territories);
     }
 
     @Ignore("Remove to run test")
@@ -164,6 +164,6 @@ public class GoCountingTest {
         territories.put(Player.WHITE, whiteTerritory);
         territories.put(Player.NONE, noneTerritory);
 
-        assertEquals(territories, gocounting.getTerritories());
+        assertThat(gocounting.getTerritories()).isEqualTo(territories);
     }
 }

--- a/exercises/practice/grains/src/test/java/GrainsTest.java
+++ b/exercises/practice/grains/src/test/java/GrainsTest.java
@@ -1,10 +1,10 @@
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.math.BigInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class GrainsTest {
 
@@ -13,49 +13,49 @@ public class GrainsTest {
     @Test
     public void countAtSquare1() {
         BigInteger result = grains.grainsOnSquare(1);
-        assertEquals(new BigInteger("1"), result);
+        assertThat(result).isEqualTo(new BigInteger("1"));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void countAtSquare2() {
         BigInteger result = grains.grainsOnSquare(2);
-        assertEquals(new BigInteger("2"), result);
+        assertThat(result).isEqualTo(new BigInteger("2"));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void countAtSquare3() {
         BigInteger result = grains.grainsOnSquare(3);
-        assertEquals(new BigInteger("4"), result);
+        assertThat(result).isEqualTo(new BigInteger("4"));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void countAtSquare4() {
         BigInteger result = grains.grainsOnSquare(4);
-        assertEquals(new BigInteger("8"), result);
+        assertThat(result).isEqualTo(new BigInteger("8"));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void countAtSquare16() {
         BigInteger result = grains.grainsOnSquare(16);
-        assertEquals(new BigInteger("32768"), result);
+        assertThat(result).isEqualTo(new BigInteger("32768"));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void countAtSquare32() {
         BigInteger result = grains.grainsOnSquare(32);
-        assertEquals(new BigInteger("2147483648"), result);
+        assertThat(result).isEqualTo(new BigInteger("2147483648"));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void countAtSquare64() {
         BigInteger result = grains.grainsOnSquare(64);
-        assertEquals(new BigInteger("9223372036854775808"), result);
+        assertThat(result).isEqualTo(new BigInteger("9223372036854775808"));
     }
 
     @Ignore("Remove to run test")
@@ -86,7 +86,7 @@ public class GrainsTest {
     @Test
     public void totalNumberOfGrainsOnABoard() {
         BigInteger total = grains.grainsOnBoard();
-        assertEquals(new BigInteger("18446744073709551615"), total);
+        assertThat(total).isEqualTo(new BigInteger("18446744073709551615"));
     }
 
 }

--- a/exercises/practice/grep/src/test/java/GrepToolTest.java
+++ b/exercises/practice/grep/src/test/java/GrepToolTest.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class GrepToolTest {
     private GrepTool grepTool;
@@ -75,7 +75,7 @@ public class GrepToolTest {
             Collections.singletonList("iliad.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -89,7 +89,7 @@ public class GrepToolTest {
             Collections.singletonList("paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -103,7 +103,7 @@ public class GrepToolTest {
             Collections.singletonList("paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -117,7 +117,7 @@ public class GrepToolTest {
             Collections.singletonList("paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -131,7 +131,7 @@ public class GrepToolTest {
             Collections.singletonList("paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -145,7 +145,7 @@ public class GrepToolTest {
             Collections.singletonList("iliad.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -161,7 +161,7 @@ public class GrepToolTest {
             Collections.singletonList("midsummer-night.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -177,7 +177,7 @@ public class GrepToolTest {
             Collections.singletonList("midsummer-night.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -191,7 +191,7 @@ public class GrepToolTest {
             Collections.singletonList("midsummer-night.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -206,7 +206,7 @@ public class GrepToolTest {
             Collections.singletonList("iliad.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -224,7 +224,7 @@ public class GrepToolTest {
             Collections.singletonList("paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -238,7 +238,7 @@ public class GrepToolTest {
             Collections.singletonList("iliad.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -252,7 +252,7 @@ public class GrepToolTest {
             Collections.singletonList("iliad.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -273,7 +273,7 @@ public class GrepToolTest {
             Collections.singletonList("iliad.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -287,7 +287,7 @@ public class GrepToolTest {
             Arrays.asList("iliad.txt", "midsummer-night.txt", "paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -303,7 +303,7 @@ public class GrepToolTest {
             Arrays.asList("iliad.txt", "midsummer-night.txt", "paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -320,7 +320,7 @@ public class GrepToolTest {
             Arrays.asList("iliad.txt", "midsummer-night.txt", "paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -335,7 +335,7 @@ public class GrepToolTest {
             Arrays.asList("iliad.txt", "midsummer-night.txt", "paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -358,7 +358,7 @@ public class GrepToolTest {
             Arrays.asList("iliad.txt", "midsummer-night.txt", "paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -374,7 +374,7 @@ public class GrepToolTest {
             Arrays.asList("iliad.txt", "midsummer-night.txt", "paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -388,7 +388,7 @@ public class GrepToolTest {
             Arrays.asList("iliad.txt", "midsummer-night.txt", "paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -402,7 +402,7 @@ public class GrepToolTest {
             Arrays.asList("iliad.txt", "midsummer-night.txt", "paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -416,7 +416,7 @@ public class GrepToolTest {
             Arrays.asList("iliad.txt", "midsummer-night.txt", "paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -431,7 +431,7 @@ public class GrepToolTest {
             Arrays.asList("iliad.txt", "midsummer-night.txt", "paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -467,7 +467,7 @@ public class GrepToolTest {
             Arrays.asList("iliad.txt", "midsummer-night.txt", "paradise-lost.txt")
         );
 
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     private void writeToFile(String filename, List<String> contents) throws IOException {

--- a/exercises/practice/isbn-verifier/src/test/java/IsbnVerifierTest.java
+++ b/exercises/practice/isbn-verifier/src/test/java/IsbnVerifierTest.java
@@ -3,7 +3,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThat;
 
 public class IsbnVerifierTest {
     private IsbnVerifier isbnVerifier;

--- a/exercises/practice/largest-series-product/src/test/java/LargestSeriesProductCalculatorTest.java
+++ b/exercises/practice/largest-series-product/src/test/java/LargestSeriesProductCalculatorTest.java
@@ -1,8 +1,8 @@
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class LargestSeriesProductCalculatorTest {
 
@@ -13,7 +13,7 @@ public class LargestSeriesProductCalculatorTest {
 
         long actualProduct = calculator.calculateLargestProductForSeriesLength(2);
 
-        assertEquals(expectedProduct, actualProduct);
+        assertThat(actualProduct).isEqualTo(expectedProduct);
     }
 
     @Ignore("Remove to run test")
@@ -24,7 +24,7 @@ public class LargestSeriesProductCalculatorTest {
 
         long actualProduct = calculator.calculateLargestProductForSeriesLength(2);
 
-        assertEquals(expectedProduct, actualProduct);
+        assertThat(actualProduct).isEqualTo(expectedProduct);
     }
 
     @Ignore("Remove to run test")
@@ -35,7 +35,7 @@ public class LargestSeriesProductCalculatorTest {
 
         long actualProduct = calculator.calculateLargestProductForSeriesLength(2);
 
-        assertEquals(expectedProduct, actualProduct);
+        assertThat(actualProduct).isEqualTo(expectedProduct);
     }
 
     @Ignore("Remove to run test")
@@ -46,7 +46,7 @@ public class LargestSeriesProductCalculatorTest {
 
         long actualProduct = calculator.calculateLargestProductForSeriesLength(3);
 
-        assertEquals(expectedProduct, actualProduct);
+        assertThat(actualProduct).isEqualTo(expectedProduct);
     }
 
     @Ignore("Remove to run test")
@@ -57,7 +57,7 @@ public class LargestSeriesProductCalculatorTest {
 
         long actualProduct = calculator.calculateLargestProductForSeriesLength(3);
 
-        assertEquals(expectedProduct, actualProduct);
+        assertThat(actualProduct).isEqualTo(expectedProduct);
     }
 
     @Ignore("Remove to run test")
@@ -68,7 +68,7 @@ public class LargestSeriesProductCalculatorTest {
 
         long actualProduct = calculator.calculateLargestProductForSeriesLength(5);
 
-        assertEquals(expectedProduct, actualProduct);
+        assertThat(actualProduct).isEqualTo(expectedProduct);
     }
 
     @Ignore("Remove to run test")
@@ -81,7 +81,7 @@ public class LargestSeriesProductCalculatorTest {
 
         long actualProduct = calculator.calculateLargestProductForSeriesLength(6);
 
-        assertEquals(expectedProduct, actualProduct);
+        assertThat(actualProduct).isEqualTo(expectedProduct);
     }
 
     @Ignore("Remove to run test")
@@ -92,7 +92,7 @@ public class LargestSeriesProductCalculatorTest {
 
         long actualProduct = calculator.calculateLargestProductForSeriesLength(2);
 
-        assertEquals(expectedProduct, actualProduct);
+        assertThat(actualProduct).isEqualTo(expectedProduct);
     }
 
     @Ignore("Remove to run test")
@@ -103,7 +103,7 @@ public class LargestSeriesProductCalculatorTest {
 
         long actualProduct = calculator.calculateLargestProductForSeriesLength(3);
 
-        assertEquals(expectedProduct, actualProduct);
+        assertThat(actualProduct).isEqualTo(expectedProduct);
     }
 
     @Ignore("Remove to run test")
@@ -152,7 +152,7 @@ public class LargestSeriesProductCalculatorTest {
 
         long actualProduct = calculator.calculateLargestProductForSeriesLength(10);
 
-        assertEquals(expectedProduct, actualProduct);
+        assertThat(actualProduct).isEqualTo(expectedProduct);
     }
 
 }

--- a/exercises/practice/matrix/src/test/java/MatrixTest.java
+++ b/exercises/practice/matrix/src/test/java/MatrixTest.java
@@ -1,7 +1,7 @@
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.junit.Assert.assertArrayEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MatrixTest {
 
@@ -13,7 +13,7 @@ public class MatrixTest {
 
         Matrix matrix = new Matrix(matrixAsString);
 
-        assertArrayEquals(expectedRow, matrix.getRow(rowIndex));
+        assertThat(matrix.getRow(rowIndex)).isEqualTo(expectedRow);
     }
 
     @Ignore("Remove to run test")
@@ -25,7 +25,7 @@ public class MatrixTest {
 
         Matrix matrix = new Matrix(matrixAsString);
 
-        assertArrayEquals(expectedRow, matrix.getRow(rowIndex));
+        assertThat(matrix.getRow(rowIndex)).isEqualTo(expectedRow);
     }
 
     @Ignore("Remove to run test")
@@ -37,7 +37,7 @@ public class MatrixTest {
 
         Matrix matrix = new Matrix(matrixAsString);
 
-        assertArrayEquals(expectedRow, matrix.getRow(rowIndex));
+        assertThat(matrix.getRow(rowIndex)).isEqualTo(expectedRow);
     }
 
     @Ignore("Remove to run test")
@@ -49,7 +49,7 @@ public class MatrixTest {
 
         Matrix matrix = new Matrix(matrixAsString);
 
-        assertArrayEquals(expectedRow, matrix.getRow(rowIndex));
+        assertThat(matrix.getRow(rowIndex)).isEqualTo(expectedRow);
     }
 
     @Ignore("Remove to run test")
@@ -61,7 +61,7 @@ public class MatrixTest {
 
         Matrix matrix = new Matrix(matrixAsString);
 
-        assertArrayEquals(expectedColumn, matrix.getColumn(columnIndex));
+        assertThat(matrix.getColumn(columnIndex)).isEqualTo(expectedColumn);
     }
 
     @Ignore("Remove to run test")
@@ -73,7 +73,7 @@ public class MatrixTest {
 
         Matrix matrix = new Matrix(matrixAsString);
 
-        assertArrayEquals(expectedColumn, matrix.getColumn(columnIndex));
+        assertThat(matrix.getColumn(columnIndex)).isEqualTo(expectedColumn);
     }
 
     @Ignore("Remove to run test")
@@ -85,7 +85,7 @@ public class MatrixTest {
 
         Matrix matrix = new Matrix(matrixAsString);
 
-        assertArrayEquals(expectedColumn, matrix.getColumn(columnIndex));
+        assertThat(matrix.getColumn(columnIndex)).isEqualTo(expectedColumn);
     }
 
     @Ignore("Remove to run test")
@@ -97,6 +97,6 @@ public class MatrixTest {
 
         Matrix matrix = new Matrix(matrixAsString);
 
-        assertArrayEquals(expectedColumn, matrix.getColumn(columnIndex));
+        assertThat(matrix.getColumn(columnIndex)).isEqualTo(expectedColumn);
     }
 }

--- a/exercises/practice/meetup/src/test/java/MeetupTest.java
+++ b/exercises/practice/meetup/src/test/java/MeetupTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MeetupTest {
 
@@ -12,7 +12,7 @@ public class MeetupTest {
     public void testMonteenthOfMay2013() {
         LocalDate expected = LocalDate.of(2013, 5, 13);
         Meetup meetup = new Meetup(5, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.MONDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.MONDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -20,7 +20,7 @@ public class MeetupTest {
     public void testMonteenthOfAugust2013() {
         LocalDate expected = LocalDate.of(2013, 8, 19);
         Meetup meetup = new Meetup(8, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.MONDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.MONDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -28,7 +28,7 @@ public class MeetupTest {
     public void testMonteenthOfSeptember2013() {
         LocalDate expected = LocalDate.of(2013, 9, 16);
         Meetup meetup = new Meetup(9, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.MONDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.MONDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -36,7 +36,7 @@ public class MeetupTest {
     public void testTuesteenthOfMarch2013() {
         LocalDate expected = LocalDate.of(2013, 3, 19);
         Meetup meetup = new Meetup(3, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -44,7 +44,7 @@ public class MeetupTest {
     public void testTuesteenthOfApril2013() {
         LocalDate expected = LocalDate.of(2013, 4, 16);
         Meetup meetup = new Meetup(4, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -52,7 +52,7 @@ public class MeetupTest {
     public void testTuesteenthOfAugust2013() {
         LocalDate expected = LocalDate.of(2013, 8, 13);
         Meetup meetup = new Meetup(8, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -60,7 +60,7 @@ public class MeetupTest {
     public void testWednesteenthOfJanuary2013() {
         LocalDate expected = LocalDate.of(2013, 1, 16);
         Meetup meetup = new Meetup(1, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -68,7 +68,7 @@ public class MeetupTest {
     public void testWednesteenthOfFebruary2013() {
         LocalDate expected = LocalDate.of(2013, 2, 13);
         Meetup meetup = new Meetup(2, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -76,7 +76,7 @@ public class MeetupTest {
     public void testWednesteenthOfJune2013() {
         LocalDate expected = LocalDate.of(2013, 6, 19);
         Meetup meetup = new Meetup(6, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -84,7 +84,7 @@ public class MeetupTest {
     public void testThursteenthOfMay2013() {
         LocalDate expected = LocalDate.of(2013, 5, 16);
         Meetup meetup = new Meetup(5, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -92,7 +92,7 @@ public class MeetupTest {
     public void testThursteenthOfJune2013() {
         LocalDate expected = LocalDate.of(2013, 6, 13);
         Meetup meetup = new Meetup(6, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -100,7 +100,7 @@ public class MeetupTest {
     public void testThursteenthOfSeptember2013() {
         LocalDate expected = LocalDate.of(2013, 9, 19);
         Meetup meetup = new Meetup(9, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -108,7 +108,7 @@ public class MeetupTest {
     public void testFriteenthOfApril2013() {
         LocalDate expected = LocalDate.of(2013, 4, 19);
         Meetup meetup = new Meetup(4, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -116,7 +116,7 @@ public class MeetupTest {
     public void testFriteenthOfAugust2013() {
         LocalDate expected = LocalDate.of(2013, 8, 16);
         Meetup meetup = new Meetup(8, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -124,7 +124,7 @@ public class MeetupTest {
     public void testFriteenthOfSeptember2013() {
         LocalDate expected = LocalDate.of(2013, 9, 13);
         Meetup meetup = new Meetup(9, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -132,7 +132,7 @@ public class MeetupTest {
     public void testSaturteenthOfFebruary2013() {
         LocalDate expected = LocalDate.of(2013, 2, 16);
         Meetup meetup = new Meetup(2, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -140,7 +140,7 @@ public class MeetupTest {
     public void testSaturteenthOfApril2013() {
         LocalDate expected = LocalDate.of(2013, 4, 13);
         Meetup meetup = new Meetup(4, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -148,7 +148,7 @@ public class MeetupTest {
     public void testSaturteenthOfOctober2013() {
         LocalDate expected = LocalDate.of(2013, 10, 19);
         Meetup meetup = new Meetup(10, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -156,7 +156,7 @@ public class MeetupTest {
     public void testSunteenthOfMay2013() {
         LocalDate expected = LocalDate.of(2013, 5, 19);
         Meetup meetup = new Meetup(5, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -164,7 +164,7 @@ public class MeetupTest {
     public void testSunteenthOfJune2013() {
         LocalDate expected = LocalDate.of(2013, 6, 16);
         Meetup meetup = new Meetup(6, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -172,7 +172,7 @@ public class MeetupTest {
     public void testSunteenthOfOctober2013() {
         LocalDate expected = LocalDate.of(2013, 10, 13);
         Meetup meetup = new Meetup(10, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.TEENTH));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.TEENTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -180,7 +180,7 @@ public class MeetupTest {
     public void testFirstMondayOfMarch2013() {
         LocalDate expected = LocalDate.of(2013, 3, 4);
         Meetup meetup = new Meetup(3, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.MONDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.MONDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -188,7 +188,7 @@ public class MeetupTest {
     public void testFirstMondayOfApril2013() {
         LocalDate expected = LocalDate.of(2013, 4, 1);
         Meetup meetup = new Meetup(4, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.MONDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.MONDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -196,7 +196,7 @@ public class MeetupTest {
     public void testFirstTuesdayOfMay2013() {
         LocalDate expected = LocalDate.of(2013, 5, 7);
         Meetup meetup = new Meetup(5, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -204,7 +204,7 @@ public class MeetupTest {
     public void testFirstTuesdayOfJune2013() {
         LocalDate expected = LocalDate.of(2013, 6, 4);
         Meetup meetup = new Meetup(6, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -212,7 +212,7 @@ public class MeetupTest {
     public void testFirstWednesdayOfJuly2013() {
         LocalDate expected = LocalDate.of(2013, 7, 3);
         Meetup meetup = new Meetup(7, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -220,7 +220,7 @@ public class MeetupTest {
     public void testFirstWednesdayOfAugust2013() {
         LocalDate expected = LocalDate.of(2013, 8, 7);
         Meetup meetup = new Meetup(8, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -228,7 +228,7 @@ public class MeetupTest {
     public void testFirstThursdayOfSeptember2013() {
         LocalDate expected = LocalDate.of(2013, 9, 5);
         Meetup meetup = new Meetup(9, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -236,7 +236,7 @@ public class MeetupTest {
     public void testFirstThursdayOfOctober2013() {
         LocalDate expected = LocalDate.of(2013, 10, 3);
         Meetup meetup = new Meetup(10, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -244,7 +244,7 @@ public class MeetupTest {
     public void testFirstFridayOfNovember2013() {
         LocalDate expected = LocalDate.of(2013, 11, 1);
         Meetup meetup = new Meetup(11, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -252,7 +252,7 @@ public class MeetupTest {
     public void testFirstFridayOfDecember2013() {
         LocalDate expected = LocalDate.of(2013, 12, 6);
         Meetup meetup = new Meetup(12, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -260,7 +260,7 @@ public class MeetupTest {
     public void testFirstSaturdayOfJanuary2013() {
         LocalDate expected = LocalDate.of(2013, 1, 5);
         Meetup meetup = new Meetup(1, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -268,7 +268,7 @@ public class MeetupTest {
     public void testFirstSaturdayOfFebruary2013() {
         LocalDate expected = LocalDate.of(2013, 2, 2);
         Meetup meetup = new Meetup(2, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -276,7 +276,7 @@ public class MeetupTest {
     public void testFirstSundayOfMarch2013() {
         LocalDate expected = LocalDate.of(2013, 3, 3);
         Meetup meetup = new Meetup(3, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -284,7 +284,7 @@ public class MeetupTest {
     public void testFirstSundayOfApril2013() {
         LocalDate expected = LocalDate.of(2013, 4, 7);
         Meetup meetup = new Meetup(4, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -292,7 +292,7 @@ public class MeetupTest {
     public void testSecondMondayOfMarch2013() {
         LocalDate expected = LocalDate.of(2013, 3, 11);
         Meetup meetup = new Meetup(3, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.MONDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.MONDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -300,7 +300,7 @@ public class MeetupTest {
     public void testSecondMondayOfApril2013() {
         LocalDate expected = LocalDate.of(2013, 4, 8);
         Meetup meetup = new Meetup(4, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.MONDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.MONDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -308,7 +308,7 @@ public class MeetupTest {
     public void testSecondTuesdayOfMay2013() {
         LocalDate expected = LocalDate.of(2013, 5, 14);
         Meetup meetup = new Meetup(5, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -316,7 +316,7 @@ public class MeetupTest {
     public void testSecondTuesdayOfJune2013() {
         LocalDate expected = LocalDate.of(2013, 6, 11);
         Meetup meetup = new Meetup(6, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -324,7 +324,7 @@ public class MeetupTest {
     public void testSecondWednesdayOfJuly2013() {
         LocalDate expected = LocalDate.of(2013, 7, 10);
         Meetup meetup = new Meetup(7, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -332,7 +332,7 @@ public class MeetupTest {
     public void testSecondWednesdayOfAugust2013() {
         LocalDate expected = LocalDate.of(2013, 8, 14);
         Meetup meetup = new Meetup(8, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -340,7 +340,7 @@ public class MeetupTest {
     public void testSecondThursdayOfSeptember2013() {
         LocalDate expected = LocalDate.of(2013, 9, 12);
         Meetup meetup = new Meetup(9, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -348,7 +348,7 @@ public class MeetupTest {
     public void testSecondThursdayOfOctober2013() {
         LocalDate expected = LocalDate.of(2013, 10, 10);
         Meetup meetup = new Meetup(10, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -356,7 +356,7 @@ public class MeetupTest {
     public void testSecondFridayOfNovember2013() {
         LocalDate expected = LocalDate.of(2013, 11, 8);
         Meetup meetup = new Meetup(11, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -364,7 +364,7 @@ public class MeetupTest {
     public void testSecondFridayOfDecember2013() {
         LocalDate expected = LocalDate.of(2013, 12, 13);
         Meetup meetup = new Meetup(12, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -372,7 +372,7 @@ public class MeetupTest {
     public void testSecondSaturdayOfJanuary2013() {
         LocalDate expected = LocalDate.of(2013, 1, 12);
         Meetup meetup = new Meetup(1, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -380,7 +380,7 @@ public class MeetupTest {
     public void testSecondSaturdayOfFebruary2013() {
         LocalDate expected = LocalDate.of(2013, 2, 9);
         Meetup meetup = new Meetup(2, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -388,7 +388,7 @@ public class MeetupTest {
     public void testSecondSundayOfMarch2013() {
         LocalDate expected = LocalDate.of(2013, 3, 10);
         Meetup meetup = new Meetup(3, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -396,7 +396,7 @@ public class MeetupTest {
     public void testSecondSundayOfApril2013() {
         LocalDate expected = LocalDate.of(2013, 4, 14);
         Meetup meetup = new Meetup(4, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.SECOND));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.SECOND)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -404,7 +404,7 @@ public class MeetupTest {
     public void testThirdMondayOfMarch2013() {
         LocalDate expected = LocalDate.of(2013, 3, 18);
         Meetup meetup = new Meetup(3, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.MONDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.MONDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -412,7 +412,7 @@ public class MeetupTest {
     public void testThirdMondayOfApril2013() {
         LocalDate expected = LocalDate.of(2013, 4, 15);
         Meetup meetup = new Meetup(4, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.MONDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.MONDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -420,7 +420,7 @@ public class MeetupTest {
     public void testThirdTuesdayOfMay2013() {
         LocalDate expected = LocalDate.of(2013, 5, 21);
         Meetup meetup = new Meetup(5, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -428,7 +428,7 @@ public class MeetupTest {
     public void testThirdTuesdayOfJune2013() {
         LocalDate expected = LocalDate.of(2013, 6, 18);
         Meetup meetup = new Meetup(6, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -436,7 +436,7 @@ public class MeetupTest {
     public void testThirdWednesdayOfJuly2013() {
         LocalDate expected = LocalDate.of(2013, 7, 17);
         Meetup meetup = new Meetup(7, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -444,7 +444,7 @@ public class MeetupTest {
     public void testThirdWednesdayOfAugust2013() {
         LocalDate expected = LocalDate.of(2013, 8, 21);
         Meetup meetup = new Meetup(8, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -452,7 +452,7 @@ public class MeetupTest {
     public void testThirdThursdayOfSeptember2013() {
         LocalDate expected = LocalDate.of(2013, 9, 19);
         Meetup meetup = new Meetup(9, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -460,7 +460,7 @@ public class MeetupTest {
     public void testThirdThursdayOfOctober2013() {
         LocalDate expected = LocalDate.of(2013, 10, 17);
         Meetup meetup = new Meetup(10, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -468,7 +468,7 @@ public class MeetupTest {
     public void testThirdFridayOfNovember2013() {
         LocalDate expected = LocalDate.of(2013, 11, 15);
         Meetup meetup = new Meetup(11, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -476,7 +476,7 @@ public class MeetupTest {
     public void testThirdFridayOfDecember2013() {
         LocalDate expected = LocalDate.of(2013, 12, 20);
         Meetup meetup = new Meetup(12, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -484,7 +484,7 @@ public class MeetupTest {
     public void testThirdSaturdayOfJanuary2013() {
         LocalDate expected = LocalDate.of(2013, 1, 19);
         Meetup meetup = new Meetup(1, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -492,7 +492,7 @@ public class MeetupTest {
     public void testThirdSaturdayOfFebruary2013() {
         LocalDate expected = LocalDate.of(2013, 2, 16);
         Meetup meetup = new Meetup(2, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -500,7 +500,7 @@ public class MeetupTest {
     public void testThirdSundayOfMarch2013() {
         LocalDate expected = LocalDate.of(2013, 3, 17);
         Meetup meetup = new Meetup(3, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -508,7 +508,7 @@ public class MeetupTest {
     public void testThirdSundayOfApril2013() {
         LocalDate expected = LocalDate.of(2013, 4, 21);
         Meetup meetup = new Meetup(4, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.THIRD));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.THIRD)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -516,7 +516,7 @@ public class MeetupTest {
     public void testFourthMondayOfMarch2013() {
         LocalDate expected = LocalDate.of(2013, 3, 25);
         Meetup meetup = new Meetup(3, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.MONDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.MONDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -524,7 +524,7 @@ public class MeetupTest {
     public void testFourthMondayOfApril2013() {
         LocalDate expected = LocalDate.of(2013, 4, 22);
         Meetup meetup = new Meetup(4, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.MONDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.MONDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -532,7 +532,7 @@ public class MeetupTest {
     public void testFourthTuesdayOfMay2013() {
         LocalDate expected = LocalDate.of(2013, 5, 28);
         Meetup meetup = new Meetup(5, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -540,7 +540,7 @@ public class MeetupTest {
     public void testFourthTuesdayOfJune2013() {
         LocalDate expected = LocalDate.of(2013, 6, 25);
         Meetup meetup = new Meetup(6, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -548,7 +548,7 @@ public class MeetupTest {
     public void testFourthWednesdayOfJuly2013() {
         LocalDate expected = LocalDate.of(2013, 7, 24);
         Meetup meetup = new Meetup(7, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -556,7 +556,7 @@ public class MeetupTest {
     public void testFourthWednesdayOfAugust2013() {
         LocalDate expected = LocalDate.of(2013, 8, 28);
         Meetup meetup = new Meetup(8, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -564,7 +564,7 @@ public class MeetupTest {
     public void testFourthThursdayOfSeptember2013() {
         LocalDate expected = LocalDate.of(2013, 9, 26);
         Meetup meetup = new Meetup(9, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -572,7 +572,7 @@ public class MeetupTest {
     public void testFourthThursdayOfOctober2013() {
         LocalDate expected = LocalDate.of(2013, 10, 24);
         Meetup meetup = new Meetup(10, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -580,7 +580,7 @@ public class MeetupTest {
     public void testFourthFridayOfNovember2013() {
         LocalDate expected = LocalDate.of(2013, 11, 22);
         Meetup meetup = new Meetup(11, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -588,7 +588,7 @@ public class MeetupTest {
     public void testFourthFridayOfDecember2013() {
         LocalDate expected = LocalDate.of(2013, 12, 27);
         Meetup meetup = new Meetup(12, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -596,7 +596,7 @@ public class MeetupTest {
     public void testFourthSaturdayOfJanuary2013() {
         LocalDate expected = LocalDate.of(2013, 1, 26);
         Meetup meetup = new Meetup(1, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -604,7 +604,7 @@ public class MeetupTest {
     public void testFourthSaturdayOfFebruary2013() {
         LocalDate expected = LocalDate.of(2013, 2, 23);
         Meetup meetup = new Meetup(2, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -612,7 +612,7 @@ public class MeetupTest {
     public void testFourthSundayOfMarch2013() {
         LocalDate expected = LocalDate.of(2013, 3, 24);
         Meetup meetup = new Meetup(3, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -620,7 +620,7 @@ public class MeetupTest {
     public void testFourthSundayOfApril2013() {
         LocalDate expected = LocalDate.of(2013, 4, 28);
         Meetup meetup = new Meetup(4, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.FOURTH));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.FOURTH)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -628,7 +628,7 @@ public class MeetupTest {
     public void testLastMondayOfMarch2013() {
         LocalDate expected = LocalDate.of(2013, 3, 25);
         Meetup meetup = new Meetup(3, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.MONDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.MONDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -636,7 +636,7 @@ public class MeetupTest {
     public void testLastMondayOfApril2013() {
         LocalDate expected = LocalDate.of(2013, 4, 29);
         Meetup meetup = new Meetup(4, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.MONDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.MONDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -644,7 +644,7 @@ public class MeetupTest {
     public void testLastTuesdayOfMay2013() {
         LocalDate expected = LocalDate.of(2013, 5, 28);
         Meetup meetup = new Meetup(5, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -652,7 +652,7 @@ public class MeetupTest {
     public void testLastTuesdayOfJune2013() {
         LocalDate expected = LocalDate.of(2013, 6, 25);
         Meetup meetup = new Meetup(6, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.TUESDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -660,7 +660,7 @@ public class MeetupTest {
     public void testLastWednesdayOfJuly2013() {
         LocalDate expected = LocalDate.of(2013, 7, 31);
         Meetup meetup = new Meetup(7, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -668,7 +668,7 @@ public class MeetupTest {
     public void testLastWednesdayOfAugust2013() {
         LocalDate expected = LocalDate.of(2013, 8, 28);
         Meetup meetup = new Meetup(8, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -676,7 +676,7 @@ public class MeetupTest {
     public void testLastThursdayOfSeptember2013() {
         LocalDate expected = LocalDate.of(2013, 9, 26);
         Meetup meetup = new Meetup(9, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -684,7 +684,7 @@ public class MeetupTest {
     public void testLastThursdayOfOctober2013() {
         LocalDate expected = LocalDate.of(2013, 10, 31);
         Meetup meetup = new Meetup(10, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.THURSDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -692,7 +692,7 @@ public class MeetupTest {
     public void testLastFridayOfNovember2013() {
         LocalDate expected = LocalDate.of(2013, 11, 29);
         Meetup meetup = new Meetup(11, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -700,7 +700,7 @@ public class MeetupTest {
     public void testLastFridayOfDecember2013() {
         LocalDate expected = LocalDate.of(2013, 12, 27);
         Meetup meetup = new Meetup(12, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -708,7 +708,7 @@ public class MeetupTest {
     public void testLastSaturdayOfJanuary2013() {
         LocalDate expected = LocalDate.of(2013, 1, 26);
         Meetup meetup = new Meetup(1, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -716,7 +716,7 @@ public class MeetupTest {
     public void testLastSaturdayOfFebruary2013() {
         LocalDate expected = LocalDate.of(2013, 2, 23);
         Meetup meetup = new Meetup(2, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.SATURDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -724,7 +724,7 @@ public class MeetupTest {
     public void testLastSundayOfMarch2013() {
         LocalDate expected = LocalDate.of(2013, 3, 31);
         Meetup meetup = new Meetup(3, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -732,7 +732,7 @@ public class MeetupTest {
     public void testLastSundayOfApril2013() {
         LocalDate expected = LocalDate.of(2013, 4, 28);
         Meetup meetup = new Meetup(4, 2013);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -740,7 +740,7 @@ public class MeetupTest {
     public void testLastWednesdayOfFebruary2012() {
         LocalDate expected = LocalDate.of(2012, 2, 29);
         Meetup meetup = new Meetup(2, 2012);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -748,7 +748,7 @@ public class MeetupTest {
     public void testLastWednesdayOfDecember2014() {
         LocalDate expected = LocalDate.of(2014, 12, 31);
         Meetup meetup = new Meetup(12, 2014);
-        assertEquals(expected, meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.WEDNESDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -756,7 +756,7 @@ public class MeetupTest {
     public void testLastSundayOfFebruary2015() {
         LocalDate expected = LocalDate.of(2015, 2, 22);
         Meetup meetup = new Meetup(2, 2015);
-        assertEquals(expected, meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.LAST));
+        assertThat(meetup.day(DayOfWeek.SUNDAY, MeetupSchedule.LAST)).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -764,6 +764,6 @@ public class MeetupTest {
     public void testFirstFridayOfDecember2012() {
         LocalDate expected = LocalDate.of(2012, 12, 7);
         Meetup meetup = new Meetup(12, 2012);
-        assertEquals(expected, meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.FIRST));
+        assertThat(meetup.day(DayOfWeek.FRIDAY, MeetupSchedule.FIRST)).isEqualTo(expected);
     }
 }

--- a/exercises/practice/micro-blog/src/test/java/MicroBlogTest.java
+++ b/exercises/practice/micro-blog/src/test/java/MicroBlogTest.java
@@ -1,7 +1,7 @@
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MicroBlogTest {
 
@@ -10,83 +10,83 @@ public class MicroBlogTest {
     @Test
     public void englishLanguageShort() {
         String expected = "Hi";
-        assertEquals(expected, microBlog.truncate("Hi"));
+        assertThat(microBlog.truncate("Hi")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void englishLanguageLong() {
         String expected = "Hello";
-        assertEquals(expected, microBlog.truncate("Hello there"));
+        assertThat(microBlog.truncate("Hello there")).isEqualTo(expected);
     }
     
     @Ignore("Remove to run test")
     @Test
     public void germanLanguageShort_broth() {
         String expected = "brühe";
-        assertEquals(expected, microBlog.truncate("brühe"));
+        assertThat(microBlog.truncate("brühe")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void germanLanguageLong_bearCarpet_to_beards() {
         String expected = "Bärte";
-        assertEquals(expected, microBlog.truncate("Bärteppich"));
+        assertThat(microBlog.truncate("Bärteppich")).isEqualTo(expected);
     }
     
     @Ignore("Remove to run test")
     @Test
     public void bulgarianLanguageShort_good() {
         String expected = "Добър";
-        assertEquals(expected, microBlog.truncate("Добър"));
+        assertThat(microBlog.truncate("Добър")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void greekLanguageShort_health() {
         String expected = "υγειά";
-        assertEquals(expected, microBlog.truncate("υγειά"));
+        assertThat(microBlog.truncate("υγειά")).isEqualTo(expected);
     }
     
     @Ignore("Remove to run test")
     @Test
     public void mathsShort() {
         String expected = "a=πr²";
-        assertEquals(expected, microBlog.truncate("a=πr²"));
+        assertThat(microBlog.truncate("a=πr²")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void mathsLong() {
         String expected = "∅⊊ℕ⊊ℤ";
-        assertEquals(expected, microBlog.truncate("∅⊊ℕ⊊ℤ⊊ℚ⊊ℝ⊊ℂ"));
+        assertThat(microBlog.truncate("∅⊊ℕ⊊ℤ⊊ℚ⊊ℝ⊊ℂ")).isEqualTo(expected);
     }
     
     @Ignore("Remove to run test")
     @Test
     public void englishAndEmojiShort() {
         String expected = "Fly 🛫";
-        assertEquals(expected, microBlog.truncate("Fly 🛫"));
+        assertThat(microBlog.truncate("Fly 🛫")).isEqualTo(expected);
     }
     
     @Ignore("Remove to run test")
     @Test
     public void emojiShort() {
         String expected = "💇";
-        assertEquals(expected, microBlog.truncate("💇"));
+        assertThat(microBlog.truncate("💇")).isEqualTo(expected);
     }
     
     @Ignore("Remove to run test")
     @Test
     public void emojiLong() {
         String expected = "❄🌡🤧🤒🏥";
-        assertEquals(expected, microBlog.truncate("❄🌡🤧🤒🏥🕰😀"));
+        assertThat(microBlog.truncate("❄🌡🤧🤒🏥🕰😀")).isEqualTo(expected);
     }
     
     @Ignore("Remove to run test")
     @Test
     public void royalFlush() {
         String expected = "🃎🂸🃅🃋🃍";
-        assertEquals(expected, microBlog.truncate("🃎🂸🃅🃋🃍🃁🃊"));
+        assertThat(microBlog.truncate("🃎🂸🃅🃋🃍🃁🃊")).isEqualTo(expected);
     }
 }

--- a/exercises/practice/minesweeper/src/test/java/MinesweeperBoardTest.java
+++ b/exercises/practice/minesweeper/src/test/java/MinesweeperBoardTest.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class MinesweeperBoardTest {
 
@@ -15,7 +15,7 @@ public class MinesweeperBoardTest {
         List<String> expectedNumberedBoard = Collections.emptyList();
         List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
 
-        assertEquals(expectedNumberedBoard, actualNumberedBoard);
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
     }
 
     @Ignore("Remove to run test")
@@ -25,7 +25,7 @@ public class MinesweeperBoardTest {
         List<String> expectedNumberedBoard = Collections.singletonList("");
         List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
 
-        assertEquals(expectedNumberedBoard, actualNumberedBoard);
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
     }
 
     @Ignore("Remove to run test")
@@ -45,7 +45,7 @@ public class MinesweeperBoardTest {
 
         List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
 
-        assertEquals(expectedNumberedBoard, actualNumberedBoard);
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
     }
 
     @Ignore("Remove to run test")
@@ -65,7 +65,7 @@ public class MinesweeperBoardTest {
 
         List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
 
-        assertEquals(expectedNumberedBoard, actualNumberedBoard);
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
     }
 
     @Ignore("Remove to run test")
@@ -85,7 +85,7 @@ public class MinesweeperBoardTest {
 
         List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
 
-        assertEquals(expectedNumberedBoard, actualNumberedBoard);
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
     }
 
     @Ignore("Remove to run test")
@@ -105,7 +105,7 @@ public class MinesweeperBoardTest {
 
         List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
 
-        assertEquals(expectedNumberedBoard, actualNumberedBoard);
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
     }
 
     @Ignore("Remove to run test")
@@ -121,7 +121,7 @@ public class MinesweeperBoardTest {
 
         List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
 
-        assertEquals(expectedNumberedBoard, actualNumberedBoard);
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
     }
 
     @Ignore("Remove to run test")
@@ -137,7 +137,7 @@ public class MinesweeperBoardTest {
 
         List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
 
-        assertEquals(expectedNumberedBoard, actualNumberedBoard);
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
     }
 
     @Ignore("Remove to run test")
@@ -161,7 +161,7 @@ public class MinesweeperBoardTest {
 
         List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
 
-        assertEquals(expectedNumberedBoard, actualNumberedBoard);
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
     }
 
     @Ignore("Remove to run test")
@@ -185,7 +185,7 @@ public class MinesweeperBoardTest {
 
         List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
 
-        assertEquals(expectedNumberedBoard, actualNumberedBoard);
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
     }
 
     @Ignore("Remove to run test")
@@ -209,7 +209,7 @@ public class MinesweeperBoardTest {
 
         List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
 
-        assertEquals(expectedNumberedBoard, actualNumberedBoard);
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
     }
 
     @Ignore("Remove to run test")
@@ -235,7 +235,7 @@ public class MinesweeperBoardTest {
 
         List<String> actualNumberedBoard = new MinesweeperBoard(inputBoard).withNumbers();
 
-        assertEquals(expectedNumberedBoard, actualNumberedBoard);
+        assertThat(actualNumberedBoard).isEqualTo(expectedNumberedBoard);
     }
 
 }

--- a/exercises/practice/nucleotide-count/src/test/java/NucleotideCounterTest.java
+++ b/exercises/practice/nucleotide-count/src/test/java/NucleotideCounterTest.java
@@ -1,10 +1,10 @@
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
-
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 public class NucleotideCounterTest {
 
@@ -51,8 +51,7 @@ public class NucleotideCounterTest {
     @Ignore("Remove to run test")
     @Test
     public void testDnaStringHasInvalidNucleotides() {
-        assertThrows(
-            IllegalArgumentException.class,
-            () -> new NucleotideCounter("AGXXACT"));
+        assertThatThrownBy(() -> new NucleotideCounter("AGXXACT"))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/exercises/practice/octal/src/test/java/OctalTest.java
+++ b/exercises/practice/octal/src/test/java/OctalTest.java
@@ -1,4 +1,3 @@
-import org.junit.Test;
 import org.junit.Ignore;
 import org.junit.Test;
 

--- a/exercises/practice/octal/src/test/java/OctalTest.java
+++ b/exercises/practice/octal/src/test/java/OctalTest.java
@@ -1,98 +1,98 @@
-import org.junit.Test;
 import org.junit.Ignore;
+import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class OctalTest {
 
     @Test
     public void testCovertDecimalOneToOctal() {
         Octal octal = new Octal("1");
-        assertEquals(1, octal.getDecimal());
+        assertThat(octal.getDecimal()).isEqualTo(1);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testCovertDecimalTenToOctal() {
         Octal octal = new Octal("10");
-        assertEquals(8, octal.getDecimal());
+        assertThat(octal.getDecimal()).isEqualTo(8);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testCovertDecimalSeventeenToOctal() {
         Octal octal = new Octal("17");
-        assertEquals(15, octal.getDecimal());
+        assertThat(octal.getDecimal()).isEqualTo(15);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testCovertElevenToOctal() {
         Octal octal = new Octal("11");
-        assertEquals(9, octal.getDecimal());
+        assertThat(octal.getDecimal()).isEqualTo(9);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testCovertDecimalElevenWithZeroToOctal() {
         Octal octal = new Octal("011");
-        assertEquals(9, octal.getDecimal());
+        assertThat(octal.getDecimal()).isEqualTo(9);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThreeDigitDecimalToOctal() {
         Octal octal = new Octal("130");
-        assertEquals(88, octal.getDecimal());
+        assertThat(octal.getDecimal()).isEqualTo(88);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSmallFourDigitDecimalToOctal() {
         Octal octal = new Octal("2047");
-        assertEquals(1063, octal.getDecimal());
+        assertThat(octal.getDecimal()).isEqualTo(1063);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testLargeFourDigitDecimalToOctal() {
         Octal octal = new Octal("7777");
-        assertEquals(4095, octal.getDecimal());
+        assertThat(octal.getDecimal()).isEqualTo(4095);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSevenDigitDecimalToOctal() {
         Octal octal = new Octal("1234567");
-        assertEquals(342391, octal.getDecimal());
+        assertThat(octal.getDecimal()).isEqualTo(342391);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testInvalidStringFirst() {
         Octal octal = new Octal("carrot");
-        assertEquals(0, octal.getDecimal());
+        assertThat(octal.getDecimal()).isEqualTo(0);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testInvalidStringSecond() {
         Octal octal = new Octal("abc1z");
-        assertEquals(0, octal.getDecimal());
+        assertThat(octal.getDecimal()).isEqualTo(0);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testInvalidDecimalEight() {
         Octal octal = new Octal("8");
-        assertEquals(0, octal.getDecimal());
+        assertThat(octal.getDecimal()).isEqualTo(0);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testInvalidNumberNine() {
         Octal octal = new Octal("9");
-        assertEquals(0, octal.getDecimal());
+        assertThat(octal.getDecimal()).isEqualTo(0);
     }
 
 }

--- a/exercises/practice/octal/src/test/java/OctalTest.java
+++ b/exercises/practice/octal/src/test/java/OctalTest.java
@@ -1,5 +1,5 @@
-import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.Ignore;
 
 import static org.junit.Assert.assertEquals;
 

--- a/exercises/practice/octal/src/test/java/OctalTest.java
+++ b/exercises/practice/octal/src/test/java/OctalTest.java
@@ -1,98 +1,99 @@
+import org.junit.Test;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 public class OctalTest {
 
     @Test
     public void testCovertDecimalOneToOctal() {
         Octal octal = new Octal("1");
-        assertThat(octal.getDecimal()).isEqualTo(1);
+        assertEquals(1, octal.getDecimal());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testCovertDecimalTenToOctal() {
         Octal octal = new Octal("10");
-        assertThat(octal.getDecimal()).isEqualTo(8);
+        assertEquals(8, octal.getDecimal());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testCovertDecimalSeventeenToOctal() {
         Octal octal = new Octal("17");
-        assertThat(octal.getDecimal()).isEqualTo(15);
+        assertEquals(15, octal.getDecimal());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testCovertElevenToOctal() {
         Octal octal = new Octal("11");
-        assertThat(octal.getDecimal()).isEqualTo(9);
+        assertEquals(9, octal.getDecimal());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testCovertDecimalElevenWithZeroToOctal() {
         Octal octal = new Octal("011");
-        assertThat(octal.getDecimal()).isEqualTo(9);
+        assertEquals(9, octal.getDecimal());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThreeDigitDecimalToOctal() {
         Octal octal = new Octal("130");
-        assertThat(octal.getDecimal()).isEqualTo(88);
+        assertEquals(88, octal.getDecimal());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSmallFourDigitDecimalToOctal() {
         Octal octal = new Octal("2047");
-        assertThat(octal.getDecimal()).isEqualTo(1063);
+        assertEquals(1063, octal.getDecimal());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testLargeFourDigitDecimalToOctal() {
         Octal octal = new Octal("7777");
-        assertThat(octal.getDecimal()).isEqualTo(4095);
+        assertEquals(4095, octal.getDecimal());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSevenDigitDecimalToOctal() {
         Octal octal = new Octal("1234567");
-        assertThat(octal.getDecimal()).isEqualTo(342391);
+        assertEquals(342391, octal.getDecimal());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testInvalidStringFirst() {
         Octal octal = new Octal("carrot");
-        assertThat(octal.getDecimal()).isEqualTo(0);
+        assertEquals(0, octal.getDecimal());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testInvalidStringSecond() {
         Octal octal = new Octal("abc1z");
-        assertThat(octal.getDecimal()).isEqualTo(0);
+        assertEquals(0, octal.getDecimal());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testInvalidDecimalEight() {
         Octal octal = new Octal("8");
-        assertThat(octal.getDecimal()).isEqualTo(0);
+        assertEquals(0, octal.getDecimal());
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testInvalidNumberNine() {
         Octal octal = new Octal("9");
-        assertThat(octal.getDecimal()).isEqualTo(0);
+        assertEquals(0, octal.getDecimal());
     }
 
 }

--- a/exercises/practice/pascals-triangle/src/test/java/PascalsTriangleGeneratorTest.java
+++ b/exercises/practice/pascals-triangle/src/test/java/PascalsTriangleGeneratorTest.java
@@ -1,7 +1,7 @@
-import static org.junit.Assert.assertArrayEquals;
-
-import org.junit.Test;
 import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PascalsTriangleGeneratorTest {
 
@@ -12,7 +12,7 @@ public class PascalsTriangleGeneratorTest {
     public void testTriangleWithZeroRows() {
         int[][] expectedOutput = new int[][]{};
 
-        assertArrayEquals(expectedOutput, pascalsTriangleGenerator.generateTriangle(0));
+        assertThat(pascalsTriangleGenerator.generateTriangle(0)).isEqualTo(expectedOutput);
     }
 
     @Ignore("Remove to run test")
@@ -22,7 +22,7 @@ public class PascalsTriangleGeneratorTest {
             {1}
         };
 
-        assertArrayEquals(expectedOutput, pascalsTriangleGenerator.generateTriangle(1));
+        assertThat(pascalsTriangleGenerator.generateTriangle(1)).isEqualTo(expectedOutput);
     }
 
     @Ignore("Remove to run test")
@@ -33,7 +33,7 @@ public class PascalsTriangleGeneratorTest {
             {1, 1}
         };
 
-        assertArrayEquals(expectedOutput, pascalsTriangleGenerator.generateTriangle(2));
+        assertThat(pascalsTriangleGenerator.generateTriangle(2)).isEqualTo(expectedOutput);
     }
 
     @Ignore("Remove to run test")
@@ -45,7 +45,7 @@ public class PascalsTriangleGeneratorTest {
             {1, 2, 1}
         };
 
-        assertArrayEquals(expectedOutput, pascalsTriangleGenerator.generateTriangle(3));
+        assertThat(pascalsTriangleGenerator.generateTriangle(3)).isEqualTo(expectedOutput);
     }
 
     @Ignore("Remove to run test")
@@ -58,7 +58,7 @@ public class PascalsTriangleGeneratorTest {
             {1, 3, 3, 1}
         };
 
-        assertArrayEquals(expectedOutput, pascalsTriangleGenerator.generateTriangle(4));
+        assertThat(pascalsTriangleGenerator.generateTriangle(4)).isEqualTo(expectedOutput);
     }
 
     @Ignore("Remove to run test")
@@ -72,7 +72,7 @@ public class PascalsTriangleGeneratorTest {
             {1, 4, 6, 4, 1}
         };
 
-        assertArrayEquals(expectedOutput, pascalsTriangleGenerator.generateTriangle(5));
+        assertThat(pascalsTriangleGenerator.generateTriangle(5)).isEqualTo(expectedOutput);
     }
 
     @Ignore("Remove to run test")
@@ -87,7 +87,7 @@ public class PascalsTriangleGeneratorTest {
             {1, 5, 10, 10, 5, 1}
         };
 
-        assertArrayEquals(expectedOutput, pascalsTriangleGenerator.generateTriangle(6));
+        assertThat(pascalsTriangleGenerator.generateTriangle(6)).isEqualTo(expectedOutput);
     }
 
     @Ignore("Remove to run test")
@@ -106,6 +106,6 @@ public class PascalsTriangleGeneratorTest {
             {1, 9, 36, 84, 126, 126, 84, 36, 9, 1}
         };
 
-        assertArrayEquals(expectedOutput, pascalsTriangleGenerator.generateTriangle(10));
+        assertThat(pascalsTriangleGenerator.generateTriangle(10)).isEqualTo(expectedOutput);
     }
 }

--- a/exercises/practice/perfect-numbers/src/test/java/NaturalNumberTest.java
+++ b/exercises/practice/perfect-numbers/src/test/java/NaturalNumberTest.java
@@ -1,68 +1,68 @@
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.Assert.assertEquals;
-
 import org.junit.Ignore;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class NaturalNumberTest {
 
     @Test
     public void testSmallPerfectNumberIsClassifiedCorrectly() {
-        assertEquals(Classification.PERFECT, new NaturalNumber(6).getClassification());
+        assertThat(new NaturalNumber(6).getClassification()).isEqualTo(Classification.PERFECT);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testMediumPerfectNumberIsClassifiedCorrectly() {
-        assertEquals(Classification.PERFECT, new NaturalNumber(28).getClassification());
+        assertThat(new NaturalNumber(28).getClassification()).isEqualTo(Classification.PERFECT);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testLargePerfectNumberIsClassifiedCorrectly() {
-        assertEquals(Classification.PERFECT, new NaturalNumber(33550336).getClassification());
+        assertThat(new NaturalNumber(33550336).getClassification()).isEqualTo(Classification.PERFECT);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSmallAbundantNumberIsClassifiedCorrectly() {
-        assertEquals(Classification.ABUNDANT, new NaturalNumber(12).getClassification());
+        assertThat(new NaturalNumber(12).getClassification()).isEqualTo(Classification.ABUNDANT);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testMediumAbundantNumberIsClassifiedCorrectly() {
-        assertEquals(Classification.ABUNDANT, new NaturalNumber(30).getClassification());
+        assertThat(new NaturalNumber(30).getClassification()).isEqualTo(Classification.ABUNDANT);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testLargeAbundantNumberIsClassifiedCorrectly() {
-        assertEquals(Classification.ABUNDANT, new NaturalNumber(33550335).getClassification());
+        assertThat(new NaturalNumber(33550335).getClassification()).isEqualTo(Classification.ABUNDANT);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSmallestPrimeDeficientNumberIsClassifiedCorrectly() {
-        assertEquals(Classification.DEFICIENT, new NaturalNumber(2).getClassification());
+        assertThat(new NaturalNumber(2).getClassification()).isEqualTo(Classification.DEFICIENT);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSmallestNonPrimeDeficientNumberIsClassifiedCorrectly() {
-        assertEquals(Classification.DEFICIENT, new NaturalNumber(4).getClassification());
+        assertThat(new NaturalNumber(4).getClassification()).isEqualTo(Classification.DEFICIENT);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testMediumDeficientNumberIsClassifiedCorrectly() {
-        assertEquals(Classification.DEFICIENT, new NaturalNumber(32).getClassification());
+        assertThat(new NaturalNumber(32).getClassification()).isEqualTo(Classification.DEFICIENT);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testLargeDeficientNumberIsClassifiedCorrectly() {
-        assertEquals(Classification.DEFICIENT, new NaturalNumber(33550337).getClassification());
+        assertThat(new NaturalNumber(33550337).getClassification()).isEqualTo(Classification.DEFICIENT);
     }
 
     @Ignore("Remove to run test")
@@ -72,7 +72,7 @@ public class NaturalNumberTest {
      * additive identity is 0, so the aliquot sum of 1 should be 0. Hence 1 should be classified as deficient.
      */
     public void testThatOneIsCorrectlyClassifiedAsDeficient() {
-        assertEquals(Classification.DEFICIENT, new NaturalNumber(1).getClassification());
+        assertThat(new NaturalNumber(1).getClassification()).isEqualTo(Classification.DEFICIENT);
     }
 
     @Ignore("Remove to run test")

--- a/exercises/practice/pig-latin/src/test/java/PigLatinTranslatorTest.java
+++ b/exercises/practice/pig-latin/src/test/java/PigLatinTranslatorTest.java
@@ -2,7 +2,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PigLatinTranslatorTest {
 
@@ -15,132 +15,132 @@ public class PigLatinTranslatorTest {
 
     @Test
     public void testWordBeginningWithA() {
-        assertEquals("appleay", pigLatinTranslator.translate("apple"));
+        assertThat(pigLatinTranslator.translate("apple")).isEqualTo("appleay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testWordBeginningWithE() {
-        assertEquals("earay", pigLatinTranslator.translate("ear"));
+        assertThat(pigLatinTranslator.translate("ear")).isEqualTo("earay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testWordBeginningWithI() {
-        assertEquals("iglooay", pigLatinTranslator.translate("igloo"));
+        assertThat(pigLatinTranslator.translate("igloo")).isEqualTo("iglooay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testWordBeginningWithO() {
-        assertEquals("objectay", pigLatinTranslator.translate("object"));
+        assertThat(pigLatinTranslator.translate("object")).isEqualTo("objectay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testWordBeginningWithU() {
-        assertEquals("underay", pigLatinTranslator.translate("under"));
+        assertThat(pigLatinTranslator.translate("under")).isEqualTo("underay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testWordBeginningWithVowelAndFollowedByQu() {
-        assertEquals("equalay", pigLatinTranslator.translate("equal"));
+        assertThat(pigLatinTranslator.translate("equal")).isEqualTo("equalay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testWordBeginningWithP() {
-        assertEquals("igpay", pigLatinTranslator.translate("pig"));
+        assertThat(pigLatinTranslator.translate("pig")).isEqualTo("igpay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testWordBeginningWithK() {
-        assertEquals("oalakay", pigLatinTranslator.translate("koala"));
+        assertThat(pigLatinTranslator.translate("koala")).isEqualTo("oalakay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testWordBeginningWithX() {
-        assertEquals("enonxay", pigLatinTranslator.translate("xenon"));
+        assertThat(pigLatinTranslator.translate("xenon")).isEqualTo("enonxay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testWordBeginningWithQWithoutAFollowingU() {
-        assertEquals("atqay", pigLatinTranslator.translate("qat"));
+        assertThat(pigLatinTranslator.translate("qat")).isEqualTo("atqay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testChTreatedLikeAConsonantAtTheBeginningOfAWord() {
-        assertEquals("airchay", pigLatinTranslator.translate("chair"));
+        assertThat(pigLatinTranslator.translate("chair")).isEqualTo("airchay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testQuTreatedLikeAConsonantAtTheBeginningOfAWord() {
-        assertEquals("eenquay", pigLatinTranslator.translate("queen"));
+        assertThat(pigLatinTranslator.translate("queen")).isEqualTo("eenquay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testQuAndAPrecedingConsonantTreatedLikeAConsonantAtTheBeginningOfAWord() {
-        assertEquals("aresquay", pigLatinTranslator.translate("square"));
+        assertThat(pigLatinTranslator.translate("square")).isEqualTo("aresquay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThTreatedLikeAConsonantAtTheBeginningOfAWord() {
-        assertEquals("erapythay", pigLatinTranslator.translate("therapy"));
+        assertThat(pigLatinTranslator.translate("therapy")).isEqualTo("erapythay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testThrTreatedLikeAConsonantAtTheBeginningOfAWord() {
-        assertEquals("ushthray", pigLatinTranslator.translate("thrush"));
+        assertThat(pigLatinTranslator.translate("thrush")).isEqualTo("ushthray");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSchTreatedLikeAConsonantAtTheBeginningOfAWord() {
-        assertEquals("oolschay", pigLatinTranslator.translate("school"));
+        assertThat(pigLatinTranslator.translate("school")).isEqualTo("oolschay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testYtTreatedLikeAVowelAtTheBeginningOfAWord() {
-        assertEquals("yttriaay", pigLatinTranslator.translate("yttria"));
+        assertThat(pigLatinTranslator.translate("yttria")).isEqualTo("yttriaay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testXrTreatedLikeAVowelAtTheBeginningOfAWord() {
-        assertEquals("xrayay", pigLatinTranslator.translate("xray"));
+        assertThat(pigLatinTranslator.translate("xray")).isEqualTo("xrayay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testYTreatedLikeAConsonantAtTheBeginningOfAWord() {
-        assertEquals("ellowyay", pigLatinTranslator.translate("yellow"));
+        assertThat(pigLatinTranslator.translate("yellow")).isEqualTo("ellowyay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testYTreatedLikeAVowelAtTheEndOfAConsonantCluster() {
-        assertEquals("ythmrhay", pigLatinTranslator.translate("rhythm"));
+        assertThat(pigLatinTranslator.translate("rhythm")).isEqualTo("ythmrhay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testYAsSecondLetterInTwoLetterWord() {
-        assertEquals("ymay", pigLatinTranslator.translate("my"));
+        assertThat(pigLatinTranslator.translate("my")).isEqualTo("ymay");
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testAWholePhrase() {
-        assertEquals("ickquay astfay unray", pigLatinTranslator.translate("quick fast run"));
+        assertThat(pigLatinTranslator.translate("quick fast run")).isEqualTo("ickquay astfay unray");
     }
 }

--- a/exercises/practice/poker/src/test/java/PokerTest.java
+++ b/exercises/practice/poker/src/test/java/PokerTest.java
@@ -4,13 +4,13 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PokerTest {
     @Test
     public void oneHand() {
         String hand = "4S 5S 7H 8D JC";
-        assertEquals(Collections.singletonList(hand), new Poker(Collections.singletonList(hand)).getBestHands());
+        assertThat(new Poker(Collections.singletonList(hand)).getBestHands()).containsExactly(hand);
     }
 
     @Ignore("Remove to run test")
@@ -19,8 +19,7 @@ public class PokerTest {
         String highest8 = "4D 5S 6S 8D 3C";
         String highest10 = "2S 4C 7S 9H 10H";
         String highestJ = "3S 4S 5D 6H JH";
-        assertEquals(Collections.singletonList(highestJ),
-                     new Poker(Arrays.asList(highest8, highest10, highestJ)).getBestHands());
+        assertThat(new Poker(Arrays.asList(highest8, highest10, highestJ)).getBestHands()).containsExactly(highestJ);
     }
 
     @Ignore("Remove to run test")
@@ -30,8 +29,7 @@ public class PokerTest {
         String highest10 = "2S 4C 7S 9H 10H";
         String highestJh = "3S 4S 5D 6H JH";
         String highestJd = "3H 4H 5C 6C JD";
-        assertEquals(Arrays.asList(highestJh, highestJd),
-                     new Poker(Arrays.asList(highest8, highest10, highestJh, highestJd)).getBestHands());
+        assertThat(new Poker(Arrays.asList(highest8, highest10, highestJh, highestJd)).getBestHands()).containsExactly(highestJh, highestJd);
     }
 
     @Ignore("Remove to run test")
@@ -39,8 +37,7 @@ public class PokerTest {
     public void sameHighCards() {
         String nextHighest3 = "3S 5H 6S 8D 7H";
         String nextHighest2 = "2S 5D 6D 8C 7S";
-        assertEquals(Collections.singletonList(nextHighest3),
-                     new Poker(Arrays.asList(nextHighest3, nextHighest2)).getBestHands());
+        assertThat(new Poker(Arrays.asList(nextHighest3, nextHighest2)).getBestHands()).containsExactly(nextHighest3);
     }
 
     @Ignore("Remove to run test")
@@ -48,8 +45,7 @@ public class PokerTest {
     public void nothingVsOnePair() {
         String nothing = "4S 5H 6C 8D KH";
         String pairOf4 = "2S 4H 6S 4D JH";
-        assertEquals(Collections.singletonList(pairOf4),
-                     new Poker(Arrays.asList(nothing, pairOf4)).getBestHands());
+        assertThat(new Poker(Arrays.asList(nothing, pairOf4)).getBestHands()).containsExactly(pairOf4);
     }
 
     @Ignore("Remove to run test")
@@ -57,8 +53,7 @@ public class PokerTest {
     public void twoPairs() {
         String pairOf2 = "4S 2H 6S 2D JH";
         String pairOf4 = "2S 4H 6C 4D JD";
-        assertEquals(Collections.singletonList(pairOf4),
-                     new Poker(Arrays.asList(pairOf2, pairOf4)).getBestHands());
+        assertThat(new Poker(Arrays.asList(pairOf2, pairOf4)).getBestHands()).containsExactly(pairOf4);
     }
 
     @Ignore("Remove to run test")
@@ -66,8 +61,7 @@ public class PokerTest {
     public void onePairVsDoublePair() {
         String pairOf8 = "2S 8H 6S 8D JH";
         String doublePair = "4S 5H 4C 8C 5C";
-        assertEquals(Collections.singletonList(doublePair),
-                     new Poker(Arrays.asList(pairOf8, doublePair)).getBestHands());
+        assertThat(new Poker(Arrays.asList(pairOf8, doublePair)).getBestHands()).containsExactly(doublePair);
     }
 
     @Ignore("Remove to run test")
@@ -75,8 +69,7 @@ public class PokerTest {
     public void twoDoublePairs() {
         String doublePair2And8 = "2S 8H 2D 8D 3H";
         String doublePair4And5 = "4S 5H 4C 8S 5D";
-        assertEquals(Collections.singletonList(doublePair2And8),
-                     new Poker(Arrays.asList(doublePair2And8, doublePair4And5)).getBestHands());
+        assertThat(new Poker(Arrays.asList(doublePair2And8, doublePair4And5)).getBestHands()).containsExactly(doublePair2And8);
     }
 
     @Ignore("Remove to run test")
@@ -84,8 +77,7 @@ public class PokerTest {
     public void sameHighestPair() {
         String doublePair2AndQ = "2S QS 2C QD JH";
         String doublePairJAndQ = "JD QH JS 8D QC";
-        assertEquals(Collections.singletonList(doublePairJAndQ),
-                     new Poker(Arrays.asList(doublePairJAndQ, doublePair2AndQ)).getBestHands());
+        assertThat(new Poker(Arrays.asList(doublePairJAndQ, doublePair2AndQ)).getBestHands()).containsExactly(doublePairJAndQ);
     }
 
     @Ignore("Remove to run test")
@@ -93,7 +85,7 @@ public class PokerTest {
     public void identicallyRankedPairs() {
         String kicker8 = "JD QH JS 8D QC";
         String kicker2 = "JS QS JC 2D QD";
-        assertEquals(Collections.singletonList(kicker8), new Poker(Arrays.asList(kicker8, kicker2)).getBestHands());
+        assertThat(new Poker(Arrays.asList(kicker8, kicker2)).getBestHands()).containsExactly(kicker8);
     }
 
     @Ignore("Remove to run test")
@@ -101,8 +93,7 @@ public class PokerTest {
     public void doublePairVsThree() {
         String doublePair2And8 = "2S 8H 2H 8D JH";
         String threeOf4 = "4S 5H 4C 8S 4H";
-        assertEquals(Collections.singletonList(threeOf4),
-                     new Poker(Arrays.asList(doublePair2And8, threeOf4)).getBestHands());
+        assertThat(new Poker(Arrays.asList(doublePair2And8, threeOf4)).getBestHands()).containsExactly(threeOf4);
     }
 
     @Ignore("Remove to run test")
@@ -110,7 +101,7 @@ public class PokerTest {
     public void twoThrees() {
         String threeOf2 = "2S 2H 2C 8D JH";
         String threeOf1 = "4S AH AS 8C AD";
-        assertEquals(Collections.singletonList(threeOf1), new Poker(Arrays.asList(threeOf2, threeOf1)).getBestHands());
+        assertThat(new Poker(Arrays.asList(threeOf2, threeOf1)).getBestHands()).containsExactly(threeOf1);
     }
 
     @Ignore("Remove to run test")
@@ -118,8 +109,7 @@ public class PokerTest {
     public void sameThreesMultipleDecks() {
         String remainingCard7 = "4S AH AS 7C AD";
         String remainingCard8 = "4S AH AS 8C AD";
-        assertEquals(Collections.singletonList(remainingCard8),
-                new Poker(Arrays.asList(remainingCard7, remainingCard8)).getBestHands());
+        assertThat(new Poker(Arrays.asList(remainingCard7, remainingCard8)).getBestHands()).containsExactly(remainingCard8);
     }
 
     @Ignore("Remove to run test")
@@ -127,7 +117,7 @@ public class PokerTest {
     public void threeVsStraight() {
         String threeOf4 = "4S 5H 4C 8D 4H";
         String straight = "3S 4D 2S 6D 5C";
-        assertEquals(Collections.singletonList(straight), new Poker(Arrays.asList(threeOf4, straight)).getBestHands());
+        assertThat(new Poker(Arrays.asList(threeOf4, straight)).getBestHands()).containsExactly(straight);
     }
 
     @Ignore("Remove to run test")
@@ -135,8 +125,7 @@ public class PokerTest {
     public void acesCanEndAStraight() {
         String hand = "4S 5H 4C 8D 4H";
         String straightEndsA = "10D JH QS KD AC";
-        assertEquals(Collections.singletonList(straightEndsA),
-                     new Poker(Arrays.asList(hand, straightEndsA)).getBestHands());
+        assertThat(new Poker(Arrays.asList(hand, straightEndsA)).getBestHands()).containsExactly(straightEndsA);
     }
 
     @Ignore("Remove to run test")
@@ -144,8 +133,7 @@ public class PokerTest {
     public void acesCanStartAStraight() {
         String hand = "4S 5H 4C 8D 4H";
         String straightStartA = "4D AH 3S 2D 5C";
-        assertEquals(Collections.singletonList(straightStartA),
-                     new Poker(Arrays.asList(hand, straightStartA)).getBestHands());
+        assertThat(new Poker(Arrays.asList(hand, straightStartA)).getBestHands()).containsExactly(straightStartA);
     }
 
     @Ignore("Remove to run test")
@@ -153,8 +141,7 @@ public class PokerTest {
     public void twoStraights() {
         String straightTo8 = "4S 6C 7S 8D 5H";
         String straightTo9 = "5S 7H 8S 9D 6H";
-        assertEquals(Collections.singletonList(straightTo9),
-                     new Poker(Arrays.asList(straightTo8, straightTo9)).getBestHands());
+        assertThat(new Poker(Arrays.asList(straightTo8, straightTo9)).getBestHands()).containsExactly(straightTo9);
     }
 
     @Ignore("Remove to run test")
@@ -162,8 +149,7 @@ public class PokerTest {
     public void theLowestStraightStartsWithAce() {
         String straight = "2H 3C 4D 5D 6H";
         String straightStartA = "4S AH 3S 2D 5H";
-        assertEquals(Collections.singletonList(straight),
-                     new Poker(Arrays.asList(straight, straightStartA)).getBestHands());
+        assertThat(new Poker(Arrays.asList(straight, straightStartA)).getBestHands()).containsExactly(straight);
     }
 
     @Ignore("Remove to run test")
@@ -171,8 +157,7 @@ public class PokerTest {
     public void straightVsFlush() {
         String straightTo8 = "4C 6H 7D 8D 5H";
         String flushTo7 = "2S 4S 5S 6S 7S";
-        assertEquals(Collections.singletonList(flushTo7),
-                     new Poker(Arrays.asList(straightTo8, flushTo7)).getBestHands());
+        assertThat(new Poker(Arrays.asList(straightTo8, flushTo7)).getBestHands()).containsExactly(flushTo7);
     }
 
     @Ignore("Remove to run test")
@@ -180,7 +165,7 @@ public class PokerTest {
     public void twoFlushes() {
         String flushTo8 = "4H 7H 8H 9H 6H";
         String flushTo7 = "2S 4S 5S 6S 7S";
-        assertEquals(Collections.singletonList(flushTo8), new Poker(Arrays.asList(flushTo8, flushTo7)).getBestHands());
+        assertThat(new Poker(Arrays.asList(flushTo8, flushTo7)).getBestHands()).containsExactly(flushTo8);
     }
 
     @Ignore("Remove to run test")
@@ -188,7 +173,7 @@ public class PokerTest {
     public void flushVsFull() {
         String flushTo8 = "3H 6H 7H 8H 5H";
         String full = "4S 5H 4C 5D 4H";
-        assertEquals(Collections.singletonList(full), new Poker(Arrays.asList(full, flushTo8)).getBestHands());
+        assertThat(new Poker(Arrays.asList(full, flushTo8)).getBestHands()).containsExactly(full);
     }
 
     @Ignore("Remove to run test")
@@ -196,8 +181,7 @@ public class PokerTest {
     public void twoFulls() {
         String fullOf4By9 = "4H 4S 4D 9S 9D";
         String fullOf5By8 = "5H 5S 5D 8S 8D";
-        assertEquals(Collections.singletonList(fullOf5By8),
-                     new Poker(Arrays.asList(fullOf4By9, fullOf5By8)).getBestHands());
+        assertThat(new Poker(Arrays.asList(fullOf4By9, fullOf5By8)).getBestHands()).containsExactly(fullOf5By8);
     }
 
     @Ignore("Remove to run test")
@@ -205,8 +189,7 @@ public class PokerTest {
     public void twoFullssameThripletMultipleDecks() {
         String fullOf5By9 = "5H 5S 5D 9S 9D";
         String fullOf5By8 = "5H 5S 5D 8S 8D";
-        assertEquals(Collections.singletonList(fullOf5By9),
-                     new Poker(Arrays.asList(fullOf5By9, fullOf5By8)).getBestHands());
+        assertThat(new Poker(Arrays.asList(fullOf5By9, fullOf5By8)).getBestHands()).containsExactly(fullOf5By9);
     }
 
     @Ignore("Remove to run test")
@@ -214,7 +197,7 @@ public class PokerTest {
     public void fullVsSquare() {
         String full = "4S 5H 4D 5D 4H";
         String squareOf3 = "3S 3H 2S 3D 3C";
-        assertEquals(Collections.singletonList(squareOf3), new Poker(Arrays.asList(full, squareOf3)).getBestHands());
+        assertThat(new Poker(Arrays.asList(full, squareOf3)).getBestHands()).containsExactly(squareOf3);
     }
 
     @Ignore("Remove to run test")
@@ -222,8 +205,7 @@ public class PokerTest {
     public void twoSquares() {
         String squareOf2 = "2S 2H 2C 8D 2D";
         String squareOf5 = "4S 5H 5S 5D 5C";
-        assertEquals(Collections.singletonList(squareOf5),
-                     new Poker(Arrays.asList(squareOf2, squareOf5)).getBestHands());
+        assertThat(new Poker(Arrays.asList(squareOf2, squareOf5)).getBestHands()).containsExactly(squareOf5);
     }
 
     @Ignore("Remove to run test")
@@ -231,7 +213,7 @@ public class PokerTest {
     public void sameSquaresMultipleDecks() {
         String kicker2 = "3S 3H 2S 3D 3C";
         String kicker4 = "3S 3H 4S 3D 3C";
-        assertEquals(Collections.singletonList(kicker4), new Poker(Arrays.asList(kicker2, kicker4)).getBestHands());
+        assertThat(new Poker(Arrays.asList(kicker2, kicker4)).getBestHands()).containsExactly(kicker4);
     }
 
     @Ignore("Remove to run test")
@@ -239,8 +221,7 @@ public class PokerTest {
     public void squareVsStraightFlush() {
         String squareOf5 = "4S 5H 5S 5D 5C";
         String straightFlushTo9 = "7S 8S 9S 6S 10S";
-        assertEquals(Collections.singletonList(straightFlushTo9),
-                new Poker(Arrays.asList(squareOf5, straightFlushTo9)).getBestHands());
+        assertThat(new Poker(Arrays.asList(squareOf5, straightFlushTo9)).getBestHands()).containsExactly(straightFlushTo9);
     }
 
     @Ignore("Remove to run test")
@@ -248,7 +229,6 @@ public class PokerTest {
     public void twoStraightFlushes() {
         String straightFlushTo8 = "4H 6H 7H 8H 5H";
         String straightFlushTo9 = "5S 7S 8S 9S 6S";
-        assertEquals(Collections.singletonList(straightFlushTo9),
-                new Poker(Arrays.asList(straightFlushTo8, straightFlushTo9)).getBestHands());
+        assertThat(new Poker(Arrays.asList(straightFlushTo8, straightFlushTo9)).getBestHands()).containsExactly(straightFlushTo9);
     }
 }

--- a/exercises/practice/poker/src/test/java/PokerTest.java
+++ b/exercises/practice/poker/src/test/java/PokerTest.java
@@ -10,7 +10,8 @@ public class PokerTest {
     @Test
     public void oneHand() {
         String hand = "4S 5S 7H 8D JC";
-        assertThat(new Poker(Collections.singletonList(hand)).getBestHands()).containsExactly(hand);
+        assertThat(new Poker(Collections.singletonList(hand)).getBestHands())
+            .containsExactly(hand);
     }
 
     @Ignore("Remove to run test")
@@ -19,7 +20,8 @@ public class PokerTest {
         String highest8 = "4D 5S 6S 8D 3C";
         String highest10 = "2S 4C 7S 9H 10H";
         String highestJ = "3S 4S 5D 6H JH";
-        assertThat(new Poker(Arrays.asList(highest8, highest10, highestJ)).getBestHands()).containsExactly(highestJ);
+        assertThat(new Poker(Arrays.asList(highest8, highest10, highestJ)).getBestHands())
+            .containsExactly(highestJ);
     }
 
     @Ignore("Remove to run test")
@@ -29,7 +31,8 @@ public class PokerTest {
         String highest10 = "2S 4C 7S 9H 10H";
         String highestJh = "3S 4S 5D 6H JH";
         String highestJd = "3H 4H 5C 6C JD";
-        assertThat(new Poker(Arrays.asList(highest8, highest10, highestJh, highestJd)).getBestHands()).containsExactly(highestJh, highestJd);
+        assertThat(new Poker(Arrays.asList(highest8, highest10, highestJh, highestJd)).getBestHands())
+            .containsExactly(highestJh, highestJd);
     }
 
     @Ignore("Remove to run test")
@@ -37,7 +40,8 @@ public class PokerTest {
     public void sameHighCards() {
         String nextHighest3 = "3S 5H 6S 8D 7H";
         String nextHighest2 = "2S 5D 6D 8C 7S";
-        assertThat(new Poker(Arrays.asList(nextHighest3, nextHighest2)).getBestHands()).containsExactly(nextHighest3);
+        assertThat(new Poker(Arrays.asList(nextHighest3, nextHighest2)).getBestHands())
+            .containsExactly(nextHighest3);
     }
 
     @Ignore("Remove to run test")
@@ -45,7 +49,8 @@ public class PokerTest {
     public void nothingVsOnePair() {
         String nothing = "4S 5H 6C 8D KH";
         String pairOf4 = "2S 4H 6S 4D JH";
-        assertThat(new Poker(Arrays.asList(nothing, pairOf4)).getBestHands()).containsExactly(pairOf4);
+        assertThat(new Poker(Arrays.asList(nothing, pairOf4)).getBestHands())
+            .containsExactly(pairOf4);
     }
 
     @Ignore("Remove to run test")
@@ -53,7 +58,8 @@ public class PokerTest {
     public void twoPairs() {
         String pairOf2 = "4S 2H 6S 2D JH";
         String pairOf4 = "2S 4H 6C 4D JD";
-        assertThat(new Poker(Arrays.asList(pairOf2, pairOf4)).getBestHands()).containsExactly(pairOf4);
+        assertThat(new Poker(Arrays.asList(pairOf2, pairOf4)).getBestHands())
+            .containsExactly(pairOf4);
     }
 
     @Ignore("Remove to run test")
@@ -61,7 +67,8 @@ public class PokerTest {
     public void onePairVsDoublePair() {
         String pairOf8 = "2S 8H 6S 8D JH";
         String doublePair = "4S 5H 4C 8C 5C";
-        assertThat(new Poker(Arrays.asList(pairOf8, doublePair)).getBestHands()).containsExactly(doublePair);
+        assertThat(new Poker(Arrays.asList(pairOf8, doublePair)).getBestHands())
+            .containsExactly(doublePair);
     }
 
     @Ignore("Remove to run test")
@@ -69,7 +76,8 @@ public class PokerTest {
     public void twoDoublePairs() {
         String doublePair2And8 = "2S 8H 2D 8D 3H";
         String doublePair4And5 = "4S 5H 4C 8S 5D";
-        assertThat(new Poker(Arrays.asList(doublePair2And8, doublePair4And5)).getBestHands()).containsExactly(doublePair2And8);
+        assertThat(new Poker(Arrays.asList(doublePair2And8, doublePair4And5)).getBestHands())
+            .containsExactly(doublePair2And8);
     }
 
     @Ignore("Remove to run test")
@@ -77,7 +85,8 @@ public class PokerTest {
     public void sameHighestPair() {
         String doublePair2AndQ = "2S QS 2C QD JH";
         String doublePairJAndQ = "JD QH JS 8D QC";
-        assertThat(new Poker(Arrays.asList(doublePairJAndQ, doublePair2AndQ)).getBestHands()).containsExactly(doublePairJAndQ);
+        assertThat(new Poker(Arrays.asList(doublePairJAndQ, doublePair2AndQ)).getBestHands())
+            .containsExactly(doublePairJAndQ);
     }
 
     @Ignore("Remove to run test")
@@ -85,7 +94,8 @@ public class PokerTest {
     public void identicallyRankedPairs() {
         String kicker8 = "JD QH JS 8D QC";
         String kicker2 = "JS QS JC 2D QD";
-        assertThat(new Poker(Arrays.asList(kicker8, kicker2)).getBestHands()).containsExactly(kicker8);
+        assertThat(new Poker(Arrays.asList(kicker8, kicker2)).getBestHands())
+            .containsExactly(kicker8);
     }
 
     @Ignore("Remove to run test")
@@ -93,7 +103,8 @@ public class PokerTest {
     public void doublePairVsThree() {
         String doublePair2And8 = "2S 8H 2H 8D JH";
         String threeOf4 = "4S 5H 4C 8S 4H";
-        assertThat(new Poker(Arrays.asList(doublePair2And8, threeOf4)).getBestHands()).containsExactly(threeOf4);
+        assertThat(new Poker(Arrays.asList(doublePair2And8, threeOf4)).getBestHands())
+            .containsExactly(threeOf4);
     }
 
     @Ignore("Remove to run test")
@@ -101,7 +112,8 @@ public class PokerTest {
     public void twoThrees() {
         String threeOf2 = "2S 2H 2C 8D JH";
         String threeOf1 = "4S AH AS 8C AD";
-        assertThat(new Poker(Arrays.asList(threeOf2, threeOf1)).getBestHands()).containsExactly(threeOf1);
+        assertThat(new Poker(Arrays.asList(threeOf2, threeOf1)).getBestHands())
+            .containsExactly(threeOf1);
     }
 
     @Ignore("Remove to run test")
@@ -109,7 +121,8 @@ public class PokerTest {
     public void sameThreesMultipleDecks() {
         String remainingCard7 = "4S AH AS 7C AD";
         String remainingCard8 = "4S AH AS 8C AD";
-        assertThat(new Poker(Arrays.asList(remainingCard7, remainingCard8)).getBestHands()).containsExactly(remainingCard8);
+        assertThat(new Poker(Arrays.asList(remainingCard7, remainingCard8)).getBestHands())
+            .containsExactly(remainingCard8);
     }
 
     @Ignore("Remove to run test")
@@ -117,7 +130,8 @@ public class PokerTest {
     public void threeVsStraight() {
         String threeOf4 = "4S 5H 4C 8D 4H";
         String straight = "3S 4D 2S 6D 5C";
-        assertThat(new Poker(Arrays.asList(threeOf4, straight)).getBestHands()).containsExactly(straight);
+        assertThat(new Poker(Arrays.asList(threeOf4, straight)).getBestHands())
+            .containsExactly(straight);
     }
 
     @Ignore("Remove to run test")
@@ -125,7 +139,8 @@ public class PokerTest {
     public void acesCanEndAStraight() {
         String hand = "4S 5H 4C 8D 4H";
         String straightEndsA = "10D JH QS KD AC";
-        assertThat(new Poker(Arrays.asList(hand, straightEndsA)).getBestHands()).containsExactly(straightEndsA);
+        assertThat(new Poker(Arrays.asList(hand, straightEndsA)).getBestHands())
+            .containsExactly(straightEndsA);
     }
 
     @Ignore("Remove to run test")
@@ -133,7 +148,8 @@ public class PokerTest {
     public void acesCanStartAStraight() {
         String hand = "4S 5H 4C 8D 4H";
         String straightStartA = "4D AH 3S 2D 5C";
-        assertThat(new Poker(Arrays.asList(hand, straightStartA)).getBestHands()).containsExactly(straightStartA);
+        assertThat(new Poker(Arrays.asList(hand, straightStartA)).getBestHands())
+            .containsExactly(straightStartA);
     }
 
     @Ignore("Remove to run test")
@@ -141,7 +157,8 @@ public class PokerTest {
     public void twoStraights() {
         String straightTo8 = "4S 6C 7S 8D 5H";
         String straightTo9 = "5S 7H 8S 9D 6H";
-        assertThat(new Poker(Arrays.asList(straightTo8, straightTo9)).getBestHands()).containsExactly(straightTo9);
+        assertThat(new Poker(Arrays.asList(straightTo8, straightTo9)).getBestHands())
+            .containsExactly(straightTo9);
     }
 
     @Ignore("Remove to run test")
@@ -149,7 +166,8 @@ public class PokerTest {
     public void theLowestStraightStartsWithAce() {
         String straight = "2H 3C 4D 5D 6H";
         String straightStartA = "4S AH 3S 2D 5H";
-        assertThat(new Poker(Arrays.asList(straight, straightStartA)).getBestHands()).containsExactly(straight);
+        assertThat(new Poker(Arrays.asList(straight, straightStartA)).getBestHands())
+            .containsExactly(straight);
     }
 
     @Ignore("Remove to run test")
@@ -157,7 +175,8 @@ public class PokerTest {
     public void straightVsFlush() {
         String straightTo8 = "4C 6H 7D 8D 5H";
         String flushTo7 = "2S 4S 5S 6S 7S";
-        assertThat(new Poker(Arrays.asList(straightTo8, flushTo7)).getBestHands()).containsExactly(flushTo7);
+        assertThat(new Poker(Arrays.asList(straightTo8, flushTo7)).getBestHands())
+            .containsExactly(flushTo7);
     }
 
     @Ignore("Remove to run test")
@@ -165,7 +184,8 @@ public class PokerTest {
     public void twoFlushes() {
         String flushTo8 = "4H 7H 8H 9H 6H";
         String flushTo7 = "2S 4S 5S 6S 7S";
-        assertThat(new Poker(Arrays.asList(flushTo8, flushTo7)).getBestHands()).containsExactly(flushTo8);
+        assertThat(new Poker(Arrays.asList(flushTo8, flushTo7)).getBestHands())
+            .containsExactly(flushTo8);
     }
 
     @Ignore("Remove to run test")
@@ -173,7 +193,8 @@ public class PokerTest {
     public void flushVsFull() {
         String flushTo8 = "3H 6H 7H 8H 5H";
         String full = "4S 5H 4C 5D 4H";
-        assertThat(new Poker(Arrays.asList(full, flushTo8)).getBestHands()).containsExactly(full);
+        assertThat(new Poker(Arrays.asList(full, flushTo8)).getBestHands())
+            .containsExactly(full);
     }
 
     @Ignore("Remove to run test")
@@ -181,7 +202,8 @@ public class PokerTest {
     public void twoFulls() {
         String fullOf4By9 = "4H 4S 4D 9S 9D";
         String fullOf5By8 = "5H 5S 5D 8S 8D";
-        assertThat(new Poker(Arrays.asList(fullOf4By9, fullOf5By8)).getBestHands()).containsExactly(fullOf5By8);
+        assertThat(new Poker(Arrays.asList(fullOf4By9, fullOf5By8)).getBestHands())
+            .containsExactly(fullOf5By8);
     }
 
     @Ignore("Remove to run test")
@@ -189,7 +211,8 @@ public class PokerTest {
     public void twoFullssameThripletMultipleDecks() {
         String fullOf5By9 = "5H 5S 5D 9S 9D";
         String fullOf5By8 = "5H 5S 5D 8S 8D";
-        assertThat(new Poker(Arrays.asList(fullOf5By9, fullOf5By8)).getBestHands()).containsExactly(fullOf5By9);
+        assertThat(new Poker(Arrays.asList(fullOf5By9, fullOf5By8)).getBestHands())
+            .containsExactly(fullOf5By9);
     }
 
     @Ignore("Remove to run test")
@@ -197,7 +220,8 @@ public class PokerTest {
     public void fullVsSquare() {
         String full = "4S 5H 4D 5D 4H";
         String squareOf3 = "3S 3H 2S 3D 3C";
-        assertThat(new Poker(Arrays.asList(full, squareOf3)).getBestHands()).containsExactly(squareOf3);
+        assertThat(new Poker(Arrays.asList(full, squareOf3)).getBestHands())
+            .containsExactly(squareOf3);
     }
 
     @Ignore("Remove to run test")
@@ -205,7 +229,8 @@ public class PokerTest {
     public void twoSquares() {
         String squareOf2 = "2S 2H 2C 8D 2D";
         String squareOf5 = "4S 5H 5S 5D 5C";
-        assertThat(new Poker(Arrays.asList(squareOf2, squareOf5)).getBestHands()).containsExactly(squareOf5);
+        assertThat(new Poker(Arrays.asList(squareOf2, squareOf5)).getBestHands())
+            .containsExactly(squareOf5);
     }
 
     @Ignore("Remove to run test")
@@ -213,7 +238,8 @@ public class PokerTest {
     public void sameSquaresMultipleDecks() {
         String kicker2 = "3S 3H 2S 3D 3C";
         String kicker4 = "3S 3H 4S 3D 3C";
-        assertThat(new Poker(Arrays.asList(kicker2, kicker4)).getBestHands()).containsExactly(kicker4);
+        assertThat(new Poker(Arrays.asList(kicker2, kicker4)).getBestHands())
+            .containsExactly(kicker4);
     }
 
     @Ignore("Remove to run test")
@@ -221,7 +247,8 @@ public class PokerTest {
     public void squareVsStraightFlush() {
         String squareOf5 = "4S 5H 5S 5D 5C";
         String straightFlushTo9 = "7S 8S 9S 6S 10S";
-        assertThat(new Poker(Arrays.asList(squareOf5, straightFlushTo9)).getBestHands()).containsExactly(straightFlushTo9);
+        assertThat(new Poker(Arrays.asList(squareOf5, straightFlushTo9)).getBestHands())
+            .containsExactly(straightFlushTo9);
     }
 
     @Ignore("Remove to run test")
@@ -229,6 +256,7 @@ public class PokerTest {
     public void twoStraightFlushes() {
         String straightFlushTo8 = "4H 6H 7H 8H 5H";
         String straightFlushTo9 = "5S 7S 8S 9S 6S";
-        assertThat(new Poker(Arrays.asList(straightFlushTo8, straightFlushTo9)).getBestHands()).containsExactly(straightFlushTo9);
+        assertThat(new Poker(Arrays.asList(straightFlushTo8, straightFlushTo9)).getBestHands())
+            .containsExactly(straightFlushTo9);
     }
 }

--- a/exercises/practice/pov/src/test/java/PovTest.java
+++ b/exercises/practice/pov/src/test/java/PovTest.java
@@ -1,10 +1,10 @@
-import static org.junit.Assert.*;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import org.junit.Ignore;
+import org.junit.Test;
 
 import java.util.List;
 
-import org.junit.Ignore;
-import org.junit.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public class PovTest {
 
@@ -12,7 +12,7 @@ public class PovTest {
     public void testFromPovGivenSingletonTree() {
         Tree tree = Tree.of("x");
         Tree expected = Tree.of("x");
-        assertEquals(expected, tree.fromPov("x"));
+        assertThat(tree.fromPov("x")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -25,7 +25,7 @@ public class PovTest {
         Tree expected = Tree.of("x",
                 List.of(Tree.of("parent",
                         List.of(Tree.of("sibling")))));
-        assertEquals(expected, tree.fromPov("x"));
+        assertThat(tree.fromPov("x")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -43,7 +43,7 @@ public class PovTest {
                                 Tree.of("b"),
                                 Tree.of("c")))));
 
-        assertEquals(expected, tree.fromPov("x"));
+        assertThat(tree.fromPov("x")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -61,7 +61,7 @@ public class PovTest {
                                 List.of(Tree.of("level-1",
                                         List.of(Tree.of("level-0")))))))));
 
-        assertEquals(expected, tree.fromPov("x"));
+        assertThat(tree.fromPov("x")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -77,7 +77,7 @@ public class PovTest {
                         Tree.of("kid-1"),
                         Tree.of("parent")));
 
-        assertEquals(expected, tree.fromPov("x"));
+        assertThat(tree.fromPov("x")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -105,7 +105,7 @@ public class PovTest {
                                                         List.of(Tree.of("cousin-0"),
                                                                 Tree.of("cousin-1")))))))));
 
-        assertEquals(expected, tree.fromPov("x"));
+        assertThat(tree.fromPov("x")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -140,7 +140,7 @@ public class PovTest {
                         Tree.of("sibling")));
 
         List<String> expected = List.of("x", "parent");
-        assertEquals(expected, tree.pathTo("x", "parent"));
+        assertThat(tree.pathTo("x", "parent")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -153,7 +153,7 @@ public class PovTest {
                         Tree.of("c")));
 
         List<String> expected = List.of("x", "parent", "b");
-        assertEquals(expected, tree.pathTo("x", "b"));
+        assertThat(tree.pathTo("x", "b")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -171,7 +171,7 @@ public class PovTest {
                                         Tree.of("cousin-1")))));
 
         List<String> expected = List.of("x", "parent", "grandparent", "uncle", "cousin-1");
-        assertEquals(expected, tree.pathTo("x", "cousin-1"));
+        assertThat(tree.pathTo("x", "cousin-1")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -184,7 +184,7 @@ public class PovTest {
                                 Tree.of("sibling-1")))));
 
         List<String> expected = List.of("x", "parent", "sibling-1");
-        assertEquals(expected, tree.pathTo("x", "sibling-1"));
+        assertThat(tree.pathTo("x", "sibling-1")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -197,7 +197,7 @@ public class PovTest {
                         Tree.of("c")));
 
         List<String> expected = List.of("a", "parent", "c");
-        assertEquals(expected, tree.pathTo("a", "c"));
+        assertThat(tree.pathTo("a", "c")).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")

--- a/exercises/practice/prime-factors/src/test/java/PrimeFactorsCalculatorTest.java
+++ b/exercises/practice/prime-factors/src/test/java/PrimeFactorsCalculatorTest.java
@@ -2,10 +2,7 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.Collections;
-
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PrimeFactorsCalculatorTest {
 
@@ -18,43 +15,43 @@ public class PrimeFactorsCalculatorTest {
 
     @Test
     public void testNoFactors() {
-        assertEquals(Collections.emptyList(), primeFactorsCalculator.calculatePrimeFactorsOf(1L));
+        assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(1L)).isEmpty();
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testPrimeNumber() {
-        assertEquals(Collections.singletonList(2L), primeFactorsCalculator.calculatePrimeFactorsOf(2L));
+        assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(2L)).containsExactly(2L);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testSquareOfAPrime() {
-        assertEquals(Arrays.asList(3L, 3L), primeFactorsCalculator.calculatePrimeFactorsOf(9L));
+        assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(9L)).containsExactly(3L, 3L);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testCubeOfAPrime() {
-        assertEquals(Arrays.asList(2L, 2L, 2L), primeFactorsCalculator.calculatePrimeFactorsOf(8L));
+        assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(8L)).containsExactly(2L, 2L, 2L);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testProductOfPrimesAndNonPrimes() {
-        assertEquals(Arrays.asList(2L, 2L, 3L), primeFactorsCalculator.calculatePrimeFactorsOf(12L));
+        assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(12L)).containsExactly(2L, 2L, 3L);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testProductOfPrimes() {
-        assertEquals(Arrays.asList(5L, 17L, 23L, 461L), primeFactorsCalculator.calculatePrimeFactorsOf(901255L));
+        assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(901255L)).containsExactly(5L, 17L, 23L, 461L);
     }
 
     @Ignore("Remove to run test")
     @Test
     public void testFactorsIncludingALargePrime() {
-        assertEquals(Arrays.asList(11L, 9539L, 894119L), primeFactorsCalculator.calculatePrimeFactorsOf(93819012551L));
+        assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(93819012551L)).containsExactly(11L, 9539L, 894119L);
     }
 
 }

--- a/exercises/practice/pythagorean-triplet/src/test/java/PythagoreanTripletTest.java
+++ b/exercises/practice/pythagorean-triplet/src/test/java/PythagoreanTripletTest.java
@@ -1,10 +1,11 @@
+import org.junit.Ignore;
+import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Collections;
-import static org.junit.Assert.assertEquals;
-import org.junit.Test;
-import org.junit.Ignore;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class PythagoreanTripletTest {
 
@@ -17,7 +18,7 @@ public class PythagoreanTripletTest {
                         .build();
         List<PythagoreanTriplet> expected
                 = Collections.singletonList(new PythagoreanTriplet(3, 4, 5));
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -30,7 +31,7 @@ public class PythagoreanTripletTest {
                         .build();
         List<PythagoreanTriplet> expected
                 = Collections.singletonList(new PythagoreanTriplet(27, 36, 45));
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -44,7 +45,7 @@ public class PythagoreanTripletTest {
                         .build();
         List<PythagoreanTriplet> expected
                 = Collections.singletonList(new PythagoreanTriplet(200, 375, 425));
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -56,7 +57,7 @@ public class PythagoreanTripletTest {
                         .thatSumTo(1001)
                         .build();
         List<PythagoreanTriplet> expected = Collections.emptyList();
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -71,7 +72,7 @@ public class PythagoreanTripletTest {
                 = Arrays.asList(
                         new PythagoreanTriplet(9, 40, 41),
                         new PythagoreanTriplet(15, 36, 39));
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -92,7 +93,7 @@ public class PythagoreanTripletTest {
                         new PythagoreanTriplet(168, 315, 357),
                         new PythagoreanTriplet(210, 280, 350),
                         new PythagoreanTriplet(240, 252, 348));
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -111,7 +112,7 @@ public class PythagoreanTripletTest {
                         new PythagoreanTriplet(168, 315, 357),
                         new PythagoreanTriplet(210, 280, 350),
                         new PythagoreanTriplet(240, 252, 348));
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -129,7 +130,7 @@ public class PythagoreanTripletTest {
                         new PythagoreanTriplet(5000, 12000, 13000),
                         new PythagoreanTriplet(6000, 11250, 12750),
                         new PythagoreanTriplet(7500, 10000, 12500));
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Ignore("Remove to run test")
@@ -143,6 +144,6 @@ public class PythagoreanTripletTest {
                         .build();
         List<PythagoreanTriplet> expected
                 = Arrays.asList(new PythagoreanTriplet(7500, 10000, 12500));
-        assertEquals(expected, actual);
+        assertThat(actual).isEqualTo(expected);
     }
 }


### PR DESCRIPTION
# pull request for (#2147 )

<!-- Your content goes here: -->
In this Pr, all the below tests have been updated to use assertj
1.  ComplexNumberTest.java
2. EtlTest.java
3. FlattenerTest.java
4. FoodChainTest.java
5. GigasecondTest.java
6. GoCountingTest.java
7. GrainsTest.java
8. GrepToolTest.java
9. IsbnVerifierTest.java
10. LargestSeriesProductCalculatorTest.java
11. MatrixTest.java
12. MeetupTest.java
13. MicroBlogTest.java
14. MinesweeperBoardTest.java
15. NucleotideCounterTest.java
16. OctalTest.java
17. PascalsTriangleGeneratorTest.java
18. NaturalNumberTest.java
19. PigLatinTranslatorTest.java
20. PokerTest.java
21. PovTest.java
22. PrimeFactorsCalculatorTest.java
23. PythagoreanTripletTest.java


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
