### PR TITLE
Update CarsAssembleTest.java

### DIFF
--- a/exercises/concept/cars-assemble/src/test/java/CarsAssembleTest.java
+++ b/exercises/concept/cars-assemble/src/test/java/CarsAssembleTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class CarsAssembleTest {
@@ -20,42 +21,42 @@ public class CarsAssembleTest {
     @Tag("task:1")
     @DisplayName("The productionRatePerHour method returns the correct result when line's speed is 0")
     public void productionRatePerHourForSpeedZero() {
-        assertThat(Math.abs(carsAssemble.productionRatePerHour(0) - 0.0) < epsilon).isTrue();
+        assertEquals(0.0, carsAssemble.productionRatePerHour(0), epsilon);
     }
 
     @Test
     @Tag("task:1")
     @DisplayName("The productionRatePerHour method returns the correct result when line's speed is 1")
     public void productionRatePerHourForSpeedOne() {
-        assertThat(Math.abs(carsAssemble.productionRatePerHour(1) - 221.0) < epsilon).isTrue();
+        assertEquals(221.0, carsAssemble.productionRatePerHour(1), epsilon);
     }
 
     @Test
     @Tag("task:1")
     @DisplayName("The productionRatePerHour method returns the correct result when line's speed is 4")
     public void productionRatePerHourForSpeedFour() {
-        assertThat(Math.abs(carsAssemble.productionRatePerHour(4) - 884.0) < epsilon).isTrue();
+        assertEquals(884.0, carsAssemble.productionRatePerHour(4), epsilon);
     }
 
     @Test
     @Tag("task:1")
     @DisplayName("The productionRatePerHour method returns the correct result when line's speed is 7")
     public void productionRatePerHourForSpeedSeven() {
-        assertThat(Math.abs(carsAssemble.productionRatePerHour(7) - 1392.3) < epsilon).isTrue();
+        assertEquals(1392.3, carsAssemble.productionRatePerHour(7), epsilon);
     }
 
     @Test
     @Tag("task:1")
     @DisplayName("The productionRatePerHour method returns the correct result when line's speed is 9")
     public void productionRatePerHourForSpeedNine() {
-        assertThat(Math.abs(carsAssemble.productionRatePerHour(9) - 1591.2) < epsilon).isTrue();
+        assertEquals(1591.2, carsAssemble.productionRatePerHour(9), epsilon);
     }
 
     @Test
     @Tag("task:1")
     @DisplayName("The productionRatePerHour method returns the correct result when line's speed is 10")
     public void productionRatePerHourForSpeedTen() {
-        assertThat(Math.abs(carsAssemble.productionRatePerHour(10) - 1701.7) < epsilon).isTrue();
+        assertEquals(1701.7, carsAssemble.productionRatePerHour(10), epsilon);
     }
 
     @Test

--- a/exercises/concept/cars-assemble/src/test/java/CarsAssembleTest.java
+++ b/exercises/concept/cars-assemble/src/test/java/CarsAssembleTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.within;
 
 
 public class CarsAssembleTest {
@@ -21,42 +21,42 @@ public class CarsAssembleTest {
     @Tag("task:1")
     @DisplayName("The productionRatePerHour method returns the correct result when line's speed is 0")
     public void productionRatePerHourForSpeedZero() {
-        assertEquals(0.0, carsAssemble.productionRatePerHour(0), epsilon);
+        assertThat(carsAssemble.productionRatePerHour(0)).isCloseTo(0.0, within(epsilon));
     }
 
     @Test
     @Tag("task:1")
     @DisplayName("The productionRatePerHour method returns the correct result when line's speed is 1")
     public void productionRatePerHourForSpeedOne() {
-        assertEquals(221.0, carsAssemble.productionRatePerHour(1), epsilon);
+        assertThat(carsAssemble.productionRatePerHour(1)).isCloseTo(221.0, within(epsilon));
     }
 
     @Test
     @Tag("task:1")
     @DisplayName("The productionRatePerHour method returns the correct result when line's speed is 4")
     public void productionRatePerHourForSpeedFour() {
-        assertEquals(884.0, carsAssemble.productionRatePerHour(4), epsilon);
+        assertThat(carsAssemble.productionRatePerHour(4)).isCloseTo(884.0, within(epsilon));
     }
 
     @Test
     @Tag("task:1")
     @DisplayName("The productionRatePerHour method returns the correct result when line's speed is 7")
     public void productionRatePerHourForSpeedSeven() {
-        assertEquals(1392.3, carsAssemble.productionRatePerHour(7), epsilon);
+        assertThat(carsAssemble.productionRatePerHour(7)).isCloseTo(1392.3, within(epsilon));
     }
 
     @Test
     @Tag("task:1")
     @DisplayName("The productionRatePerHour method returns the correct result when line's speed is 9")
     public void productionRatePerHourForSpeedNine() {
-        assertEquals(1591.2, carsAssemble.productionRatePerHour(9), epsilon);
+        assertThat(carsAssemble.productionRatePerHour(9)).isCloseTo(1591.2, within(epsilon));
     }
 
     @Test
     @Tag("task:1")
     @DisplayName("The productionRatePerHour method returns the correct result when line's speed is 10")
     public void productionRatePerHourForSpeedTen() {
-        assertEquals(1701.7, carsAssemble.productionRatePerHour(10), epsilon);
+        assertThat(carsAssemble.productionRatePerHour(10)).isCloseTo(1701.7, within(epsilon));
     }
 
     @Test


### PR DESCRIPTION
Tests for Task 1 used a boolean comparison to determine whether tests pass. Replaced those with more idiomatic assertEquals(double, double, epsilon) form. 

When the new style of test fails the user is shown the expected value and the actual value: 
Expected :1591.2
Actual   :1989.0
The previous implementation showed the user the  less clear: 
Expected :true
Actual   :false

The test implementation being replaced required the comparison to be strictly less than epsilon, not inclusive of epsilon. The JUnit assertEquals replacement check is inclusive of epsilon. OLD: Math.abs(value1 - value2) < epsilon)
NEW: Math.abs(value1 - value2) <= epsilon

Given an epsilon of 0.0000001d this is unlikely to see any existing solutions fail given the expected answers only check the tenths place.

# pull request

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
