### PR TITLE
Remove duplicate Gradle workflows being triggered

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,9 +1,11 @@
-# This workflow will build a Java project with Gradle
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
-
 name: Java CI with Gradle
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 defaults:
   run:


### PR DESCRIPTION
Currently the Gradle CI action is run twice for every push to every PR, one for the push event and another for the PR event. This changes the workflow to only run for push events to the `main` branch.

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
