### PR TITLE
Run tests using java-test-runner

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,4 +1,4 @@
-name: Java CI with Gradle
+name: Gradle
 
 on:
   pull_request:
@@ -14,7 +14,6 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 1.17
@@ -22,16 +21,11 @@ jobs:
         with:
           java-version: 17
           distribution: "temurin"
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
       - name: Check if tests compile cleanly with starter sources
         run: ./gradlew compileStarterTestJava --continue
-      - name: Run checkstyle
-        run: ./gradlew check --exclude-task test --continue
 
-  test:
+  lint:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 1.17
@@ -39,12 +33,5 @@ jobs:
         with:
           java-version: 17
           distribution: "temurin"
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-      - name: Test all reference implementations with Gradle
-        run: ./gradlew test --continue
-      - name: Create test summary
-        uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f
-        with:
-          paths: "**/build/test-results/test/*.xml"
-        if: always()
+      - name: Run checkstyle
+        run: ./gradlew check --exclude-task test --continue

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -13,7 +13,7 @@ defaults:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 1.17
@@ -25,7 +25,7 @@ jobs:
         run: ./gradlew compileStarterTestJava --continue
 
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Set up JDK 1.17

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,3 +14,9 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Test all exercises using java-test-runner
         run: bin/test-with-test-runner
+      - name: Archive test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: exercises/**/build/results.json
+        if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - name: Test all exercises using java-test-runner
+        run: bin/test-with-test-runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - name: Test all exercises using java-test-runner

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,4 +19,4 @@ jobs:
         with:
           name: test-results
           path: exercises/**/build/results.json
-        if: always()
+        if: failure()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Test all exercises using java-test-runner
         run: bin/test-with-test-runner
       - name: Archive test results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
         with:
           name: test-results
           path: exercises/**/build/results.json

--- a/bin/test-with-test-runner
+++ b/bin/test-with-test-runner
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+# Test if the example/exemplar solution of each
+# Practice/Concept Exercise passes the exercise's tests.
+
+# Example:
+# ./bin/test-with-test-runner
+
+set -eo pipefail
+
+docker pull exercism/java-test-runner
+
+exit_code=0
+
+function run_test_runner() {
+    local dir=$1
+    local slug=$2
+
+    docker run \
+        --rm \
+        --network none \
+        --mount type=bind,src="${dir}",dst=/solution \
+        --mount type=bind,src="${dir}",dst=/output \
+        --tmpfs /tmp:rw \
+        exercism/java-test-runner "${slug}" "/solution" "/output"
+}
+
+function verify_exercise() {
+    local dir=$(realpath $1)
+    local slug=$(basename "${dir}")
+    local implementation_file_key=$2
+    local implementation_file=$(jq -r --arg d "${dir}" --arg k "${implementation_file_key}" '$d + "/" + .files[$k][0]' "${dir}/.meta/config.json")
+    local stub_file=$(jq -r --arg d "${dir}" '$d + "/" + .files.solution[0]' "${dir}/.meta/config.json")
+    local stub_backup_file="${stub_file}.bak"
+    local results_file="${dir}/results.json"
+
+    cp "${stub_file}" "${stub_backup_file}"
+    cp "${implementation_file}" "${stub_file}"
+
+    run_test_runner "${dir}" "${slug}"
+
+    if [[ $(jq -r '.status' "${results_file}") != "pass" ]]; then
+        echo "${slug}: ${implementation_file_key} solution did not pass the tests"
+        exit_code=1
+    fi
+
+    mv "${stub_backup_file}" "${stub_file}"
+    rm -f "${results_file}"
+}
+
+# Verify the Concept Exercises
+for concept_exercise_dir in ./exercises/concept/*/; do
+    if [ -d $concept_exercise_dir ]; then
+        echo "Checking $(basename "${concept_exercise_dir}") exercise..."
+        verify_exercise $concept_exercise_dir "exemplar"
+    fi
+done
+
+# Verify the Practice Exercises
+for practice_exercise_dir in ./exercises/practice/*/; do
+    if [ -d $practice_exercise_dir ]; then
+        echo "Checking $(basename "${practice_exercise_dir}") exercise..."
+        verify_exercise $practice_exercise_dir "example"
+    fi
+done
+
+exit ${exit_code}

--- a/bin/test-with-test-runner
+++ b/bin/test-with-test-runner
@@ -31,14 +31,21 @@ function verify_exercise() {
     local slug=$(basename "${dir}")
     local output_dir="${dir}/build"
     local implementation_file_key=$2
-    local implementation_file=$(jq -r --arg d "${dir}" --arg k "${implementation_file_key}" '$d + "/" + .files[$k][0]' "${dir}/.meta/config.json")
-    local stub_file=$(jq -r --arg d "${dir}" '$d + "/" + .files.solution[0]' "${dir}/.meta/config.json")
-    local stub_backup_file="${stub_file}.bak"
+    local implementation_files=($(jq -r --arg d "${dir}" --arg k "${implementation_file_key}" '$d + "/" + .files[$k][]' "${dir}/.meta/config.json"))
+    local stub_files=($(jq -r --arg d "${dir}" '$d + "/" + .files.solution[]' "${dir}/.meta/config.json"))
     local results_file="${output_dir}/results.json"
 
-    cp "${stub_file}" "${stub_backup_file}"
-    cp "${implementation_file}" "${stub_file}"
     mkdir -p "${output_dir}"
+
+    for stub_file in "${stub_files[@]}"; do
+        cp "${stub_file}" "${stub_file}.bak"
+
+        for impl_file in "${implementation_files[@]}"; do
+            if [[ $(basename "${stub_file}") == $(basename "${impl_file}") ]]; then
+                cp "${impl_file}" "${stub_file}"
+            fi
+        done
+    done
 
     run_test_runner "${slug}" "${dir}" "${output_dir}"
 
@@ -47,7 +54,9 @@ function verify_exercise() {
         exit_code=1
     fi
 
-    mv "${stub_backup_file}" "${stub_file}"
+    for stub_file in "${stub_files[@]}"; do
+        mv "${stub_file}.bak" "${stub_file}"
+    done
 }
 
 # Verify the Concept Exercises

--- a/bin/test-with-test-runner
+++ b/bin/test-with-test-runner
@@ -39,12 +39,10 @@ function verify_exercise() {
 
     for stub_file in "${stub_files[@]}"; do
         cp "${stub_file}" "${stub_file}.bak"
+    done
 
-        for impl_file in "${implementation_files[@]}"; do
-            if [[ $(basename "${stub_file}") == $(basename "${impl_file}") ]]; then
-                cp "${impl_file}" "${stub_file}"
-            fi
-        done
+    for impl_file in "${implementation_files[@]}"; do
+        cp "${impl_file}" "${dir}/src/main/java/$(basename ${impl_file})"
     done
 
     run_test_runner "${slug}" "${dir}" "${output_dir}"
@@ -53,6 +51,10 @@ function verify_exercise() {
         echo "${slug}: ${implementation_file_key} solution did not pass the tests"
         exit_code=1
     fi
+
+    for impl_file in "${implementation_files[@]}"; do
+        rm "${dir}/src/main/java/$(basename ${impl_file})"
+    done
 
     for stub_file in "${stub_files[@]}"; do
         mv "${stub_file}.bak" "${stub_file}"

--- a/bin/test-with-test-runner
+++ b/bin/test-with-test-runner
@@ -13,14 +13,15 @@ docker pull exercism/java-test-runner
 exit_code=0
 
 function run_test_runner() {
-    local dir=$1
-    local slug=$2
+    local slug=$1
+    local solution_dir=$2
+    local output_dir=$3
 
     docker run \
         --rm \
         --network none \
-        --mount type=bind,src="${dir}",dst=/solution \
-        --mount type=bind,src="${dir}",dst=/output \
+        --mount type=bind,src="${solution_dir}",dst=/solution \
+        --mount type=bind,src="${output_dir}",dst=/output \
         --tmpfs /tmp:rw \
         exercism/java-test-runner "${slug}" "/solution" "/output"
 }
@@ -28,16 +29,18 @@ function run_test_runner() {
 function verify_exercise() {
     local dir=$(realpath $1)
     local slug=$(basename "${dir}")
+    local output_dir="${dir}/build"
     local implementation_file_key=$2
     local implementation_file=$(jq -r --arg d "${dir}" --arg k "${implementation_file_key}" '$d + "/" + .files[$k][0]' "${dir}/.meta/config.json")
     local stub_file=$(jq -r --arg d "${dir}" '$d + "/" + .files.solution[0]' "${dir}/.meta/config.json")
     local stub_backup_file="${stub_file}.bak"
-    local results_file="${dir}/results.json"
+    local results_file="${output_dir}/results.json"
 
     cp "${stub_file}" "${stub_backup_file}"
     cp "${implementation_file}" "${stub_file}"
+    mkdir -p "${output_dir}"
 
-    run_test_runner "${dir}" "${slug}"
+    run_test_runner "${slug}" "${dir}" "${output_dir}"
 
     if [[ $(jq -r '.status' "${results_file}") != "pass" ]]; then
         echo "${slug}: ${implementation_file_key} solution did not pass the tests"
@@ -45,7 +48,6 @@ function verify_exercise() {
     fi
 
     mv "${stub_backup_file}" "${stub_file}"
-    rm -f "${results_file}"
 }
 
 # Verify the Concept Exercises

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -26,7 +26,8 @@
       "src/test/java/BowlingGameTest.java"
     ],
     "example": [
-      ".meta/src/reference/java/BowlingGame.java"
+      ".meta/src/reference/java/BowlingGame.java",
+      ".meta/src/reference/java/Frame.java"
     ],
     "invalidator": [
       "build.gradle"

--- a/exercises/practice/error-handling/.meta/config.json
+++ b/exercises/practice/error-handling/.meta/config.json
@@ -24,7 +24,9 @@
       "src/test/java/ErrorHandlingTest.java"
     ],
     "example": [
-      ".meta/src/reference/java/ErrorHandling.java"
+      ".meta/src/reference/java/ErrorHandling.java",
+      ".meta/src/reference/java/CustomCheckedException.java",
+      ".meta/src/reference/java/CustomUncheckedException.java"
     ],
     "invalidator": [
       "build.gradle"

--- a/exercises/practice/forth/.meta/config.json
+++ b/exercises/practice/forth/.meta/config.json
@@ -24,7 +24,8 @@
       "src/test/java/ForthEvaluatorTest.java"
     ],
     "example": [
-      ".meta/src/reference/java/ForthEvaluator.java"
+      ".meta/src/reference/java/ForthEvaluator.java",
+      ".meta/src/reference/java/Token.java"
     ],
     "invalidator": [
       "build.gradle"

--- a/exercises/practice/hangman/.meta/config.json
+++ b/exercises/practice/hangman/.meta/config.json
@@ -9,16 +9,17 @@
   ],
   "files": {
     "solution": [
-      "src/main/java/Hangman.java"
+      "src/main/java/Hangman.java",
+      "src/main/java/Output.java"
     ],
     "test": [
       "src/test/java/HangmanTest.java"
     ],
     "example": [
-      ".meta/src/reference/java/Hangman.java"
+      ".meta/src/reference/java/Hangman.java",
+      ".meta/src/reference/java/Output.java"
     ],
     "editor": [
-      "src/main/java/Output.java",
       "src/main/java/Part.java",
       "src/main/java/Status.java"
     ],

--- a/exercises/practice/mazy-mice/.meta/src/reference/java/MazeGenerator.java
+++ b/exercises/practice/mazy-mice/.meta/src/reference/java/MazeGenerator.java
@@ -31,28 +31,6 @@ public class MazeGenerator {
     }
 }
 
-enum Direction {
-    NORTH(0, 1),
-    EAST(1, 0),
-    SOUTH(0, -1),
-    WEST(-1, 0);
-    private final int dx;
-    private final int dy;
-
-    Direction(int dx, int dy) {
-        this.dx = dx;
-        this.dy = dy;
-    }
-
-    public int dx() {
-        return dx;
-    }
-
-    public int dy() {
-        return dy;
-    }
-}
-
 final class Grid {
     private final Dimensions dimensions;
     private final BitSet grid;
@@ -180,6 +158,28 @@ final class Grid {
                 case 15 -> '┼';
                 default -> throw new IllegalStateException("Unexpected value: " + i);
             };
+        }
+    }
+
+    private enum Direction {
+        NORTH(0, 1),
+        EAST(1, 0),
+        SOUTH(0, -1),
+        WEST(-1, 0);
+        private final int dx;
+        private final int dy;
+
+        Direction(int dx, int dy) {
+            this.dx = dx;
+            this.dy = dy;
+        }
+
+        public int dx() {
+            return dx;
+        }
+
+        public int dy() {
+            return dy;
         }
     }
 }

--- a/exercises/practice/mazy-mice/src/test/java/MazeGeneratorTest.java
+++ b/exercises/practice/mazy-mice/src/test/java/MazeGeneratorTest.java
@@ -8,28 +8,6 @@ import java.util.Set;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
-enum Direction {
-    NORTH(0, 1),
-    EAST(1, 0),
-    SOUTH(0, -1),
-    WEST(-1, 0);
-    private final int dx;
-    private final int dy;
-
-    Direction(int dx, int dy) {
-        this.dx = dx;
-        this.dy = dy;
-    }
-
-    public int dx() {
-        return dx;
-    }
-
-    public int dy() {
-        return dy;
-    }
-}
-
 public class MazeGeneratorTest {
     private static final char EMPTY_CELL = ' ';
     private static final Set<Character> ALLOWED_SYMBOLS = Set.of(
@@ -242,5 +220,27 @@ public class MazeGeneratorTest {
             }
         }
         return entranceCount;
+    }
+
+    private enum Direction {
+        NORTH(0, 1),
+        EAST(1, 0),
+        SOUTH(0, -1),
+        WEST(-1, 0);
+        private final int dx;
+        private final int dy;
+
+        Direction(int dx, int dy) {
+            this.dx = dx;
+            this.dy = dy;
+        }
+
+        public int dx() {
+            return dx;
+        }
+
+        public int dy() {
+            return dy;
+        }
     }
 }

--- a/exercises/practice/ocr-numbers/.meta/config.json
+++ b/exercises/practice/ocr-numbers/.meta/config.json
@@ -28,7 +28,8 @@
       "src/test/java/OpticalCharacterReaderTest.java"
     ],
     "example": [
-      ".meta/src/reference/java/OpticalCharacterReader.java"
+      ".meta/src/reference/java/OpticalCharacterReader.java",
+      ".meta/src/reference/java/Digit.java"
     ],
     "invalidator": [
       "build.gradle"

--- a/exercises/practice/poker/.meta/config.json
+++ b/exercises/practice/poker/.meta/config.json
@@ -27,6 +27,8 @@
       "src/test/java/PokerTest.java"
     ],
     "example": [
+      ".meta/src/reference/java/Card.java",
+      ".meta/src/reference/java/Hand.java",
       ".meta/src/reference/java/Poker.java"
     ],
     "invalidator": [

--- a/exercises/practice/queen-attack/.meta/config.json
+++ b/exercises/practice/queen-attack/.meta/config.json
@@ -32,6 +32,7 @@
       "src/test/java/QueenAttackCalculatorTest.java"
     ],
     "example": [
+      ".meta/src/reference/java/Queen.java",
       ".meta/src/reference/java/QueenAttackCalculator.java"
     ],
     "invalidator": [

--- a/exercises/practice/rest-api/.meta/config.json
+++ b/exercises/practice/rest-api/.meta/config.json
@@ -9,17 +9,18 @@
   ],
   "files": {
     "solution": [
-      "src/main/java/RestApi.java"
+      "src/main/java/RestApi.java",
+      "src/main/java/User.java"
     ],
     "test": [
       "src/test/java/RestApiTest.java"
     ],
     "example": [
-      ".meta/src/reference/java/RestApi.java"
+      ".meta/src/reference/java/RestApi.java",
+      ".meta/src/reference/java/User.java"
     ],
     "editor": [
-      "src/main/java/Iou.java",
-      "src/main/java/User.java"
+      "src/main/java/Iou.java"
     ],
     "invalidator": [
       "build.gradle"

--- a/exercises/practice/spiral-matrix/.meta/config.json
+++ b/exercises/practice/spiral-matrix/.meta/config.json
@@ -23,6 +23,8 @@
       "src/test/java/SpiralMatrixBuilderTest.java"
     ],
     "example": [
+      ".meta/src/reference/java/Coordinate.java",
+      ".meta/src/reference/java/Direction.java",
       ".meta/src/reference/java/SpiralMatrixBuilder.java"
     ],
     "invalidator": [

--- a/exercises/practice/tournament/.meta/config.json
+++ b/exercises/practice/tournament/.meta/config.json
@@ -24,6 +24,8 @@
       "src/test/java/TournamentTest.java"
     ],
     "example": [
+      ".meta/src/reference/java/Result.java",
+      ".meta/src/reference/java/TeamResult.java",
       ".meta/src/reference/java/Tournament.java"
     ],
     "invalidator": [


### PR DESCRIPTION
Inspired by this forum topic: https://forum.exercism.org/t/re-using-the-test-runners-in-corresponding-track-ci-jobs/8070.

Note that this required some updates to some of the exercises, particularly ones where not all files that are part of the example solution were correctly listed in the exercise's `config.json`. 

The Mazy Mice exercise required a small change because of a compilation error due to a class being defined in both the example solution as well as the tests. Not sure why this wasn't caught when using the tests with Gradle. It shouldn't impact students though.

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
