### PR TITLE
Update instructions.md

### DIFF
--- a/exercises/concept/logs-logs-logs/.docs/instructions.md
+++ b/exercises/concept/logs-logs-logs/.docs/instructions.md
@@ -1,69 +1,43 @@
-# Instructions
+public enum LogLevel {
+    UNKNOWN,
+    TRACE,
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR,
+    FATAL
+}
 
-In this exercise you'll be processing log-lines.
+public class LogLine {
+    private String logLine;
 
-Each log line is a string formatted as follows: `"[<LVL>]: <MESSAGE>"`.
+    public LogLine(String logLine) {
+        this.logLine = logLine;
+    }
+    public LogLevel getLogLevel() {
+        String logLevelStr = logLine.substring(logLine.indexOf("[") + 1, logLine.indexOf("]"));
+        switch (logLevelStr) {
+            case "TRC": return LogLevel.TRACE;
+            case "DBG": return LogLevel.DEBUG;
+            case "INF": return LogLevel.INFO;
+            case "WRN": return LogLevel.WARNING;
+            case "ERR": return LogLevel.ERROR;
+            case "FTL": return LogLevel.FATAL;
+            default: return LogLevel.UNKNOWN;
+        }
+    }
 
-These are the different log levels:
-
-- `TRC` (trace)
-- `DBG` (debug)
-- `INF` (info)
-- `WRN` (warning)
-- `ERR` (error)
-- `FTL` (fatal)
-
-You have three tasks.
-
-## 1. Parse log level
-
-Define a `LogLevel` enum that has six elements corresponding to the above log levels.
-
-- `TRACE`
-- `DEBUG`
-- `INFO`
-- `WARNING`
-- `ERROR`
-- `FATAL`
-
-Next, implement the `LogLine.getLogLevel()` method that returns the parsed the log level of a log line:
-
-```java
-var logLine = new LogLine("[INF]: File deleted");
-logLine.getLogLevel();
-// => LogLevel.INFO
-```
-
-## 2. Support unknown log level
-
-Unfortunately, occasionally some log lines have an unknown log level.
-To gracefully handle these log lines, add an `UNKNOWN` element to the `LogLevel` enum which should be returned when parsing an unknown log level:
-
-```java
-var logLine = new LogLine("[XYZ]: Overly specific, out of context message");
-logLine.getLogLevel();
-// => LogLevel.UNKNOWN
-```
-
-## 3. Convert log line to short format
-
-The log level of a log line is quite verbose.
-To reduce the disk space needed to store the log lines, a short format is developed: `"[<ENCODED_LEVEL>]:<MESSAGE>"`.
-
-The encoded log level is a simple mapping of a log level to a number:
-
-- `UNKNOWN` - `0`
-- `TRACE` - `1`
-- `DEBUG` - `2`
-- `INFO` - `4`
-- `WARNING` - `5`
-- `ERROR` - `6`
-- `FATAL` - `42`
-
-Implement the `LogLine.getOutputForShortLog()` method that can output the shortened log line format:
-
-```java
-var logLine = new LogLine("[ERR]: Stack Overflow");
-logLine.getOutputForShortLog();
-// => "6:Stack overflow"
-```
+    public String getOutputForShortLog() {
+        int encodedLevel = switch (getLogLevel()) {
+            case TRACE -> 1;
+            case DEBUG -> 2;
+            case INFO -> 4;
+            case WARNING -> 5;
+            case ERROR -> 6;
+            case FATAL -> 42;
+            default -> 0;
+        };
+        String message = logLine.substring(logLine.indexOf("]:") + 2).trim();
+        return encodedLevel + ":" + message;
+    }
+}


### PR DESCRIPTION


# pull request

<!-- Your content goes here: -->
### Pull Request: Log Line Processing

#### Introduction
This pull request introduces enhancements to the LogLine processing in the form of a LogLevel enum, improved log level parsing, support for unknown log levels, and a short log format.

#### Changes Made
1. **LogLevel Enum**
   - Added a `LogLevel` enum with elements corresponding to different log levels: - `UNKNOWN` - `TRACE` - `DEBUG` - `INFO` - `WARNING` - `ERROR` - `FATAL`

2. **Improved Log Level Parsing**
   - Implemented the `getLogLevel()` method in the `LogLine` class to extract and return the log level from a log line string.
   - The method uses a switch statement to map the log level string to the corresponding enum value.

   ```java
   var logLine = new LogLine("[INF]: File deleted");
   logLine.getLogLevel();
   // => LogLevel.INFO
   ```

3. **Support for Unknown Log Levels**
   - Added an `UNKNOWN` element to the `LogLevel` enum to gracefully handle log lines with unknown log levels.
   - If the log level cannot be determined, the method returns `LogLevel.UNKNOWN`.

   ```java
   var logLine = new LogLine("[XYZ]: Overly specific, out of context message");
   logLine.getLogLevel();
   // => LogLevel.UNKNOWN
   ```

4. **Short Log Format**
   - Implemented the `getOutputForShortLog()` method in the `LogLine` class to generate a shortened log line format.
   - The encoded log level is a simple mapping of log levels to numbers.
   - The method returns a string in the format: `"<ENCODED_LEVEL>:<MESSAGE>"`.

   ```java
   var logLine = new LogLine("[ERR]: Stack Overflow");
   logLine.getOutputForShortLog();
   // => "6:Stack Overflow"
   ```

#### How to Use
1. **Get Log Level**
   - To retrieve the log level of a log line, use the `getLogLevel()` method.

   ```java
   var logLine = new LogLine("[INF]: File deleted");
   LogLevel level = logLine.getLogLevel();
   ```

2. **Handle Unknown Log Levels**
   - The `getLogLevel()` method gracefully handles unknown log levels by returning `LogLevel.UNKNOWN`.

   ```java
   var logLine = new LogLine("[XYZ]: Overly specific, out of context message");
   LogLevel level = logLine.getLogLevel();
   // level is LogLevel.UNKNOWN
   ```

3. **Short Log Format**
   - To obtain a shortened log line format, use the `getOutputForShortLog()` method.

   ```java
   var logLine = new LogLine("[ERR]: Stack Overflow");
   String shortLog = logLine.getOutputForShortLog();
   // shortLog is "6:Stack Overflow"
   ```

#### Additional Notes
- Ensure existing code that uses the `LogLine` class is updated to leverage the new functionalities introduced in this pull request.
- Review and test the changes thoroughly to ensure compatibility and correctness.

#### Checklist
- [ ] Code has been tested locally.
- [ ] Documentation has been updated to reflect the changes.
- [ ] No breaking changes introduced.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
