### PR TITLE
Fix existing prerequisites for practice exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -256,7 +256,8 @@
           "if-else-statements"
         ],
         "prerequisites": [
-          "basics"
+          "strings",
+          "if-else-statements"
         ],
         "difficulty": 1
       },
@@ -268,8 +269,7 @@
           "for-loops"
         ],
         "prerequisites": [
-          "strings",
-          "chars"
+          "for-loops"
         ],
         "difficulty": 3
       },
@@ -281,7 +281,7 @@
           "numbers"
         ],
         "prerequisites": [
-          "basics"
+          "numbers"
         ],
         "difficulty": 3
       },
@@ -295,8 +295,9 @@
           "chars"
         ],
         "prerequisites": [
-          "strings",
-          "for-loops"
+          "arrays",
+          "switch-statement",
+          "chars"
         ],
         "difficulty": 3
       },
@@ -308,7 +309,7 @@
           "numbers"
         ],
         "prerequisites": [
-          "basics"
+          "numbers"
         ],
         "difficulty": 3
       },
@@ -322,8 +323,7 @@
         ],
         "prerequisites": [
           "enums",
-          "numbers",
-          "for-loops"
+          "lists"
         ],
         "difficulty": 3
       },
@@ -336,9 +336,8 @@
           "arrays"
         ],
         "prerequisites": [
-          "strings",
-          "numbers",
-          "for-loops"
+          "constructors",
+          "arrays"
         ],
         "difficulty": 4
       },
@@ -350,8 +349,7 @@
           "constructors"
         ],
         "prerequisites": [
-          "numbers",
-          "if-else-statements"
+          "constructors"
         ],
         "difficulty": 4
       },
@@ -363,7 +361,7 @@
           "chars"
         ],
         "prerequisites": [
-          "strings",
+          "chars",
           "if-else-statements",
           "for-loops"
         ],
@@ -377,9 +375,7 @@
           "lists"
         ],
         "prerequisites": [
-          "numbers",
-          "for-loops",
-          "classes"
+          "lists"
         ],
         "difficulty": 4
       },
@@ -388,12 +384,12 @@
         "name": "Flatten Array",
         "uuid": "a732a838-8170-458a-a85e-d6b4c46f97a1",
         "practices": [
-          "lists"
+          "lists",
+          "generic-types"
         ],
         "prerequisites": [
-          "if-else-statements",
-          "for-loops",
-          "classes"
+          "lists",
+          "generic-types"
         ],
         "difficulty": 5
       },
@@ -406,8 +402,7 @@
         ],
         "prerequisites": [
           "for-loops",
-          "arrays",
-          "classes"
+          "arrays"
         ],
         "difficulty": 5
       },
@@ -432,8 +427,7 @@
           "lists"
         ],
         "prerequisites": [
-          "if-else-statements",
-          "classes"
+          "lists"
         ],
         "difficulty": 6
       },
@@ -446,8 +440,7 @@
           "classes"
         ],
         "prerequisites": [
-          "numbers",
-          "classes"
+          "constructors"
         ],
         "difficulty": 6
       },
@@ -463,8 +456,7 @@
         "prerequisites": [
           "lists",
           "classes",
-          "generic-types",
-          "for-loops"
+          "generic-types"
         ],
         "difficulty": 6
       },
@@ -543,7 +535,7 @@
           "chars"
         ],
         "prerequisites": [
-          "basics"
+          "chars"
         ],
         "difficulty": 1
       },
@@ -556,7 +548,8 @@
           "constructors"
         ],
         "prerequisites": [
-          "numbers"
+          "if-else-statements",
+          "constructors"
         ],
         "difficulty": 2
       },
@@ -569,8 +562,8 @@
           "constructors"
         ],
         "prerequisites": [
-          "numbers",
-          "for-loops"
+          "arrays",
+          "constructors"
         ],
         "difficulty": 2
       },
@@ -583,7 +576,7 @@
         ],
         "prerequisites": [
           "if-else-statements",
-          "for-loops"
+          "numbers"
         ],
         "difficulty": 2
       },
@@ -595,7 +588,7 @@
           "arrays"
         ],
         "prerequisites": [
-          "basics"
+          "arrays"
         ],
         "difficulty": 2
       },
@@ -608,6 +601,7 @@
           "enums"
         ],
         "prerequisites": [
+          "arrays",
           "enums"
         ],
         "difficulty": 2
@@ -620,7 +614,7 @@
           "strings"
         ],
         "prerequisites": [
-          "basics"
+          "strings"
         ],
         "difficulty": 3
       },
@@ -632,8 +626,8 @@
           "arrays"
         ],
         "prerequisites": [
-          "strings",
-          "for-loops"
+          "arrays",
+          "strings"
         ],
         "difficulty": 3
       },
@@ -646,7 +640,7 @@
           "lists"
         ],
         "prerequisites": [
-          "strings"
+          "lists"
         ],
         "difficulty": 4
       },
@@ -684,8 +678,8 @@
           "if-else-statements"
         ],
         "prerequisites": [
-          "strings",
-          "classes"
+          "if-else-statements",
+          "strings"
         ],
         "difficulty": 5
       },
@@ -718,8 +712,7 @@
           "arrays"
         ],
         "prerequisites": [
-          "strings",
-          "classes"
+          "arrays"
         ],
         "difficulty": 6
       },
@@ -732,8 +725,8 @@
           "for-loops"
         ],
         "prerequisites": [
-          "arrays",
-          "classes"
+          "strings",
+          "for-loops"
         ],
         "difficulty": 6
       },
@@ -786,8 +779,7 @@
           "lists"
         ],
         "prerequisites": [
-          "if-else-statements",
-          "classes"
+          "lists"
         ],
         "difficulty": 5
       },
@@ -800,8 +792,7 @@
         ],
         "prerequisites": [
           "if-else-statements",
-          "for-loops",
-          "classes"
+          "for-loops"
         ],
         "difficulty": 5
       },
@@ -814,8 +805,7 @@
         ],
         "prerequisites": [
           "chars",
-          "if-else-statements",
-          "classes"
+          "if-else-statements"
         ],
         "difficulty": 5
       },
@@ -828,8 +818,8 @@
           "lists"
         ],
         "prerequisites": [
-          "strings",
-          "classes"
+          "lists",
+          "strings"
         ],
         "difficulty": 5
       },
@@ -838,11 +828,11 @@
         "name": "Roman Numerals",
         "uuid": "3e728cd4-5e5f-4c69-8a53-bc36d020fcdb",
         "practices": [
-          "arrays"
+          "numbers"
         ],
         "prerequisites": [
-          "strings",
-          "classes"
+          "numbers",
+          "strings"
         ],
         "difficulty": 6
       },
@@ -907,13 +897,13 @@
         "name": "Minesweeper",
         "uuid": "416a1489-12af-4593-8540-0f55285c96b4",
         "practices": [
-          "lists",
-          "constructors"
+          "constructors",
+          "lists"
         ],
         "prerequisites": [
-          "strings",
-          "for-loops",
-          "classes"
+          "constructors",
+          "lists",
+          "strings"
         ],
         "difficulty": 6
       },


### PR DESCRIPTION
Some practice exercises were configured so that they would unlock before their corresponding concept exercises were finished, causing confusion with students who are trying to follow the learning path.

Example: https://forum.exercism.org/t/confused-by-concepts-exercises-and-learning-exercises/8330

Relates to #1867 and #1923

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
