### PR TITLE
Fix broken test in Captains Log

### DIFF
--- a/exercises/concept/captains-log/.meta/config.json
+++ b/exercises/concept/captains-log/.meta/config.json
@@ -2,6 +2,9 @@
   "authors": [
     "sanderploegsma"
   ],
+  "contributors": [
+    "santialb"
+  ],
   "files": {
     "solution": [
       "src/main/java/CaptainsLog.java"

--- a/exercises/concept/captains-log/.meta/src/reference/java/CaptainsLog.java
+++ b/exercises/concept/captains-log/.meta/src/reference/java/CaptainsLog.java
@@ -17,7 +17,7 @@ class CaptainsLog {
 
     String randomShipRegistryNumber() {
         var start = 1000;
-        var end = 9999;
+        var end = 11000;
         return String.format("NCC-%d", start + random.nextInt(end - start));
     }
 

--- a/exercises/concept/captains-log/.meta/src/reference/java/CaptainsLog.java
+++ b/exercises/concept/captains-log/.meta/src/reference/java/CaptainsLog.java
@@ -17,7 +17,7 @@ class CaptainsLog {
 
     String randomShipRegistryNumber() {
         var start = 1000;
-        var end = 11000;
+        var end = 10000;
         return String.format("NCC-%d", start + random.nextInt(end - start));
     }
 

--- a/exercises/concept/captains-log/src/test/java/CaptainsLogTest.java
+++ b/exercises/concept/captains-log/src/test/java/CaptainsLogTest.java
@@ -45,9 +45,9 @@ public class CaptainsLogTest {
     @Tag("task:2")
     @DisplayName("Generating a random ship registry number")
     public void testRandomShipRegistryNumber() {
-        assertThat(new CaptainsLog(random1).randomShipRegistryNumber()).isEqualTo("NCC-8773");
-        assertThat(new CaptainsLog(random2).randomShipRegistryNumber()).isEqualTo("NCC-2473");
-        assertThat(new CaptainsLog(random3).randomShipRegistryNumber()).isEqualTo("NCC-9576");
+        assertThat(new CaptainsLog(random1).randomShipRegistryNumber()).isEqualTo("NCC-6258");
+        assertThat(new CaptainsLog(random2).randomShipRegistryNumber()).isEqualTo("NCC-1683");
+        assertThat(new CaptainsLog(random3).randomShipRegistryNumber()).isEqualTo("NCC-4922");
     }
 
     @Test


### PR DESCRIPTION
Changed the end index of the randomShipRegistryNumber() so that the range goes from 1000 to 9999

Fixes #2589 

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
