### PR TITLE
Removing (static) from exception message

### DIFF
--- a/exercises/concept/tim-from-marketing/src/main/java/Badge.java
+++ b/exercises/concept/tim-from-marketing/src/main/java/Badge.java
@@ -1,5 +1,5 @@
 class Badge {
     public String print(Integer id, String name, String department) {
-        throw new UnsupportedOperationException("Please implement the (static) Badge.print() method");
+        throw new UnsupportedOperationException("Please implement the Badge.print() method");
     }
 }


### PR DESCRIPTION
Removing '(static)' from the exception message thrown for the tim-from-marketing concept exercise.
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
