### PR TITLE
Fixing typo on the introduction of booking up for beauty exercise

### DIFF
--- a/exercises/concept/booking-up-for-beauty/.docs/introduction.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/introduction.md
@@ -80,7 +80,7 @@ Attempting to parse a `LocalDate` or `LocalDateTime` from a `String` like this u
 Instead, to format dates using a custom format, you should use the `java.time.format.DateTimeFormatter`:
 
 ```java
-DateTimeFormatter parser = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd/MM/yyyy");
 LocalDate date = LocalDate.parse("03/12/2007", formatter);
 
 DateTimeFormatter printer = DateTimeFormatter.ofPattern("MMMM d, yyyy");


### PR DESCRIPTION
# pull request

The issue addresses: [#2597](https://github.com/exercism/java/issues/2597)

The goal is to fix a typo in the introduction of the exercise Booking for beauty.


---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
