### PR TITLE
Sync tests from exercise ``matching brackets``

### DIFF
--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [81ec11da-38dd-442a-bcf9-3de7754609a5]
 description = "paired square brackets"
@@ -41,11 +48,20 @@ description = "unpaired and nested brackets"
 [a0205e34-c2ac-49e6-a88a-899508d7d68e]
 description = "paired and wrong nested brackets"
 
+[1d5c093f-fc84-41fb-8c2a-e052f9581602]
+description = "paired and wrong nested brackets but innermost are correct"
+
 [ef47c21b-bcfd-4998-844c-7ad5daad90a8]
 description = "paired and incomplete brackets"
 
 [a4675a40-a8be-4fc2-bc47-2a282ce6edbe]
 description = "too many closing brackets"
+
+[a345a753-d889-4b7e-99ae-34ac85910d1a]
+description = "early unexpected brackets"
+
+[21f81d61-1608-465a-b850-baa44c5def83]
+description = "early mismatched brackets"
 
 [99255f93-261b-4435-a352-02bdecc9bdf2]
 description = "math expression"

--- a/exercises/practice/matching-brackets/src/test/java/BracketCheckerTest.java
+++ b/exercises/practice/matching-brackets/src/test/java/BracketCheckerTest.java
@@ -97,6 +97,13 @@ public class BracketCheckerTest {
 
     @Ignore("Remove to run test")
     @Test
+    public void testPairedAndWrongNestedBracketsButInnermostAreCorrect() {
+        BracketChecker bracketChecker = new BracketChecker("[({}])");
+        assertThat(bracketChecker.areBracketsMatchedAndNestedCorrectly()).isFalse();
+    }
+
+    @Ignore("Remove to run test")
+    @Test
     public void testPairedAndIncompleteBrackets() {
         BracketChecker bracketChecker = new BracketChecker("{}[");
         assertThat(bracketChecker.areBracketsMatchedAndNestedCorrectly()).isFalse();
@@ -106,6 +113,20 @@ public class BracketCheckerTest {
     @Test
     public void testTooManyClosingBrackets() {
         BracketChecker bracketChecker = new BracketChecker("[]]");
+        assertThat(bracketChecker.areBracketsMatchedAndNestedCorrectly()).isFalse();
+    }
+
+    @Ignore("Remove to run test")
+    @Test
+    public void testEarlyUnexpectedBrackets() {
+        BracketChecker bracketChecker = new BracketChecker(")()");
+        assertThat(bracketChecker.areBracketsMatchedAndNestedCorrectly()).isFalse();
+    }
+    
+    @Ignore("Remove to run test")
+    @Test
+    public void testEarlyMismatchedBrackets() {
+        BracketChecker bracketChecker = new BracketChecker("{)()");
         assertThat(bracketChecker.areBracketsMatchedAndNestedCorrectly()).isFalse();
     }
 


### PR DESCRIPTION
# pull request

This issue addresses: [#2388](https://github.com/exercism/java/issues/2388)

The goal is to sync the tests of the matching brackets practice exercise

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
