### PR TITLE
Sync tests from exercise ``word count``

### DIFF
--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [61559d5f-2cad-48fb-af53-d3973a9ee9ef]
 description = "count one word"
@@ -28,6 +35,11 @@ description = "normalize case"
 
 [4185a902-bdb0-4074-864c-f416e42a0f19]
 description = "with apostrophes"
+include = false
+
+[4ff6c7d7-fcfc-43ef-b8e7-34ff1837a2d3]
+description = "with apostrophes"
+reimplements = "4185a902-bdb0-4074-864c-f416e42a0f19"
 
 [be72af2b-8afe-4337-b151-b297202e4a7b]
 description = "with quotations"
@@ -40,3 +52,6 @@ description = "multiple spaces not detected as a word"
 
 [50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360]
 description = "alternating word separators not detected as a word"
+
+[6d00f1db-901c-4bec-9829-d20eb3044557]
+description = "quotation for word with apostrophe"

--- a/exercises/practice/word-count/src/test/java/WordCountTest.java
+++ b/exercises/practice/word-count/src/test/java/WordCountTest.java
@@ -117,8 +117,11 @@ public class WordCountTest {
         expectedWordCount.put("laugh", 1);
         expectedWordCount.put("then", 1);
         expectedWordCount.put("cry", 1);
+        expectedWordCount.put("you're", 1);
+        expectedWordCount.put("getting", 1);
+        expectedWordCount.put("it", 1);
 
-        actualWordCount = wordCount.phrase("First: don't laugh. Then: don't cry.");
+        actualWordCount = wordCount.phrase("'First: don't laugh. Then: don't cry. You're getting it.'");
         assertThat(actualWordCount).isEqualTo(expectedWordCount);
     }
 
@@ -170,6 +173,16 @@ public class WordCountTest {
         expectedWordCount.put("three", 1);
 
         actualWordCount = wordCount.phrase(",\n,one,\n ,two \n 'three'");
+        assertThat(actualWordCount).isEqualTo(expectedWordCount);
+    }
+
+    @Ignore("Remove to run test")
+    @Test
+    public void quotationForWordWithApostrophe() {
+        expectedWordCount.put("can", 1);
+        expectedWordCount.put("can't", 2);
+
+        actualWordCount = wordCount.phrase("can, can't, 'can't'");
         assertThat(actualWordCount).isEqualTo(expectedWordCount);
     }
 


### PR DESCRIPTION
# pull request

This issue addresses: [#2388](https://github.com/exercism/java/issues/2388)

The goal is to sync the tests of the word count practice exercise

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
