### PR TITLE
Sync tests for practice exercise ``transpose``

### DIFF
--- a/exercises/practice/transpose/.meta/tests.toml
+++ b/exercises/practice/transpose/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [404b7262-c050-4df0-a2a2-0cb06cd6a821]
 description = "empty string"
@@ -34,3 +41,6 @@ description = "rectangle"
 
 [b80badc9-057e-4543-bd07-ce1296a1ea2c]
 description = "triangle"
+
+[76acfd50-5596-4d05-89f1-5116328a7dd9]
+description = "jagged triangle"

--- a/exercises/practice/transpose/src/test/java/TransposeTest.java
+++ b/exercises/practice/transpose/src/test/java/TransposeTest.java
@@ -206,4 +206,24 @@ public class TransposeTest {
                 "    ER\n" +
                 "     R");
     }
+    
+    @Ignore("Remove to run test")
+    @Test
+    public void jaggedTriangle() {
+        assertThat(
+            transpose.transpose(
+                "11\n" +
+                "2\n" +
+                "3333\n" +
+                "444\n" +
+                "555555\n" +
+                "66666"))
+            .isEqualTo(
+                "123456\n" +
+                "1 3456\n" +
+                "  3456\n" +
+                "  3 56\n" +
+                "    56\n" +
+                "    5");
+    }
 }


### PR DESCRIPTION
# pull request

This issue addresses: [#2388](https://github.com/exercism/java/issues/2388)

The goal is to sync the tests of the transpose practice exercise

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
