### PR TITLE
Order practice exercises by difficulty

### DIFF
--- a/config.json
+++ b/config.json
@@ -289,12 +289,87 @@
     ],
     "practice": [
       {
+        "slug": "accumulate",
+        "name": "Accumulate",
+        "uuid": "e58c29d2-80a7-40ef-bed0-4a184ae35f34",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "status": "deprecated"
+      },
+      {
+        "slug": "binary",
+        "name": "Binary",
+        "uuid": "9ea6e0fa-b91d-4d17-ac8f-6d2dc30fdd44",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "status": "deprecated"
+      },
+      {
         "slug": "hello-world",
         "name": "Hello World",
         "uuid": "f77dc7e3-35a8-4300-a7c8-2c1765e9644d",
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
+      },
+      {
+        "slug": "hexadecimal",
+        "name": "Hexadecimal",
+        "uuid": "6fe53a08-c123-465d-864a-ef18217203c4",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "status": "deprecated"
+      },
+      {
+        "slug": "leap",
+        "name": "Leap",
+        "uuid": "61fe1fa6-246d-4e38-92d6-b74af64c88af",
+        "practices": [],
+        "prerequisites": [
+          "booleans",
+          "numbers"
+        ],
+        "difficulty": 1
+      },
+      {
+        "slug": "octal",
+        "name": "Octal",
+        "uuid": "14a29e82-f9b1-4662-b678-06992e306c01",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "status": "deprecated"
+      },
+      {
+        "slug": "reverse-string",
+        "name": "Reverse String",
+        "uuid": "2c8afeed-480e-41f3-ad58-590fa8f88029",
+        "practices": [],
+        "prerequisites": [
+          "chars"
+        ],
+        "difficulty": 1
+      },
+      {
+        "slug": "strain",
+        "name": "Strain",
+        "uuid": "2d195cd9-1814-490a-8dd6-a2c676f1d4cd",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "status": "deprecated"
+      },
+      {
+        "slug": "trinary",
+        "name": "Trinary",
+        "uuid": "ee3a8abe-6b19-4b47-9cf6-4d39ae915fb7",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1,
+        "status": "deprecated"
       },
       {
         "slug": "two-fer",
@@ -308,226 +383,14 @@
         "difficulty": 1
       },
       {
-        "slug": "hamming",
-        "name": "Hamming",
-        "uuid": "ce899ca6-9cc7-47ba-b76f-1bbcf2630b76",
-        "practices": [],
-        "prerequisites": [
-          "for-loops"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "gigasecond",
-        "name": "Gigasecond",
-        "uuid": "bf1641c8-dc0d-4d38-9cfe-b4c132ea3553",
-        "practices": [],
-        "prerequisites": [
-          "datetime",
-          "numbers"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "scrabble-score",
-        "name": "Scrabble Score",
-        "uuid": "afae9f2d-8baf-4bd7-8d7c-d486337f7c97",
-        "practices": [],
-        "prerequisites": [
-          "arrays",
-          "switch-statement",
-          "chars"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "difference-of-squares",
-        "name": "Difference of Squares",
-        "uuid": "b0da59c6-1b55-405c-b163-007ebf09f5e8",
+        "slug": "armstrong-numbers",
+        "name": "Armstrong Numbers",
+        "uuid": "8e1dd48c-e05e-4a72-bf0f-5aed8dd123f5",
         "practices": [],
         "prerequisites": [
           "numbers"
         ],
-        "difficulty": 3
-      },
-      {
-        "slug": "secret-handshake",
-        "name": "Secret Handshake",
-        "uuid": "71c7c174-7e2c-43c2-bdd6-7515fcb12a91",
-        "practices": [],
-        "prerequisites": [
-          "enums",
-          "lists"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "matrix",
-        "name": "Matrix",
-        "uuid": "c1d4e0b4-6a0f-4be9-8222-345966621f53",
-        "practices": [],
-        "prerequisites": [
-          "constructors",
-          "arrays"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "triangle",
-        "name": "Triangle",
-        "uuid": "ec268d8e-997b-4553-8c67-8bdfa1ecb888",
-        "practices": [],
-        "prerequisites": [
-          "constructors"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "rotational-cipher",
-        "name": "Rotational Cipher",
-        "uuid": "9eb41883-55ef-4681-b5ac-5c2259302772",
-        "practices": [],
-        "prerequisites": [
-          "chars",
-          "if-else-statements",
-          "for-loops"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "saddle-points",
-        "name": "Saddle Points",
-        "uuid": "8dfc2f0d-1141-46e9-95e2-6f35ccf6f160",
-        "practices": [],
-        "prerequisites": [
-          "lists"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "flatten-array",
-        "name": "Flatten Array",
-        "uuid": "a732a838-8170-458a-a85e-d6b4c46f97a1",
-        "practices": [],
-        "prerequisites": [
-          "lists",
-          "generic-types"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "word-count",
-        "name": "Word Count",
-        "uuid": "3603b770-87a5-4758-91f3-b4d1f9075bc1",
-        "practices": [],
-        "prerequisites": [
-          "for-loops",
-          "arrays"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "robot-name",
-        "name": "Robot Name",
-        "uuid": "d7c2eed9-64c7-4c4a-b45d-c787d460337f",
-        "practices": [],
-        "prerequisites": [
-          "constructors",
-          "classes",
-          "randomness"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "binary-search",
-        "name": "Binary Search",
-        "uuid": "50136dc3-caf7-4fa1-b7bd-0cba1bea9176",
-        "practices": [],
-        "prerequisites": [
-          "lists"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "bank-account",
-        "name": "Bank Account",
-        "uuid": "a242efc5-159d-492b-861d-12a1459fb334",
-        "practices": [],
-        "prerequisites": [
-          "constructors"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "linked-list",
-        "name": "Linked List",
-        "uuid": "7ba5084d-3b75-4406-a0d7-87c26387f9c0",
-        "practices": [],
-        "prerequisites": [
-          "lists",
-          "classes",
-          "generic-types"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "raindrops",
-        "name": "Raindrops",
-        "uuid": "d916e4f8-fda1-41c0-ab24-79e8fc3f1272",
-        "practices": [],
-        "prerequisites": [
-          "if-else-statements",
-          "numbers",
-          "strings"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "isogram",
-        "name": "Isogram",
-        "uuid": "c3e89c7c-3a8a-4ddc-b653-9b0ff9e1d7d8",
-        "practices": [],
-        "prerequisites": [
-          "if-else-statements",
-          "for-loops",
-          "strings"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "pig-latin",
-        "name": "Pig Latin",
-        "uuid": "38bc80ae-d842-4c04-a797-48edf322504d",
-        "practices": [],
-        "prerequisites": [
-          "arrays",
-          "lists",
-          "strings"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "anagram",
-        "name": "Anagram",
-        "uuid": "fb10dc2f-0ba1-44b6-8365-5e48e86d1283",
-        "practices": [],
-        "prerequisites": [
-          "arrays",
-          "if-else-statements",
-          "lists",
-          "for-loops"
-        ],
-        "difficulty": 7
-      },
-      {
-        "slug": "reverse-string",
-        "name": "Reverse String",
-        "uuid": "2c8afeed-480e-41f3-ad58-590fa8f88029",
-        "practices": [],
-        "prerequisites": [
-          "chars"
-        ],
-        "difficulty": 1
+        "difficulty": 2
       },
       {
         "slug": "darts",
@@ -563,6 +426,16 @@
         "difficulty": 2
       },
       {
+        "slug": "high-scores",
+        "name": "High Scores",
+        "uuid": "574d6323-5ff5-4019-9ebe-0067daafba13",
+        "practices": [],
+        "prerequisites": [
+          "lists"
+        ],
+        "difficulty": 2
+      },
+      {
         "slug": "resistor-color",
         "name": "Resistor Color",
         "uuid": "e5e821ed-fc1f-4419-9c90-ad4a0b564bea",
@@ -584,12 +457,96 @@
         "difficulty": 2
       },
       {
+        "slug": "rna-transcription",
+        "name": "RNA Transcription",
+        "uuid": "8e983ed2-62f7-439a-a144-fb8fdbdf4d30",
+        "practices": [],
+        "prerequisites": [
+          "foreach-loops",
+          "strings"
+        ],
+        "difficulty": 2
+      },
+      {
+        "slug": "acronym",
+        "name": "Acronym",
+        "uuid": "c31bbc6d-bdcf-44f7-bf35-5f98752e38d0",
+        "practices": [],
+        "prerequisites": [
+          "for-loops",
+          "strings"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "difference-of-squares",
+        "name": "Difference of Squares",
+        "uuid": "b0da59c6-1b55-405c-b163-007ebf09f5e8",
+        "practices": [],
+        "prerequisites": [
+          "numbers"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "gigasecond",
+        "name": "Gigasecond",
+        "uuid": "bf1641c8-dc0d-4d38-9cfe-b4c132ea3553",
+        "practices": [],
+        "prerequisites": [
+          "datetime",
+          "numbers"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "hamming",
+        "name": "Hamming",
+        "uuid": "ce899ca6-9cc7-47ba-b76f-1bbcf2630b76",
+        "practices": [],
+        "prerequisites": [
+          "for-loops"
+        ],
+        "difficulty": 3
+      },
+      {
         "slug": "micro-blog",
         "name": "Micro Blog",
         "uuid": "8295ae71-5c0e-49d0-bbe9-9b43a85bf2dd",
         "practices": [],
         "prerequisites": [
           "strings"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "pangram",
+        "name": "Pangram",
+        "uuid": "133b0f84-bdc7-4508-a0a1-5732a7db81ef",
+        "practices": [],
+        "prerequisites": [
+          "chars"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "perfect-numbers",
+        "name": "Perfect Numbers",
+        "uuid": "d0dcc898-ec38-4822-9e3c-1a1829c9b2d9",
+        "practices": [],
+        "prerequisites": [
+          "enums",
+          "exceptions"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "pop-count",
+        "name": "Eliud's Eggs",
+        "uuid": "2d5b6404-3315-48c1-892f-b594a960e7a1",
+        "practices": [],
+        "prerequisites": [
+          "numbers"
         ],
         "difficulty": 3
       },
@@ -605,6 +562,74 @@
         "difficulty": 3
       },
       {
+        "slug": "raindrops",
+        "name": "Raindrops",
+        "uuid": "d916e4f8-fda1-41c0-ab24-79e8fc3f1272",
+        "practices": [],
+        "prerequisites": [
+          "if-else-statements",
+          "numbers",
+          "strings"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "say",
+        "name": "Say",
+        "uuid": "3c76a983-e689-4d82-8f1b-6d52f3c5434c",
+        "practices": [],
+        "prerequisites": [
+          "numbers",
+          "strings"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "scrabble-score",
+        "name": "Scrabble Score",
+        "uuid": "afae9f2d-8baf-4bd7-8d7c-d486337f7c97",
+        "practices": [],
+        "prerequisites": [
+          "arrays",
+          "switch-statement",
+          "chars"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "secret-handshake",
+        "name": "Secret Handshake",
+        "uuid": "71c7c174-7e2c-43c2-bdd6-7515fcb12a91",
+        "practices": [],
+        "prerequisites": [
+          "enums",
+          "lists"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "space-age",
+        "name": "Space Age",
+        "uuid": "e5b524cd-3a1c-468a-8981-13e8eeccb29d",
+        "practices": [],
+        "prerequisites": [
+          "numbers"
+        ],
+        "difficulty": 3
+      },
+      {
+        "slug": "collatz-conjecture",
+        "name": "Collatz Conjecture",
+        "uuid": "1500d39a-c9d9-4d3a-9e77-fdc1837fc6ad",
+        "practices": [],
+        "prerequisites": [
+          "exceptions",
+          "if-else-statements",
+          "numbers"
+        ],
+        "difficulty": 4
+      },
+      {
         "slug": "diamond",
         "name": "Diamond",
         "uuid": "ecbd997b-86f4-4e11-9ff0-706ac2899415",
@@ -615,77 +640,14 @@
         "difficulty": 4
       },
       {
-        "slug": "proverb",
-        "name": "Proverb",
-        "uuid": "9906491b-a638-408d-86a4-4ad320a92658",
+        "slug": "error-handling",
+        "name": "Error Handling",
+        "uuid": "846ae792-7ca7-43e1-b523-bb1ec9fa08eb",
         "practices": [],
         "prerequisites": [
-          "for-loops",
-          "arrays"
+          "exceptions"
         ],
         "difficulty": 4
-      },
-      {
-        "slug": "twelve-days",
-        "name": "Twelve Days",
-        "uuid": "581afdbb-dfb6-4dc5-9554-a025b5469a3c",
-        "practices": [],
-        "prerequisites": [
-          "for-loops",
-          "arrays"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "bob",
-        "name": "Bob",
-        "uuid": "34cd328c-cd96-492b-abd4-2b8716cdcd9a",
-        "practices": [],
-        "prerequisites": [
-          "if-else-statements",
-          "strings"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "beer-song",
-        "name": "Beer Song",
-        "uuid": "56943095-de76-40bf-b42b-fa3e70f8df5e",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 6,
-        "status": "deprecated"
-      },
-      {
-        "slug": "bottle-song",
-        "name": "Bottle Song",
-        "uuid": "3fa6750f-cf01-4542-a494-df9a8c658733",
-        "practices": [],
-        "prerequisites": [
-          "strings"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "food-chain",
-        "name": "Food Chain",
-        "uuid": "dd3e6fd6-5359-4978-acd7-c39374cead4d",
-        "practices": [],
-        "prerequisites": [
-          "arrays"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "house",
-        "name": "House",
-        "uuid": "6b51aca3-3451-4a64-ad7b-00b151d7548a",
-        "practices": [],
-        "prerequisites": [
-          "strings",
-          "for-loops"
-        ],
-        "difficulty": 6
       },
       {
         "slug": "isbn-verifier",
@@ -695,6 +657,40 @@
         "prerequisites": [
           "chars",
           "for-loops"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "isogram",
+        "name": "Isogram",
+        "uuid": "c3e89c7c-3a8a-4ddc-b653-9b0ff9e1d7d8",
+        "practices": [],
+        "prerequisites": [
+          "if-else-statements",
+          "for-loops",
+          "strings"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "killer-sudoku-helper",
+        "name": "Killer Sudoku Helper",
+        "uuid": "8c45a47d-b3e3-484c-a124-90136ec838fd",
+        "practices": [],
+        "prerequisites": [
+          "numbers",
+          "lists"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "kindergarten-garden",
+        "name": "Kindergarten Garden",
+        "uuid": "df41c70c-daa1-4380-9729-638c17b4105d",
+        "practices": [],
+        "prerequisites": [
+          "enums",
+          "lists"
         ],
         "difficulty": 4
       },
@@ -722,202 +718,61 @@
         "difficulty": 4
       },
       {
-        "slug": "knapsack",
-        "name": "Knapsack",
-        "uuid": "89a6bf1e-66d5-4e39-9bc0-294b8b76cb2a",
+        "slug": "matrix",
+        "name": "Matrix",
+        "uuid": "c1d4e0b4-6a0f-4be9-8222-345966621f53",
         "practices": [],
         "prerequisites": [
-          "lists"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "nucleotide-count",
-        "name": "Nucleotide Count",
-        "uuid": "2d80fdfc-5bd7-4b67-9fbe-8ab820d89051",
-        "practices": [],
-        "prerequisites": [
-          "if-else-statements",
-          "for-loops"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "phone-number",
-        "name": "Phone Number",
-        "uuid": "5f9139e7-9fbb-496a-a0d7-a946283033de",
-        "practices": [],
-        "prerequisites": [
-          "chars",
-          "if-else-statements"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "series",
-        "name": "Series",
-        "uuid": "af80d7f4-c7d0-4d0b-9c30-09da120f6bb9",
-        "practices": [],
-        "prerequisites": [
-          "lists",
-          "strings"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "roman-numerals",
-        "name": "Roman Numerals",
-        "uuid": "3e728cd4-5e5f-4c69-8a53-bc36d020fcdb",
-        "practices": [],
-        "prerequisites": [
-          "numbers",
-          "strings"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "allergies",
-        "name": "Allergies",
-        "uuid": "6a617ddb-04e3-451c-bb30-27ccd0be9125",
-        "practices": [],
-        "prerequisites": [
-          "for-loops",
-          "enums"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "meetup",
-        "name": "Meetup",
-        "uuid": "602511d5-7e89-4def-b072-4dd311816810",
-        "practices": [],
-        "prerequisites": [
-          "datetime",
-          "enums"
-        ],
-        "difficulty": 7
-      },
-      {
-        "slug": "yacht",
-        "name": "Yacht",
-        "uuid": "0cb45688-9598-49aa-accc-ed48c5d6962d",
-        "practices": [],
-        "prerequisites": [
-          "enums"
+          "constructors",
+          "arrays"
         ],
         "difficulty": 4
       },
       {
-        "slug": "bowling",
-        "name": "Bowling",
-        "uuid": "4b3f7771-c642-4278-a3d9-2fb958f26361",
+        "slug": "nth-prime",
+        "name": "Nth Prime",
+        "uuid": "2c69db99-648d-4bd7-8012-1fbdeff6ca0a",
+        "practices": [],
+        "prerequisites": [
+          "exceptions",
+          "for-loops",
+          "if-else-statements",
+          "numbers"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "proverb",
+        "name": "Proverb",
+        "uuid": "9906491b-a638-408d-86a4-4ad320a92658",
         "practices": [],
         "prerequisites": [
           "for-loops",
           "arrays"
         ],
-        "difficulty": 6
+        "difficulty": 4
       },
       {
-        "slug": "minesweeper",
-        "name": "Minesweeper",
-        "uuid": "416a1489-12af-4593-8540-0f55285c96b4",
+        "slug": "rotational-cipher",
+        "name": "Rotational Cipher",
+        "uuid": "9eb41883-55ef-4681-b5ac-5c2259302772",
         "practices": [],
         "prerequisites": [
-          "constructors",
-          "lists",
-          "strings"
+          "chars",
+          "if-else-statements",
+          "for-loops"
         ],
-        "difficulty": 6
+        "difficulty": 4
       },
       {
-        "slug": "queen-attack",
-        "name": "Queen Attack",
-        "uuid": "5404109e-3ed9-4691-8eaf-af8b36024a44",
+        "slug": "saddle-points",
+        "name": "Saddle Points",
+        "uuid": "8dfc2f0d-1141-46e9-95e2-6f35ccf6f160",
         "practices": [],
         "prerequisites": [
-          "constructors",
-          "exceptions"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "dominoes",
-        "name": "Dominoes",
-        "uuid": "8e3cb20e-623b-4b4d-8a91-d1a51c0911b5",
-        "practices": [],
-        "prerequisites": [
-          "exceptions",
           "lists"
         ],
-        "difficulty": 7
-      },
-      {
-        "slug": "go-counting",
-        "name": "Go Counting",
-        "uuid": "2e760ae2-fadd-4d31-9639-c4554e2826e9",
-        "practices": [],
-        "prerequisites": [
-          "enums"
-        ],
-        "difficulty": 7
-      },
-      {
-        "slug": "markdown",
-        "name": "Markdown",
-        "uuid": "cc18f2e5-4e36-47d6-aa60-8ca5ff54019a",
-        "practices": [],
-        "prerequisites": [
-          "if-else-statements",
-          "strings"
-        ],
-        "difficulty": 7
-      },
-      {
-        "slug": "poker",
-        "name": "Poker",
-        "uuid": "57eeac00-741c-4843-907a-51f0ac5ea4cb",
-        "practices": [],
-        "prerequisites": [
-          "constructors",
-          "if-else-statements",
-          "lists"
-        ],
-        "difficulty": 7
-      },
-      {
-        "slug": "word-search",
-        "name": "Word Search",
-        "uuid": "b53bde52-cb5f-4d43-86ec-18aa509d62f9",
-        "practices": [],
-        "prerequisites": [
-          "arrays",
-          "strings",
-          "if-else-statements"
-        ],
-        "difficulty": 7
-      },
-      {
-        "slug": "perfect-numbers",
-        "name": "Perfect Numbers",
-        "uuid": "d0dcc898-ec38-4822-9e3c-1a1829c9b2d9",
-        "practices": [],
-        "prerequisites": [
-          "enums",
-          "exceptions"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "say",
-        "name": "Say",
-        "uuid": "3c76a983-e689-4d82-8f1b-6d52f3c5434c",
-        "practices": [],
-        "prerequisites": [
-          "numbers",
-          "strings"
-        ],
-        "difficulty": 3
+        "difficulty": 4
       },
       {
         "slug": "sieve",
@@ -943,6 +798,27 @@
         "difficulty": 4
       },
       {
+        "slug": "triangle",
+        "name": "Triangle",
+        "uuid": "ec268d8e-997b-4553-8c67-8bdfa1ecb888",
+        "practices": [],
+        "prerequisites": [
+          "constructors"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "twelve-days",
+        "name": "Twelve Days",
+        "uuid": "581afdbb-dfb6-4dc5-9554-a025b5469a3c",
+        "practices": [],
+        "prerequisites": [
+          "for-loops",
+          "arrays"
+        ],
+        "difficulty": 4
+      },
+      {
         "slug": "variable-length-quantity",
         "name": "Variable Length Quantity",
         "uuid": "d8a2c7ba-2040-4cfe-ab15-f90b3b61dd89",
@@ -953,6 +829,246 @@
         "difficulty": 4
       },
       {
+        "slug": "yacht",
+        "name": "Yacht",
+        "uuid": "0cb45688-9598-49aa-accc-ed48c5d6962d",
+        "practices": [],
+        "prerequisites": [
+          "enums"
+        ],
+        "difficulty": 4
+      },
+      {
+        "slug": "allergies",
+        "name": "Allergies",
+        "uuid": "6a617ddb-04e3-451c-bb30-27ccd0be9125",
+        "practices": [],
+        "prerequisites": [
+          "for-loops",
+          "enums"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "atbash-cipher",
+        "name": "Atbash Cipher",
+        "uuid": "d36ce010-210f-4e9a-9d6c-cb933e0a59af",
+        "practices": [],
+        "prerequisites": [
+          "chars",
+          "foreach-loops"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "bob",
+        "name": "Bob",
+        "uuid": "34cd328c-cd96-492b-abd4-2b8716cdcd9a",
+        "practices": [],
+        "prerequisites": [
+          "if-else-statements",
+          "strings"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "flatten-array",
+        "name": "Flatten Array",
+        "uuid": "a732a838-8170-458a-a85e-d6b4c46f97a1",
+        "practices": [],
+        "prerequisites": [
+          "lists",
+          "generic-types"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "grep",
+        "name": "Grep",
+        "uuid": "9c15ddab-7b52-43d4-b38c-0bf635b363c3",
+        "practices": [],
+        "prerequisites": [
+          "lists",
+          "strings"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "knapsack",
+        "name": "Knapsack",
+        "uuid": "89a6bf1e-66d5-4e39-9bc0-294b8b76cb2a",
+        "practices": [],
+        "prerequisites": [
+          "lists"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "ledger",
+        "name": "Ledger",
+        "uuid": "6597548e-176d-49c6-be33-789f4c43867a",
+        "practices": [],
+        "prerequisites": [
+          "classes",
+          "datetime",
+          "strings"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "matching-brackets",
+        "name": "Matching Brackets",
+        "uuid": "85aa50ac-0141-49eb-bc6f-62f3f7a97647",
+        "practices": [],
+        "prerequisites": [
+          "foreach-loops",
+          "strings"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "nucleotide-count",
+        "name": "Nucleotide Count",
+        "uuid": "2d80fdfc-5bd7-4b67-9fbe-8ab820d89051",
+        "practices": [],
+        "prerequisites": [
+          "if-else-statements",
+          "for-loops"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "pascals-triangle",
+        "name": "Pascal's Triangle",
+        "uuid": "d2a76905-1c8c-4b03-b4f7-4fbff19329f3",
+        "practices": [],
+        "prerequisites": [
+          "arrays",
+          "exceptions",
+          "numbers"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "phone-number",
+        "name": "Phone Number",
+        "uuid": "5f9139e7-9fbb-496a-a0d7-a946283033de",
+        "practices": [],
+        "prerequisites": [
+          "chars",
+          "if-else-statements"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "pig-latin",
+        "name": "Pig Latin",
+        "uuid": "38bc80ae-d842-4c04-a797-48edf322504d",
+        "practices": [],
+        "prerequisites": [
+          "arrays",
+          "lists",
+          "strings"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "prime-factors",
+        "name": "Prime Factors",
+        "uuid": "599c08ec-7338-46ed-99f8-a76f78f724e6",
+        "practices": [],
+        "prerequisites": [
+          "if-else-statements",
+          "lists",
+          "numbers"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "robot-name",
+        "name": "Robot Name",
+        "uuid": "d7c2eed9-64c7-4c4a-b45d-c787d460337f",
+        "practices": [],
+        "prerequisites": [
+          "constructors",
+          "classes",
+          "randomness"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "run-length-encoding",
+        "name": "Run-Length Encoding",
+        "uuid": "4499a3f9-73a7-48bf-8753-d5b6abf588c9",
+        "practices": [],
+        "prerequisites": [
+          "chars",
+          "if-else-statements",
+          "for-loops"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "series",
+        "name": "Series",
+        "uuid": "af80d7f4-c7d0-4d0b-9c30-09da120f6bb9",
+        "practices": [],
+        "prerequisites": [
+          "lists",
+          "strings"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "square-root",
+        "name": "Square Root",
+        "uuid": "61886554-ec84-422a-bbf9-aeee37c45bb6",
+        "practices": [],
+        "prerequisites": [
+          "numbers"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "word-count",
+        "name": "Word Count",
+        "uuid": "3603b770-87a5-4758-91f3-b4d1f9075bc1",
+        "practices": [],
+        "prerequisites": [
+          "for-loops",
+          "arrays"
+        ],
+        "difficulty": 5
+      },
+      {
+        "slug": "affine-cipher",
+        "name": "Affine Cipher",
+        "uuid": "e6e3faaf-54c2-4782-93af-bb8d95403f2a",
+        "practices": [],
+        "prerequisites": [
+          "chars",
+          "exceptions",
+          "for-loops",
+          "if-else-statements",
+          "numbers"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "all-your-base",
+        "name": "All Your Base",
+        "uuid": "f7c2e4b5-1995-4dfe-b827-c9aff8ac5332",
+        "practices": [],
+        "prerequisites": [
+          "arrays",
+          "exceptions",
+          "for-loops",
+          "if-else-statements",
+          "numbers"
+        ],
+        "difficulty": 6
+      },
+      {
         "slug": "alphametics",
         "name": "Alphametics",
         "uuid": "0639a1f8-5af4-4877-95c1-5db8e97c30bf",
@@ -960,6 +1076,170 @@
         "prerequisites": [
           "chars",
           "exceptions"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "bank-account",
+        "name": "Bank Account",
+        "uuid": "a242efc5-159d-492b-861d-12a1459fb334",
+        "practices": [],
+        "prerequisites": [
+          "constructors"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "beer-song",
+        "name": "Beer Song",
+        "uuid": "56943095-de76-40bf-b42b-fa3e70f8df5e",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6,
+        "status": "deprecated"
+      },
+      {
+        "slug": "binary-search",
+        "name": "Binary Search",
+        "uuid": "50136dc3-caf7-4fa1-b7bd-0cba1bea9176",
+        "practices": [],
+        "prerequisites": [
+          "lists"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "bottle-song",
+        "name": "Bottle Song",
+        "uuid": "3fa6750f-cf01-4542-a494-df9a8c658733",
+        "practices": [],
+        "prerequisites": [
+          "strings"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "bowling",
+        "name": "Bowling",
+        "uuid": "4b3f7771-c642-4278-a3d9-2fb958f26361",
+        "practices": [],
+        "prerequisites": [
+          "for-loops",
+          "arrays"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "etl",
+        "name": "ETL",
+        "uuid": "76d28d97-75d3-47eb-bb77-3d347b76f1b6",
+        "practices": [],
+        "prerequisites": [
+          "foreach-loops",
+          "strings"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "food-chain",
+        "name": "Food Chain",
+        "uuid": "dd3e6fd6-5359-4978-acd7-c39374cead4d",
+        "practices": [],
+        "prerequisites": [
+          "arrays"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "grade-school",
+        "name": "Grade School",
+        "uuid": "b4af5da1-601f-4b0f-bfb8-4a381851090c",
+        "practices": [],
+        "prerequisites": [
+          "if-else-statements",
+          "lists",
+          "strings"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "house",
+        "name": "House",
+        "uuid": "6b51aca3-3451-4a64-ad7b-00b151d7548a",
+        "practices": [],
+        "prerequisites": [
+          "strings",
+          "for-loops"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "linked-list",
+        "name": "Linked List",
+        "uuid": "7ba5084d-3b75-4406-a0d7-87c26387f9c0",
+        "practices": [],
+        "prerequisites": [
+          "lists",
+          "classes",
+          "generic-types"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "minesweeper",
+        "name": "Minesweeper",
+        "uuid": "416a1489-12af-4593-8540-0f55285c96b4",
+        "practices": [],
+        "prerequisites": [
+          "constructors",
+          "lists",
+          "strings"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "parallel-letter-frequency",
+        "name": "Parallel Letter Frequency",
+        "uuid": "38a405e8-619d-400f-b53c-2f06461fdf9d",
+        "practices": [],
+        "prerequisites": [
+          "strings"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "queen-attack",
+        "name": "Queen Attack",
+        "uuid": "5404109e-3ed9-4691-8eaf-af8b36024a44",
+        "practices": [],
+        "prerequisites": [
+          "constructors",
+          "exceptions"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "rail-fence-cipher",
+        "name": "Rail Fence Cipher",
+        "uuid": "6e4ad4ed-cc02-4132-973d-b9163ba0ea3d",
+        "practices": [],
+        "prerequisites": [
+          "arrays",
+          "chars",
+          "foreach-loops",
+          "if-else-statements"
+        ],
+        "difficulty": 6
+      },
+      {
+        "slug": "rest-api",
+        "name": "REST API",
+        "uuid": "809c0e3d-3494-4a85-843d-2bafa8752ce8",
+        "practices": [],
+        "prerequisites": [
+          "classes",
+          "constructors",
+          "lists"
         ],
         "difficulty": 6
       },
@@ -974,62 +1254,15 @@
         "difficulty": 6
       },
       {
-        "slug": "wordy",
-        "name": "Wordy",
-        "uuid": "3310a3cd-c0cb-45fa-8c51-600178be904a",
+        "slug": "roman-numerals",
+        "name": "Roman Numerals",
+        "uuid": "3e728cd4-5e5f-4c69-8a53-bc36d020fcdb",
         "practices": [],
         "prerequisites": [
-          "exceptions",
           "numbers",
           "strings"
         ],
         "difficulty": 6
-      },
-      {
-        "slug": "forth",
-        "name": "Forth",
-        "uuid": "f0c0316d-3fb5-455e-952a-91161e7fb298",
-        "practices": [],
-        "prerequisites": [
-          "exceptions",
-          "lists",
-          "strings"
-        ],
-        "difficulty": 9
-      },
-      {
-        "slug": "killer-sudoku-helper",
-        "name": "Killer Sudoku Helper",
-        "uuid": "8c45a47d-b3e3-484c-a124-90136ec838fd",
-        "practices": [],
-        "prerequisites": [
-          "numbers",
-          "lists"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "kindergarten-garden",
-        "name": "Kindergarten Garden",
-        "uuid": "df41c70c-daa1-4380-9729-638c17b4105d",
-        "practices": [],
-        "prerequisites": [
-          "enums",
-          "lists"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "pascals-triangle",
-        "name": "Pascal's Triangle",
-        "uuid": "d2a76905-1c8c-4b03-b4f7-4fbff19329f3",
-        "practices": [],
-        "prerequisites": [
-          "arrays",
-          "exceptions",
-          "numbers"
-        ],
-        "difficulty": 5
       },
       {
         "slug": "spiral-matrix",
@@ -1065,145 +1298,54 @@
         "difficulty": 6
       },
       {
-        "slug": "collatz-conjecture",
-        "name": "Collatz Conjecture",
-        "uuid": "1500d39a-c9d9-4d3a-9e77-fdc1837fc6ad",
+        "slug": "wordy",
+        "name": "Wordy",
+        "uuid": "3310a3cd-c0cb-45fa-8c51-600178be904a",
         "practices": [],
         "prerequisites": [
           "exceptions",
-          "if-else-statements",
-          "numbers"
+          "numbers",
+          "strings"
         ],
-        "difficulty": 4
+        "difficulty": 6
       },
       {
-        "slug": "error-handling",
-        "name": "Error Handling",
-        "uuid": "846ae792-7ca7-43e1-b523-bb1ec9fa08eb",
+        "slug": "anagram",
+        "name": "Anagram",
+        "uuid": "fb10dc2f-0ba1-44b6-8365-5e48e86d1283",
         "practices": [],
         "prerequisites": [
-          "exceptions"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "nth-prime",
-        "name": "Nth Prime",
-        "uuid": "2c69db99-648d-4bd7-8012-1fbdeff6ca0a",
-        "practices": [],
-        "prerequisites": [
-          "exceptions",
-          "for-loops",
-          "if-else-statements",
-          "numbers"
-        ],
-        "difficulty": 4
-      },
-      {
-        "slug": "prime-factors",
-        "name": "Prime Factors",
-        "uuid": "599c08ec-7338-46ed-99f8-a76f78f724e6",
-        "practices": [],
-        "prerequisites": [
+          "arrays",
           "if-else-statements",
           "lists",
-          "numbers"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "two-bucket",
-        "name": "Two Bucket",
-        "uuid": "210bf628-b385-443b-8329-3483cc6e8d7e",
-        "practices": [],
-        "prerequisites": [
-          "constructors",
-          "if-else-statements",
-          "numbers"
+          "for-loops"
         ],
         "difficulty": 7
       },
       {
-        "slug": "complex-numbers",
-        "name": "Complex Numbers",
-        "uuid": "52d11278-0d65-4b5b-b387-1374fced3243",
+        "slug": "binary-search-tree",
+        "name": "Binary Search Tree",
+        "uuid": "0a2d18aa-7b5e-4401-a952-b93d2060694f",
         "practices": [],
         "prerequisites": [
-          "numbers"
+          "classes",
+          "generic-types",
+          "lists"
         ],
-        "difficulty": 8
+        "difficulty": 7
       },
       {
-        "slug": "rational-numbers",
-        "name": "Rational Numbers",
-        "uuid": "50ed54ce-3047-4590-9fda-0a7e9aeeba30",
-        "practices": [],
-        "prerequisites": [
-          "numbers"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "pythagorean-triplet",
-        "name": "Pythagorean Triplet",
-        "uuid": "88505f95-89e5-4a08-8ed2-208eb818cdf1",
+        "slug": "clock",
+        "name": "Clock",
+        "uuid": "97c8fcd4-85b6-41cb-9de2-b4e1b4951222",
         "practices": [],
         "prerequisites": [
           "constructors",
-          "lists",
-          "numbers"
-        ],
-        "difficulty": 9
-      },
-      {
-        "slug": "atbash-cipher",
-        "name": "Atbash Cipher",
-        "uuid": "d36ce010-210f-4e9a-9d6c-cb933e0a59af",
-        "practices": [],
-        "prerequisites": [
-          "chars",
-          "foreach-loops"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "run-length-encoding",
-        "name": "Run-Length Encoding",
-        "uuid": "4499a3f9-73a7-48bf-8753-d5b6abf588c9",
-        "practices": [],
-        "prerequisites": [
-          "chars",
           "if-else-statements",
-          "for-loops"
+          "numbers",
+          "strings"
         ],
-        "difficulty": 5
-      },
-      {
-        "slug": "affine-cipher",
-        "name": "Affine Cipher",
-        "uuid": "e6e3faaf-54c2-4782-93af-bb8d95403f2a",
-        "practices": [],
-        "prerequisites": [
-          "chars",
-          "exceptions",
-          "for-loops",
-          "if-else-statements",
-          "numbers"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "rail-fence-cipher",
-        "name": "Rail Fence Cipher",
-        "uuid": "6e4ad4ed-cc02-4132-973d-b9163ba0ea3d",
-        "practices": [],
-        "prerequisites": [
-          "arrays",
-          "chars",
-          "foreach-loops",
-          "if-else-statements"
-        ],
-        "difficulty": 6
+        "difficulty": 7
       },
       {
         "slug": "crypto-square",
@@ -1220,206 +1362,73 @@
         "difficulty": 7
       },
       {
-        "slug": "simple-cipher",
-        "name": "Simple Cipher",
-        "uuid": "f654831f-c34b-44f5-9dd5-054efbb486f2",
+        "slug": "dominoes",
+        "name": "Dominoes",
+        "uuid": "8e3cb20e-623b-4b4d-8a91-d1a51c0911b5",
         "practices": [],
         "prerequisites": [
+          "exceptions",
+          "lists"
+        ],
+        "difficulty": 7
+      },
+      {
+        "slug": "go-counting",
+        "name": "Go Counting",
+        "uuid": "2e760ae2-fadd-4d31-9639-c4554e2826e9",
+        "practices": [],
+        "prerequisites": [
+          "enums"
+        ],
+        "difficulty": 7
+      },
+      {
+        "slug": "markdown",
+        "name": "Markdown",
+        "uuid": "cc18f2e5-4e36-47d6-aa60-8ca5ff54019a",
+        "practices": [],
+        "prerequisites": [
+          "if-else-statements",
+          "strings"
+        ],
+        "difficulty": 7
+      },
+      {
+        "slug": "meetup",
+        "name": "Meetup",
+        "uuid": "602511d5-7e89-4def-b072-4dd311816810",
+        "practices": [],
+        "prerequisites": [
+          "datetime",
+          "enums"
+        ],
+        "difficulty": 7
+      },
+      {
+        "slug": "poker",
+        "name": "Poker",
+        "uuid": "57eeac00-741c-4843-907a-51f0ac5ea4cb",
+        "practices": [],
+        "prerequisites": [
+          "constructors",
+          "if-else-statements",
+          "lists"
+        ],
+        "difficulty": 7
+      },
+      {
+        "slug": "sgf-parsing",
+        "name": "SGF Parsing",
+        "uuid": "0d6325d1-c0a3-456e-9a92-cea0559e82ed",
+        "practices": [],
+        "prerequisites": [
+          "strings",
           "chars",
-          "exceptions",
-          "for-loops",
           "if-else-statements",
-          "numbers",
-          "randomness"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "all-your-base",
-        "name": "All Your Base",
-        "uuid": "f7c2e4b5-1995-4dfe-b827-c9aff8ac5332",
-        "practices": [],
-        "prerequisites": [
-          "arrays",
-          "exceptions",
-          "for-loops",
-          "if-else-statements",
-          "numbers"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "clock",
-        "name": "Clock",
-        "uuid": "97c8fcd4-85b6-41cb-9de2-b4e1b4951222",
-        "practices": [],
-        "prerequisites": [
-          "constructors",
-          "if-else-statements",
-          "numbers",
-          "strings"
+          "lists",
+          "for-loops"
         ],
         "difficulty": 7
-      },
-      {
-        "slug": "zebra-puzzle",
-        "name": "Zebra Puzzle",
-        "uuid": "b1e2bd39-3f4b-44c1-b7e2-258d4ee241f8",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 7
-      },
-      {
-        "slug": "palindrome-products",
-        "name": "Palindrome Products",
-        "uuid": "873c05de-b5f5-4c5b-97f0-d1ede8a82832",
-        "practices": [],
-        "prerequisites": [
-          "exceptions",
-          "for-loops",
-          "if-else-statements",
-          "numbers"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "matching-brackets",
-        "name": "Matching Brackets",
-        "uuid": "85aa50ac-0141-49eb-bc6f-62f3f7a97647",
-        "practices": [],
-        "prerequisites": [
-          "foreach-loops",
-          "strings"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "book-store",
-        "name": "Book Store",
-        "uuid": "e5f05d00-fe5b-4d78-b2fa-934c1c9afb32",
-        "practices": [],
-        "prerequisites": [
-          "exceptions",
-          "if-else-statements",
-          "lists",
-          "numbers"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "change",
-        "name": "Change",
-        "uuid": "bac1f4bc-eea9-43c1-8e95-097347f5925e",
-        "practices": [],
-        "prerequisites": [
-          "exceptions",
-          "lists",
-          "numbers"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "etl",
-        "name": "ETL",
-        "uuid": "76d28d97-75d3-47eb-bb77-3d347b76f1b6",
-        "practices": [],
-        "prerequisites": [
-          "foreach-loops",
-          "strings"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "grade-school",
-        "name": "Grade School",
-        "uuid": "b4af5da1-601f-4b0f-bfb8-4a381851090c",
-        "practices": [],
-        "prerequisites": [
-          "if-else-statements",
-          "lists",
-          "strings"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "grep",
-        "name": "Grep",
-        "uuid": "9c15ddab-7b52-43d4-b38c-0bf635b363c3",
-        "practices": [],
-        "prerequisites": [
-          "lists",
-          "strings"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "rest-api",
-        "name": "REST API",
-        "uuid": "809c0e3d-3494-4a85-843d-2bafa8752ce8",
-        "practices": [],
-        "prerequisites": [
-          "classes",
-          "constructors",
-          "lists"
-        ],
-        "difficulty": 6
-      },
-      {
-        "slug": "ocr-numbers",
-        "name": "OCR Numbers",
-        "uuid": "5cbc6a67-3a53-4aad-ae68-ff469525437f",
-        "practices": [],
-        "prerequisites": [
-          "exceptions",
-          "lists",
-          "strings"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "react",
-        "name": "React",
-        "uuid": "33531718-1d8a-4abd-bd2a-090303ad0c39",
-        "practices": [],
-        "prerequisites": [
-          "classes",
-          "generic-types"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "rectangles",
-        "name": "Rectangles",
-        "uuid": "64cda115-919a-4eef-9a45-9ec5d1af98cc",
-        "practices": [],
-        "prerequisites": [
-          "arrays",
-          "exceptions",
-          "strings"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "binary-search-tree",
-        "name": "Binary Search Tree",
-        "uuid": "0a2d18aa-7b5e-4401-a952-b93d2060694f",
-        "practices": [],
-        "prerequisites": [
-          "classes",
-          "generic-types",
-          "lists"
-        ],
-        "difficulty": 7
-      },
-      {
-        "slug": "parallel-letter-frequency",
-        "name": "Parallel Letter Frequency",
-        "uuid": "38a405e8-619d-400f-b53c-2f06461fdf9d",
-        "practices": [],
-        "prerequisites": [
-          "strings"
-        ],
-        "difficulty": 6
       },
       {
         "slug": "simple-linked-list",
@@ -1459,6 +1468,38 @@
         "difficulty": 7
       },
       {
+        "slug": "two-bucket",
+        "name": "Two Bucket",
+        "uuid": "210bf628-b385-443b-8329-3483cc6e8d7e",
+        "practices": [],
+        "prerequisites": [
+          "constructors",
+          "if-else-statements",
+          "numbers"
+        ],
+        "difficulty": 7
+      },
+      {
+        "slug": "word-search",
+        "name": "Word Search",
+        "uuid": "b53bde52-cb5f-4d43-86ec-18aa509d62f9",
+        "practices": [],
+        "prerequisites": [
+          "arrays",
+          "strings",
+          "if-else-statements"
+        ],
+        "difficulty": 7
+      },
+      {
+        "slug": "zebra-puzzle",
+        "name": "Zebra Puzzle",
+        "uuid": "b1e2bd39-3f4b-44c1-b7e2-258d4ee241f8",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 7
+      },
+      {
         "slug": "zipper",
         "name": "Zipper",
         "uuid": "25d2c7a5-1ec8-464a-b3de-ad1b27464ef1",
@@ -1473,6 +1514,31 @@
         "difficulty": 7
       },
       {
+        "slug": "book-store",
+        "name": "Book Store",
+        "uuid": "e5f05d00-fe5b-4d78-b2fa-934c1c9afb32",
+        "practices": [],
+        "prerequisites": [
+          "exceptions",
+          "if-else-statements",
+          "lists",
+          "numbers"
+        ],
+        "difficulty": 8
+      },
+      {
+        "slug": "change",
+        "name": "Change",
+        "uuid": "bac1f4bc-eea9-43c1-8e95-097347f5925e",
+        "practices": [],
+        "prerequisites": [
+          "exceptions",
+          "lists",
+          "numbers"
+        ],
+        "difficulty": 8
+      },
+      {
         "slug": "circular-buffer",
         "name": "Circular Buffer",
         "uuid": "626dc25a-062c-4053-a8c1-788e4dc44ca0",
@@ -1481,6 +1547,26 @@
           "classes",
           "exceptions",
           "generic-types"
+        ],
+        "difficulty": 8
+      },
+      {
+        "slug": "complex-numbers",
+        "name": "Complex Numbers",
+        "uuid": "52d11278-0d65-4b5b-b387-1374fced3243",
+        "practices": [],
+        "prerequisites": [
+          "numbers"
+        ],
+        "difficulty": 8
+      },
+      {
+        "slug": "connect",
+        "name": "Connect",
+        "uuid": "1532b9a8-7e0d-479f-ad55-636e01e9d19f",
+        "practices": [],
+        "prerequisites": [
+          "enums"
         ],
         "difficulty": 8
       },
@@ -1515,6 +1601,129 @@
         "difficulty": 8
       },
       {
+        "slug": "mazy-mice",
+        "name": "Mazy Mice",
+        "uuid": "1bac7473-9ee8-4cfc-928b-77792102ffc1",
+        "practices": [],
+        "prerequisites": [
+          "for-loops",
+          "randomness",
+          "strings"
+        ],
+        "difficulty": 8,
+        "status": "beta"
+      },
+      {
+        "slug": "ocr-numbers",
+        "name": "OCR Numbers",
+        "uuid": "5cbc6a67-3a53-4aad-ae68-ff469525437f",
+        "practices": [],
+        "prerequisites": [
+          "exceptions",
+          "lists",
+          "strings"
+        ],
+        "difficulty": 8
+      },
+      {
+        "slug": "palindrome-products",
+        "name": "Palindrome Products",
+        "uuid": "873c05de-b5f5-4c5b-97f0-d1ede8a82832",
+        "practices": [],
+        "prerequisites": [
+          "exceptions",
+          "for-loops",
+          "if-else-statements",
+          "numbers"
+        ],
+        "difficulty": 8
+      },
+      {
+        "slug": "pov",
+        "name": "POV",
+        "uuid": "cae26d37-2977-42c4-af10-b6bb83adef19",
+        "practices": [],
+        "prerequisites": [
+          "strings",
+          "if-else-statements",
+          "lists",
+          "for-loops"
+        ],
+        "difficulty": 8
+      },
+      {
+        "slug": "rational-numbers",
+        "name": "Rational Numbers",
+        "uuid": "50ed54ce-3047-4590-9fda-0a7e9aeeba30",
+        "practices": [],
+        "prerequisites": [
+          "numbers"
+        ],
+        "difficulty": 8
+      },
+      {
+        "slug": "react",
+        "name": "React",
+        "uuid": "33531718-1d8a-4abd-bd2a-090303ad0c39",
+        "practices": [],
+        "prerequisites": [
+          "classes",
+          "generic-types"
+        ],
+        "difficulty": 8
+      },
+      {
+        "slug": "rectangles",
+        "name": "Rectangles",
+        "uuid": "64cda115-919a-4eef-9a45-9ec5d1af98cc",
+        "practices": [],
+        "prerequisites": [
+          "arrays",
+          "exceptions",
+          "strings"
+        ],
+        "difficulty": 8
+      },
+      {
+        "slug": "simple-cipher",
+        "name": "Simple Cipher",
+        "uuid": "f654831f-c34b-44f5-9dd5-054efbb486f2",
+        "practices": [],
+        "prerequisites": [
+          "chars",
+          "exceptions",
+          "for-loops",
+          "if-else-statements",
+          "numbers",
+          "randomness"
+        ],
+        "difficulty": 8
+      },
+      {
+        "slug": "forth",
+        "name": "Forth",
+        "uuid": "f0c0316d-3fb5-455e-952a-91161e7fb298",
+        "practices": [],
+        "prerequisites": [
+          "exceptions",
+          "lists",
+          "strings"
+        ],
+        "difficulty": 9
+      },
+      {
+        "slug": "pythagorean-triplet",
+        "name": "Pythagorean Triplet",
+        "uuid": "88505f95-89e5-4a08-8ed2-208eb818cdf1",
+        "practices": [],
+        "prerequisites": [
+          "constructors",
+          "lists",
+          "numbers"
+        ],
+        "difficulty": 9
+      },
+      {
         "slug": "custom-set",
         "name": "Custom Set",
         "uuid": "377fe38b-08ad-4f3a-8118-a43c10f7b9b2",
@@ -1535,215 +1744,6 @@
           "lists"
         ],
         "difficulty": 10
-      },
-      {
-        "slug": "accumulate",
-        "name": "Accumulate",
-        "uuid": "e58c29d2-80a7-40ef-bed0-4a184ae35f34",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "status": "deprecated"
-      },
-      {
-        "slug": "binary",
-        "name": "Binary",
-        "uuid": "9ea6e0fa-b91d-4d17-ac8f-6d2dc30fdd44",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "status": "deprecated"
-      },
-      {
-        "slug": "hexadecimal",
-        "name": "Hexadecimal",
-        "uuid": "6fe53a08-c123-465d-864a-ef18217203c4",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "status": "deprecated"
-      },
-      {
-        "slug": "octal",
-        "name": "Octal",
-        "uuid": "14a29e82-f9b1-4662-b678-06992e306c01",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "status": "deprecated"
-      },
-      {
-        "slug": "strain",
-        "name": "Strain",
-        "uuid": "2d195cd9-1814-490a-8dd6-a2c676f1d4cd",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "status": "deprecated"
-      },
-      {
-        "slug": "trinary",
-        "name": "Trinary",
-        "uuid": "ee3a8abe-6b19-4b47-9cf6-4d39ae915fb7",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 1,
-        "status": "deprecated"
-      },
-      {
-        "slug": "leap",
-        "name": "Leap",
-        "uuid": "61fe1fa6-246d-4e38-92d6-b74af64c88af",
-        "practices": [],
-        "prerequisites": [
-          "booleans",
-          "numbers"
-        ],
-        "difficulty": 1
-      },
-      {
-        "slug": "armstrong-numbers",
-        "name": "Armstrong Numbers",
-        "uuid": "8e1dd48c-e05e-4a72-bf0f-5aed8dd123f5",
-        "practices": [],
-        "prerequisites": [
-          "numbers"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "rna-transcription",
-        "name": "RNA Transcription",
-        "uuid": "8e983ed2-62f7-439a-a144-fb8fdbdf4d30",
-        "practices": [],
-        "prerequisites": [
-          "foreach-loops",
-          "strings"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "acronym",
-        "name": "Acronym",
-        "uuid": "c31bbc6d-bdcf-44f7-bf35-5f98752e38d0",
-        "practices": [],
-        "prerequisites": [
-          "for-loops",
-          "strings"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "pangram",
-        "name": "Pangram",
-        "uuid": "133b0f84-bdc7-4508-a0a1-5732a7db81ef",
-        "practices": [],
-        "prerequisites": [
-          "chars"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "space-age",
-        "name": "Space Age",
-        "uuid": "e5b524cd-3a1c-468a-8981-13e8eeccb29d",
-        "practices": [],
-        "prerequisites": [
-          "numbers"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "connect",
-        "name": "Connect",
-        "uuid": "1532b9a8-7e0d-479f-ad55-636e01e9d19f",
-        "practices": [],
-        "prerequisites": [
-          "enums"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "sgf-parsing",
-        "name": "SGF Parsing",
-        "uuid": "0d6325d1-c0a3-456e-9a92-cea0559e82ed",
-        "practices": [],
-        "prerequisites": [
-          "strings",
-          "chars",
-          "if-else-statements",
-          "lists",
-          "for-loops"
-        ],
-        "difficulty": 7
-      },
-      {
-        "slug": "pov",
-        "name": "POV",
-        "uuid": "cae26d37-2977-42c4-af10-b6bb83adef19",
-        "practices": [],
-        "prerequisites": [
-          "strings",
-          "if-else-statements",
-          "lists",
-          "for-loops"
-        ],
-        "difficulty": 8
-      },
-      {
-        "slug": "ledger",
-        "name": "Ledger",
-        "uuid": "6597548e-176d-49c6-be33-789f4c43867a",
-        "practices": [],
-        "prerequisites": [
-          "classes",
-          "datetime",
-          "strings"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "high-scores",
-        "name": "High Scores",
-        "uuid": "574d6323-5ff5-4019-9ebe-0067daafba13",
-        "practices": [],
-        "prerequisites": [
-          "lists"
-        ],
-        "difficulty": 2
-      },
-      {
-        "slug": "square-root",
-        "name": "Square Root",
-        "uuid": "61886554-ec84-422a-bbf9-aeee37c45bb6",
-        "practices": [],
-        "prerequisites": [
-          "numbers"
-        ],
-        "difficulty": 5
-      },
-      {
-        "slug": "pop-count",
-        "name": "Eliud's Eggs",
-        "uuid": "2d5b6404-3315-48c1-892f-b594a960e7a1",
-        "practices": [],
-        "prerequisites": [
-          "numbers"
-        ],
-        "difficulty": 3
-      },
-      {
-        "slug": "mazy-mice",
-        "name": "Mazy Mice",
-        "uuid": "1bac7473-9ee8-4cfc-928b-77792102ffc1",
-        "practices": [],
-        "prerequisites": [
-          "for-loops",
-          "randomness",
-          "strings"
-        ],
-        "difficulty": 8,
-        "status": "beta"
       }
     ],
     "foregone": [


### PR DESCRIPTION
The order of the practice exercises on the website is determined by their ordering in `config.json`. This reorders the practice exercises so that less difficult exercises appear before harder exercises. Hopefully that should help students pick their next exercise based on their skill level.

Reordering was done using `jq`:

```sh
cat config.json | jq -r '.exercises.practice | sort_by(.difficulty, .slug)'
```

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
