### PR TITLE
Sync tests for practice exercise ``space age``

### DIFF
--- a/exercises/practice/space-age/.meta/src/reference/java/SpaceAge.java
+++ b/exercises/practice/space-age/.meta/src/reference/java/SpaceAge.java
@@ -1,73 +1,37 @@
-import java.math.BigDecimal;
+import java.util.Map;
+import java.util.HashMap;
 
 class SpaceAge {
 
-    private enum Planet {
-        EARTH(1.0),
-        MERCURY(0.2408467),
-        VENUS(0.61519726),
-        MARS(1.8808158),
-        JUPITER(11.862615),
-        SATURN(29.447498),
-        URANUS(84.016846),
-        NEPTUNE(164.79132);
-
-        private final double relativeOrbitalPeriod;
-
-        Planet(double relativeOrbitalPeriod) {
-            this.relativeOrbitalPeriod = relativeOrbitalPeriod;
-        }
-
-        private double getRelativeOrbitalPeriod() {
-            return relativeOrbitalPeriod;
-        }
-    }
+    private Map<String, Double> planetsOrbitalPeriod = new HashMap<>() {{
+            put("Mercury", 0.2408467);
+            put("Venus", 0.61519726);
+            put("Mars", 1.8808158);
+            put("Jupiter", 11.862615);
+            put("Saturn", 29.447498);
+            put("Uranus", 84.016846);
+            put("Neptune", 164.79132);
+            put("Earth", 1.0);
+        }};
 
     private static final double EARTH_ORBITAL_PERIOD_IN_SECONDS = 31557600.0;
-    private static final int PRECISION = 2;
-
     private double seconds;
+    private String planet;
 
-    SpaceAge(double seconds) {
+    SpaceAge(double seconds, String planet) {
         this.seconds = seconds;
+        this.planet = planet;
+
+        if (planetsOrbitalPeriod.get(planet) == null) {
+            throw new IllegalArgumentException("not a planet");
+        }
     }
 
-    double onEarth() {
-        return calculateAge(Planet.EARTH);
-    }
-
-    double onMercury() {
-        return calculateAge(Planet.MERCURY);
-    }
-
-    double onVenus() {
-        return calculateAge(Planet.VENUS);
-    }
-
-    double onMars() {
-        return calculateAge(Planet.MARS);
-    }
-
-    double onJupiter() {
-        return calculateAge(Planet.JUPITER);
-    }
-
-    double onSaturn() {
-        return calculateAge(Planet.SATURN);
-    }
-
-    double onUranus() {
-        return calculateAge(Planet.URANUS);
-    }
-
-    double onNeptune() {
-        return calculateAge(Planet.NEPTUNE);
-    }
-
-    private double calculateAge(Planet planet) {
-        double age = seconds / (EARTH_ORBITAL_PERIOD_IN_SECONDS * planet.getRelativeOrbitalPeriod());
-
-        return new BigDecimal(age).setScale(PRECISION, BigDecimal.ROUND_HALF_UP).doubleValue();
+    double calculateAge() {
+        double earthyears = seconds / EARTH_ORBITAL_PERIOD_IN_SECONDS;
+        double years = earthyears / planetsOrbitalPeriod.get(planet);
+        
+        return (double) Math.round(years * 100) / 100;
     }
 
 }

--- a/exercises/practice/space-age/.meta/src/reference/java/SpaceAge.java
+++ b/exercises/practice/space-age/.meta/src/reference/java/SpaceAge.java
@@ -61,9 +61,7 @@ class SpaceAge {
     }
 
     private double calculateAge(Planet planet) {
-        double planetYears = (seconds / EARTH_ORBITAL_PERIOD_IN_SECONDS) / planet.getRelativeOrbitalPeriod();
-        
-        return (double) Math.round(planetYears * 100) / 100;
+        return (seconds / EARTH_ORBITAL_PERIOD_IN_SECONDS) / planet.getRelativeOrbitalPeriod();
     }
 
 }

--- a/exercises/practice/space-age/.meta/src/reference/java/SpaceAge.java
+++ b/exercises/practice/space-age/.meta/src/reference/java/SpaceAge.java
@@ -1,37 +1,69 @@
-import java.util.Map;
-import java.util.HashMap;
-
 class SpaceAge {
 
-    private Map<String, Double> planetsOrbitalPeriod = new HashMap<>() {{
-            put("Mercury", 0.2408467);
-            put("Venus", 0.61519726);
-            put("Mars", 1.8808158);
-            put("Jupiter", 11.862615);
-            put("Saturn", 29.447498);
-            put("Uranus", 84.016846);
-            put("Neptune", 164.79132);
-            put("Earth", 1.0);
-        }};
+    private enum Planet {
+        EARTH(1.0),
+        MERCURY(0.2408467),
+        VENUS(0.61519726),
+        MARS(1.8808158),
+        JUPITER(11.862615),
+        SATURN(29.447498),
+        URANUS(84.016846),
+        NEPTUNE(164.79132);
 
-    private static final double EARTH_ORBITAL_PERIOD_IN_SECONDS = 31557600.0;
-    private double seconds;
-    private String planet;
+        private final double relativeOrbitalPeriod;
 
-    SpaceAge(double seconds, String planet) {
-        this.seconds = seconds;
-        this.planet = planet;
+        Planet(double relativeOrbitalPeriod) {
+            this.relativeOrbitalPeriod = relativeOrbitalPeriod;
+        }
 
-        if (planetsOrbitalPeriod.get(planet) == null) {
-            throw new IllegalArgumentException("not a planet");
+        private double getRelativeOrbitalPeriod() {
+            return relativeOrbitalPeriod;
         }
     }
 
-    double calculateAge() {
-        double earthyears = seconds / EARTH_ORBITAL_PERIOD_IN_SECONDS;
-        double years = earthyears / planetsOrbitalPeriod.get(planet);
+    private static final double EARTH_ORBITAL_PERIOD_IN_SECONDS = 31557600.0;
+    private double seconds;
+
+    SpaceAge(double seconds) {
+        this.seconds = seconds;
+    }
+
+    double onEarth() {
+        return calculateAge(Planet.EARTH);
+    }
+
+    double onMercury() {
+        return calculateAge(Planet.MERCURY);
+    }
+
+    double onVenus() {
+        return calculateAge(Planet.VENUS);
+    }
+
+    double onMars() {
+        return calculateAge(Planet.MARS);
+    }
+
+    double onJupiter() {
+        return calculateAge(Planet.JUPITER);
+    }
+
+    double onSaturn() {
+        return calculateAge(Planet.SATURN);
+    }
+
+    double onUranus() {
+        return calculateAge(Planet.URANUS);
+    }
+
+    double onNeptune() {
+        return calculateAge(Planet.NEPTUNE);
+    }
+
+    private double calculateAge(Planet planet) {
+        double planetYears = (seconds / EARTH_ORBITAL_PERIOD_IN_SECONDS) / planet.getRelativeOrbitalPeriod();
         
-        return (double) Math.round(years * 100) / 100;
+        return (double) Math.round(planetYears * 100) / 100;
     }
 
 }

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [84f609af-5a91-4d68-90a3-9e32d8a5cd34]
 description = "age on Earth"
@@ -25,3 +32,6 @@ description = "age on Uranus"
 
 [80096d30-a0d4-4449-903e-a381178355d8]
 description = "age on Neptune"
+
+[57b96e2a-1178-40b7-b34d-f3c9c34e4bf4]
+description = "invalid planet causes error"

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -35,3 +35,5 @@ description = "age on Neptune"
 
 [57b96e2a-1178-40b7-b34d-f3c9c34e4bf4]
 description = "invalid planet causes error"
+include = false
+comment = "Excluded because the design of the exercise does not allow for arbitrary planets"

--- a/exercises/practice/space-age/src/main/java/SpaceAge.java
+++ b/exercises/practice/space-age/src/main/java/SpaceAge.java
@@ -1,42 +1,10 @@
 class SpaceAge {
 
-    SpaceAge(double seconds) {
+    SpaceAge(double seconds, String planet) {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
     }
 
-    double getSeconds() {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
-    }
-
-    double onEarth() {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
-    }
-
-    double onMercury() {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
-    }
-
-    double onVenus() {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
-    }
-
-    double onMars() {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
-    }
-
-    double onJupiter() {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
-    }
-
-    double onSaturn() {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
-    }
-
-    double onUranus() {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
-    }
-
-    double onNeptune() {
+    double calculateAge() {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
     }
 

--- a/exercises/practice/space-age/src/main/java/SpaceAge.java
+++ b/exercises/practice/space-age/src/main/java/SpaceAge.java
@@ -1,10 +1,42 @@
 class SpaceAge {
 
-    SpaceAge(double seconds, String planet) {
+    SpaceAge(double seconds) {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
     }
 
-    double calculateAge() {
+    double getSeconds() {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    double onEarth() {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    double onMercury() {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    double onVenus() {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    double onMars() {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    double onJupiter() {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    double onSaturn() {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    double onUranus() {
+        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
+    }
+
+    double onNeptune() {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
     }
 

--- a/exercises/practice/space-age/src/test/java/SpaceAgeTest.java
+++ b/exercises/practice/space-age/src/test/java/SpaceAgeTest.java
@@ -2,7 +2,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
+import static org.assertj.core.api.Assertions.offset;
 
 public class SpaceAgeTest {
 
@@ -12,7 +12,7 @@ public class SpaceAgeTest {
     public void ageOnEarth() {
         SpaceAge age = new SpaceAge(1000000000);
 
-        assertThat(age.onEarth()).isEqualTo(31.69, within(MAXIMUM_DELTA));
+        assertThat(age.onEarth()).isEqualTo(31.69, offset(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
@@ -20,7 +20,7 @@ public class SpaceAgeTest {
     public void ageOnMercury() {
         SpaceAge age = new SpaceAge(2134835688);
 
-        assertThat(age.onMercury()).isEqualTo(280.88, within(MAXIMUM_DELTA));
+        assertThat(age.onMercury()).isEqualTo(280.88, offset(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
@@ -28,7 +28,7 @@ public class SpaceAgeTest {
     public void ageOnVenus() {
         SpaceAge age = new SpaceAge(189839836);
 
-        assertThat(age.onVenus()).isEqualTo(9.78, within(MAXIMUM_DELTA));
+        assertThat(age.onVenus()).isEqualTo(9.78, offset(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
@@ -36,7 +36,7 @@ public class SpaceAgeTest {
     public void ageOnMars() {
         SpaceAge age = new SpaceAge(2129871239L);
 
-        assertThat(age.onMars()).isEqualTo(35.88, within(MAXIMUM_DELTA));
+        assertThat(age.onMars()).isEqualTo(35.88, offset(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
@@ -44,7 +44,7 @@ public class SpaceAgeTest {
     public void ageOnJupiter() {
         SpaceAge age = new SpaceAge(901876382);
 
-        assertThat(age.onJupiter()).isEqualTo(2.41, within(MAXIMUM_DELTA));
+        assertThat(age.onJupiter()).isEqualTo(2.41, offset(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
@@ -52,7 +52,7 @@ public class SpaceAgeTest {
     public void ageOnSaturn() {
         SpaceAge age = new SpaceAge(2000000000L);
 
-        assertThat(age.onSaturn()).isEqualTo(2.15, within(MAXIMUM_DELTA));
+        assertThat(age.onSaturn()).isEqualTo(2.15, offset(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
@@ -60,7 +60,7 @@ public class SpaceAgeTest {
     public void ageOnUranus() {
         SpaceAge age = new SpaceAge(1210123456L);
 
-        assertThat(age.onUranus()).isEqualTo(0.46, within(MAXIMUM_DELTA));
+        assertThat(age.onUranus()).isEqualTo(0.46, offset(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
@@ -68,6 +68,6 @@ public class SpaceAgeTest {
     public void ageOnNeptune() {
         SpaceAge age = new SpaceAge(1821023456L);
 
-        assertThat(age.onNeptune()).isEqualTo(0.35, within(MAXIMUM_DELTA));
+        assertThat(age.onNeptune()).isEqualTo(0.35, offset(MAXIMUM_DELTA));
     }
 }

--- a/exercises/practice/space-age/src/test/java/SpaceAgeTest.java
+++ b/exercises/practice/space-age/src/test/java/SpaceAgeTest.java
@@ -2,7 +2,6 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.within;
 
 public class SpaceAgeTest {
@@ -11,73 +10,64 @@ public class SpaceAgeTest {
 
     @Test
     public void ageOnEarth() {
-        SpaceAge age = new SpaceAge(1000000000, "Earth");
+        SpaceAge age = new SpaceAge(1000000000);
 
-        assertThat(age.calculateAge()).isEqualTo(31.69, within(MAXIMUM_DELTA));
+        assertThat(age.onEarth()).isEqualTo(31.69, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnMercury() {
-        SpaceAge age = new SpaceAge(2134835688, "Mercury");
+        SpaceAge age = new SpaceAge(2134835688);
 
-        assertThat(age.calculateAge()).isEqualTo(280.88, within(MAXIMUM_DELTA));
+        assertThat(age.onMercury()).isEqualTo(280.88, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnVenus() {
-        SpaceAge age = new SpaceAge(189839836, "Venus");
+        SpaceAge age = new SpaceAge(189839836);
 
-        assertThat(age.calculateAge()).isEqualTo(9.78, within(MAXIMUM_DELTA));
+        assertThat(age.onVenus()).isEqualTo(9.78, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnMars() {
-        SpaceAge age = new SpaceAge(2129871239L, "Mars");
+        SpaceAge age = new SpaceAge(2129871239L);
 
-        assertThat(age.calculateAge()).isEqualTo(35.88, within(MAXIMUM_DELTA));
+        assertThat(age.onMars()).isEqualTo(35.88, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnJupiter() {
-        SpaceAge age = new SpaceAge(901876382, "Jupiter");
+        SpaceAge age = new SpaceAge(901876382);
 
-        assertThat(age.calculateAge()).isEqualTo(2.41, within(MAXIMUM_DELTA));
+        assertThat(age.onJupiter()).isEqualTo(2.41, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnSaturn() {
-        SpaceAge age = new SpaceAge(2000000000L, "Saturn");
+        SpaceAge age = new SpaceAge(2000000000L);
 
-        assertThat(age.calculateAge()).isEqualTo(2.15, within(MAXIMUM_DELTA));
+        assertThat(age.onSaturn()).isEqualTo(2.15, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnUranus() {
-        SpaceAge age = new SpaceAge(1210123456L, "Uranus");
+        SpaceAge age = new SpaceAge(1210123456L);
 
-        assertThat(age.calculateAge()).isEqualTo(0.46, within(MAXIMUM_DELTA));
+        assertThat(age.onUranus()).isEqualTo(0.46, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnNeptune() {
-        SpaceAge age = new SpaceAge(1821023456L, "Neptune");
+        SpaceAge age = new SpaceAge(1821023456L);
 
-        assertThat(age.calculateAge()).isEqualTo(0.35, within(MAXIMUM_DELTA));
-    }
-
-    @Ignore("Remove to run test")
-    @Test
-    public void invalidPlanetCausesError() {
-
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> new SpaceAge(680804807L, "Sun"))
-                .withMessage("not a planet");
+        assertThat(age.onNeptune()).isEqualTo(0.35, within(MAXIMUM_DELTA));
     }
 }

--- a/exercises/practice/space-age/src/test/java/SpaceAgeTest.java
+++ b/exercises/practice/space-age/src/test/java/SpaceAgeTest.java
@@ -2,6 +2,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.within;
 
 public class SpaceAgeTest {
@@ -10,64 +11,73 @@ public class SpaceAgeTest {
 
     @Test
     public void ageOnEarth() {
-        SpaceAge age = new SpaceAge(1000000000);
+        SpaceAge age = new SpaceAge(1000000000, "Earth");
 
-        assertThat(age.onEarth()).isEqualTo(31.69, within(MAXIMUM_DELTA));
+        assertThat(age.calculateAge()).isEqualTo(31.69, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnMercury() {
-        SpaceAge age = new SpaceAge(2134835688);
+        SpaceAge age = new SpaceAge(2134835688, "Mercury");
 
-        assertThat(age.onMercury()).isEqualTo(280.88, within(MAXIMUM_DELTA));
+        assertThat(age.calculateAge()).isEqualTo(280.88, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnVenus() {
-        SpaceAge age = new SpaceAge(189839836);
+        SpaceAge age = new SpaceAge(189839836, "Venus");
 
-        assertThat(age.onVenus()).isEqualTo(9.78, within(MAXIMUM_DELTA));
+        assertThat(age.calculateAge()).isEqualTo(9.78, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnMars() {
-        SpaceAge age = new SpaceAge(2129871239L);
+        SpaceAge age = new SpaceAge(2129871239L, "Mars");
 
-        assertThat(age.onMars()).isEqualTo(35.88, within(MAXIMUM_DELTA));
+        assertThat(age.calculateAge()).isEqualTo(35.88, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnJupiter() {
-        SpaceAge age = new SpaceAge(901876382);
+        SpaceAge age = new SpaceAge(901876382, "Jupiter");
 
-        assertThat(age.onJupiter()).isEqualTo(2.41, within(MAXIMUM_DELTA));
+        assertThat(age.calculateAge()).isEqualTo(2.41, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnSaturn() {
-        SpaceAge age = new SpaceAge(2000000000L);
+        SpaceAge age = new SpaceAge(2000000000L, "Saturn");
 
-        assertThat(age.onSaturn()).isEqualTo(2.15, within(MAXIMUM_DELTA));
+        assertThat(age.calculateAge()).isEqualTo(2.15, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnUranus() {
-        SpaceAge age = new SpaceAge(1210123456L);
+        SpaceAge age = new SpaceAge(1210123456L, "Uranus");
 
-        assertThat(age.onUranus()).isEqualTo(0.46, within(MAXIMUM_DELTA));
+        assertThat(age.calculateAge()).isEqualTo(0.46, within(MAXIMUM_DELTA));
     }
 
     @Ignore("Remove to run test")
     @Test
     public void ageOnNeptune() {
-        SpaceAge age = new SpaceAge(1821023456L);
+        SpaceAge age = new SpaceAge(1821023456L, "Neptune");
 
-        assertThat(age.onNeptune()).isEqualTo(0.35, within(MAXIMUM_DELTA));
+        assertThat(age.calculateAge()).isEqualTo(0.35, within(MAXIMUM_DELTA));
+    }
+
+    @Ignore("Remove to run test")
+    @Test
+    public void invalidPlanetCausesError() {
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new SpaceAge(680804807L, "Sun"))
+                .withMessage("not a planet");
     }
 }


### PR DESCRIPTION
# pull request

This issue addresses: [#2388](https://github.com/exercism/java/issues/2388)

This one required a major reformat, due to tests passing a new parameter and also usage of a deprecated method ``setScale``
````
{
  "uuid": "57b96e2a-1178-40b7-b34d-f3c9c34e4bf4",
  "description": "invalid planet causes error",
  "property": "age",
  "input": {
    "planet": "Sun",
    "seconds": 680804807
  },
  "expected": {
    "error": "not a planet"
  }
}
````

I used as reference the ``go`` track that is updated.

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
