### PR TITLE
Sync tests for practice exercise ``series``

### DIFF
--- a/exercises/practice/series/.meta/src/reference/java/Series.java
+++ b/exercises/practice/series/.meta/src/reference/java/Series.java
@@ -10,16 +10,20 @@ class Series {
     private List<String> digits;
 
     Series(String string) {
+        if (string.length() == 0) {
+            throw new IllegalArgumentException("series cannot be empty");
+        }
+
         this.digits = Arrays.stream(string.split("")).collect(Collectors.toList());
         this.digitsSize = string.isEmpty() ? 0 : this.digits.size();
     }
 
     List<String> slices(int num) {
         if (num <= 0) {
-            throw new IllegalArgumentException("Slice size is too small.");
+            throw new IllegalArgumentException("slice length cannot be negative or zero");
         }
         if (num > this.digitsSize) {
-            throw new IllegalArgumentException("Slice size is too big.");
+            throw new IllegalArgumentException("slice length cannot be greater than series length");
         }
         final int limit = this.digitsSize - num + 1;
         List<String> result = new ArrayList<>(limit);

--- a/exercises/practice/series/.meta/tests.toml
+++ b/exercises/practice/series/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [7ae7a46a-d992-4c2a-9c15-a112d125ebad]
 description = "slices of one from one"
@@ -22,6 +29,9 @@ description = "slices of a long series"
 
 [6d235d85-46cf-4fae-9955-14b6efef27cd]
 description = "slice length is too large"
+
+[d7957455-346d-4e47-8e4b-87ed1564c6d7]
+description = "slice length is way too large"
 
 [d34004ad-8765-4c09-8ba1-ada8ce776806]
 description = "slice length cannot be zero"

--- a/exercises/practice/series/src/test/java/SeriesTest.java
+++ b/exercises/practice/series/src/test/java/SeriesTest.java
@@ -120,11 +120,10 @@ public class SeriesTest {
     @Ignore("Remove to run test")
     @Test
     public void emptySeries() {
-        Series series = new Series("");
 
         assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> series.slices(1))
-                .withMessage("Slice size is too big.");
+                .isThrownBy(() -> new Series(""))
+                .withMessage("series cannot be empty");
     }
 
 }

--- a/exercises/practice/series/src/test/java/SeriesTest.java
+++ b/exercises/practice/series/src/test/java/SeriesTest.java
@@ -84,7 +84,17 @@ public class SeriesTest {
 
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> series.slices(6))
-                .withMessage("Slice size is too big.");
+                .withMessage("slice length cannot be greater than series length");
+    }
+
+    @Ignore("Remove to run test")
+    @Test
+    public void sliceLengthIsWayToolarge() {
+        Series series = new Series("12345");
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> series.slices(42))
+                .withMessage("slice length cannot be greater than series length");
     }
 
     @Ignore("Remove to run test")
@@ -94,7 +104,7 @@ public class SeriesTest {
 
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> series.slices(0))
-                .withMessage("Slice size is too small.");
+                .withMessage("slice length cannot be negative or zero");
     }
 
     @Ignore("Remove to run test")
@@ -104,7 +114,7 @@ public class SeriesTest {
 
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> series.slices(-1))
-                .withMessage("Slice size is too small.");
+                .withMessage("slice length cannot be negative or zero");
     }
 
     @Ignore("Remove to run test")


### PR DESCRIPTION
# pull request

This issue addresses: [#2388](https://github.com/exercism/java/issues/2388)

The goal is to sync the tests of the series practice exercise

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
