### PR TITLE
Enable representer and analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,25 @@
 [![Build](https://github.com/exercism/java/actions/workflows/build.yml/badge.svg)](https://github.com/exercism/java/actions/workflows/build.yml)
 [![Test](https://github.com/exercism/java/actions/workflows/test.yml/badge.svg)](https://github.com/exercism/java/actions/workflows/test.yml)
 
-Source for Exercism Exercises in Java.
+This repository contains the source for the exercises of the Java track on Exercism.
+
+## Java Track Tooling
+
+Next to the exercises, the Java track also consists of the following tooling:
+
+- [exercism/java-test-runner] - The Exercism [test runner][docs-test-runners] for the Java track that automatically verifies if a submitted solution passes all of the exercise's tests.
+- [exercism/java-representer] - The Exercism [representer][docs-representers] for the Java track that creates normalized representations of submitted solutions.
+- [exercism/java-analyzer] - The Exercism [analyzer][docs-analyzers] for the Java track that automatically provides comments on submitted solutions.
 
 ## Contributing Guide
 
 For general information about how to contribute to Exercism, please refer to the [Contributing Guide](https://exercism.org/contributing).
 
 For information on contributing to this track, refer to the [CONTRIBUTING.md](https://github.com/exercism/java/blob/main/CONTRIBUTING.md) file.
+
+[docs-analyzers]: https://exercism.org/docs/building/tooling/analyzers
+[docs-representers]: https://exercism.org/docs/building/tooling/representers
+[docs-test-runners]: https://exercism.org/docs/building/tooling/test-runners
+[exercism/java-analyzer]: https://github.com/exercism/java-analyzer
+[exercism/java-representer]: https://github.com/exercism/java-representer
+[exercism/java-test-runner]: https://github.com/exercism/java-test-runner

--- a/config.json
+++ b/config.json
@@ -5,8 +5,8 @@
   "status": {
     "concept_exercises": true,
     "test_runner": true,
-    "representer": false,
-    "analyzer": false
+    "representer": true,
+    "analyzer": true
   },
   "blurb": "Java is a very widely used Object Oriented programming language. It's safe, simple to use and portable so that you can \"write once, run anywhere\".",
   "version": 3,


### PR DESCRIPTION
- The representer was recently disabled because it kept crashing; this bug has been fixed here: https://github.com/exercism/java-representer/pull/82
- The analyzer is still in an early stage: it only has an implementation for the `hamming`, `leap` and `two-fer` exercises. However, due to a recent addition that provides some basic general feedback to _all_ exercises I think it makes sense to enable it. Especially since there are a lot of questions on Discord from people who are struggling with getting tests to pass because they are printing the answers instead of returning them (which is something the analyzer informs them of).

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
