### PR TITLE
Sync tests for practice exercise ``knapsack``

### DIFF
--- a/exercises/practice/knapsack/.meta/tests.toml
+++ b/exercises/practice/knapsack/.meta/tests.toml
@@ -1,9 +1,21 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [a4d7d2f0-ad8a-460c-86f3-88ba709d41a7]
 description = "no items"
+include = false
+
+[3993a824-c20e-493d-b3c9-ee8a7753ee59]
+description = "no items"
+reimplements = "a4d7d2f0-ad8a-460c-86f3-88ba709d41a7"
 
 [1d39e98c-6249-4a8b-912f-87cb12e506b0]
 description = "one item, too heavy"


### PR DESCRIPTION
# pull request

This issue addresses: [#2388](https://github.com/exercism/java/issues/2388)

This exercise does not need any change only the update of the ``tests.toml``, The test already expected an empty list instead of an empty item.

````
$ bin/configlet sync --tests --update --exercise knapsack
Updating cached 'problem-specifications' data...
Checking exercises...
[warn] knapsack: missing 1 test case
The following test case is missing:
{
  "uuid": "3993a824-c20e-493d-b3c9-ee8a7753ee59",
  "reimplements": "a4d7d2f0-ad8a-460c-86f3-88ba709d41a7",
  "description": "no items",
  "property": "maximumValue",
  "input": {
    "maximumWeight": 100,
    "items": []
  },
  "expected": 0
}

It reimplements this test case:
{
  "uuid": "a4d7d2f0-ad8a-460c-86f3-88ba709d41a7",
  "description": "no items",
  "property": "maximumValue",
  "input": {
    "maximumWeight": 100,
    "items": {}
  },
  "expected": 0
}
````

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
