### PR TITLE
Add existing analyzer comments

### DIFF
--- a/exercises/concept/lasagna/.meta/design.md
+++ b/exercises/concept/lasagna/.meta/design.md
@@ -47,7 +47,13 @@ This exercise does not require any specific representation logic to be added to 
 
 ## Analyzer
 
-This exercise does not require any specific logic to be added to the [analyzer][analyzer]:
+This exercise could benefit from the following rules in the [analyzer]:
+
+- `actionable`: If the student did not reuse the implementation of the `expectedMinutesInOven` method in the `remainingMinutesInOven` method, instruct them to do so.
+  Explain that reusing existing code instead of copy-pasting can help make code easier to maintain.
+- `actionable`: If the student did not reuse the implementation of the `preparationTimeInMinutes` method in the `totalTimeInMinutes` method, instruct them to do so.
+  Explain that reusing existing code instead of copy-pasting can help make code easier to maintain.
+- `actionable`: If the student left any `// TODO: ...` comments in the code, instruct them to remove these.
 
 [analyzer]: https://github.com/exercism/java-analyzer
 [representer]: https://github.com/exercism/java-representer

--- a/exercises/practice/hamming/.meta/design.md
+++ b/exercises/practice/hamming/.meta/design.md
@@ -1,0 +1,15 @@
+# Design
+
+## Analyzer
+
+This exercise could benefit from the following rules in the [analyzer]:
+
+- `actionable`: If the solution calculates the Hamming distance each time `getHammingDistance()` is called,
+  instruct the student to calculate the Hamming distance once in the constructor.
+  Explain how this is more efficient.
+- `actionable`: If the solution hard-codes the DNA cells as character literals (`A`, `C`, `G`, `T`) when comparing strands,
+  inform the student that their solution should be able to calculate the Hamming distance between any two strings,
+  regardless of their contents.
+- `informative`: If the solution uses `Instream.reduce()`, inform the student that it can be simplified to `Instream.filter().count()`.
+
+[analyzer]: https://github.com/exercism/java-analyzer

--- a/exercises/practice/leap/.meta/design.md
+++ b/exercises/practice/leap/.meta/design.md
@@ -1,0 +1,12 @@
+# Design
+
+## Analyzer
+
+This exercise could benefit from the following rules in the [analyzer]:
+
+- `essential`: Verify that the solution does not use `java.time.Year.isLeap(int)` or `new java.util.GregorianCalendar().isLeapYear(int)`.
+- `essential`: Verify that the solution does not contain hard-coded years used in the tests.
+- `actionable`: If the solution uses conditional statements like `if/else` or ternary expressions, instruct the student to use simple boolean logic instead.
+- `actionable`: If the solution contains more than 3 checks, instruct the student that their solution can be simplified.
+
+[analyzer]: https://github.com/exercism/java-analyzer

--- a/exercises/practice/two-fer/.meta/design.md
+++ b/exercises/practice/two-fer/.meta/design.md
@@ -1,0 +1,25 @@
+# Design
+
+## Analyzer
+
+This exercise could benefit from the following rules in the [analyzer]:
+
+- `essential`: Verify that the solution does not hard-code the names used by the tests (`Alice`, `Bob`).
+- `actionable`: If the solution contains more than one `return` statement, instruct the student to try and only use one.
+  Using multiple `return` statements in this exercise could be an indication of code duplication, as it probably contains the sentence twice:
+
+  ```java
+  String twofer(String name) {
+      if (name == null) {
+          return "One for you, one for me."
+      }
+
+      return "One for " + name + ", one for me."
+  }
+  ```
+
+- `actionable`: If the solution uses an `if` statement, instruct the student to use a ternary expression instead.
+- `actionable`: If the solution uses `String.format`, instruct the student to use simple string concatenation instead.
+  Explain that `String.format` is significantly slower than concatenating strings and should be used in more complex scenarios.
+
+[analyzer]: https://github.com/exercism/java-analyzer


### PR DESCRIPTION
This adds the comments already implemented in the Java analyzer to the respective exercise's `.meta/design.md`.

Note that practice exercises generally don't have this file yet, as it is not required.
Still, I think it's good practice to record any major design decisions related to the exercise somewhere, so they might benefit from having one.

Fixes #2679

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
