### PR TITLE
Add documentation on representations

### DIFF
--- a/exercises/shared/.docs/representations.md
+++ b/exercises/shared/.docs/representations.md
@@ -1,0 +1,20 @@
+# Representations
+
+The [Java representer][github-java-representer] applies the following normalizations:
+
+- All comments are removed
+- All import declarations are removed
+- Whitespace is normalized
+- Identifiers are normalized to a placeholder value
+
+## Before you submit
+
+Please check the following things:
+
+- You don't duplicate feedback given by the analyzer.
+- You check the "examples" tab in the submit dialog and see if the feedback makes sense for all tabs.
+- You check that you have not referred to whitespace or comments.
+- You check that you don't refer to function names, or variable names as they appear in the solution, but rather use the mapping provided (or leave names out).
+  Only identifiers used by the exercise tests can be safely referred to because these are always the same for everyone.
+
+[github-java-representer]: https://github.com/exercism/java-representer


### PR DESCRIPTION
The `exercises/shared/.docs/representations.md` file contents are displayed in the Automations part of the website used by mentors to set up automated mentor feedback on solution sets grouped by their representations. This is explained here: https://exercism.org/docs/building/tracks/shared-files#h-file-representations-md

Fixes #2699 


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
