### PR TITLE
Fixing typo in the 'Secrets' exercise instructions.md file

### DIFF
--- a/exercises/concept/secrets/.docs/instructions.md
+++ b/exercises/concept/secrets/.docs/instructions.md
@@ -46,7 +46,7 @@ Secrets.flipBits(0b1100, 0b0101);
 
 ## 4. Clear specific bits
 
-Lastly, there are also certain bits that always decrpyt to 0.
+Lastly, there are also certain bits that always decrypt to 0.
 
 Implement the `Secrets.clearBits` method that takes a value and a mask.
 The bits in the `value` should be set to 0 where the bit in the mask is 1.


### PR DESCRIPTION
# pull request - 'Secrets' typo fix

Just fixing a typo I noticed ("decrpyt" -> "decrypt").

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
