### PR TITLE
Update reference resolution

### DIFF
--- a/exercises/concept/log-levels/.meta/src/reference/java/LogLevels.java
+++ b/exercises/concept/log-levels/.meta/src/reference/java/LogLevels.java
@@ -8,6 +8,6 @@ public class LogLevels {
     }
 
     public static String reformat(String logLine) {
-        return String.format("%s (%s)", message(logLine), logLevel(logLine));
+        return message(logLine) + " (" + logLevel(logLine) + ")";
     }
 }


### PR DESCRIPTION
# pull request

As in the design.md file we are informing that it's better for performance using string concatenation seems appropriate to use them instead of the ``String.format`` method

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
