### PR TITLE
Adding analyzer feedback for ``secrets`` concept exercise

### DIFF
--- a/exercises/concept/secrets/.meta/design.md
+++ b/exercises/concept/secrets/.meta/design.md
@@ -25,7 +25,8 @@ This exercise could benefit from the following rules in the [analyzer]:
 - `essential`: If the student did not use the `>>>` operator in the `shiftBack` method, instruct the student to do so.
 - `essential`: If the student did not use the `|` operator in the `setBits` method, instruct the student to do so.
 - `essential`: If the student did not use the `^` operator in the `flipBits` method, instruct the student to do so.
-- `essential`: If the student did not use the `&` or `~` operator in the `clearBits` method, instruct the student to do so.
+- `essential`: If the student did not use the `&` operator in the `clearBits` method, instruct the student to do so.
+- `informative`: If the solution did not use the `~` operator in the `clearBits` method, inform the student that with it will achieve a more concise solution.
 
 If the solution does not receive any of the above feedback, it must be exemplar.
 Leave a `celebratory` comment to celebrate the success!

--- a/exercises/concept/secrets/.meta/design.md
+++ b/exercises/concept/secrets/.meta/design.md
@@ -17,3 +17,17 @@ The goal of this exercise is to teach the student about bitwise operations in Ja
 This exercise's prerequisites Concepts are:
 
 - 'numbers'
+
+## Analyzer
+
+This exercise could benefit from the following rules in the [analyzer]:
+
+- `essential`: If the student did not use the `>>>` operator in the `shiftBack` method, instruct the student to do so.
+- `essential`: If the student did not use the `|` operator in the `setBits` method, instruct the student to do so.
+- `essential`: If the student did not use the `^` operator in the `flipBits` method, instruct the student to do so.
+- `essential`: If the student did not use the `&` or `~` operator in the `clearBits` method, instruct the student to do so.
+
+If the solution does not receive any of the above feedback, it must be exemplar.
+Leave a `celebratory` comment to celebrate the success!
+
+[analyzer]: https://github.com/exercism/java-analyzer


### PR DESCRIPTION
# pull request

closes [#2685](https://github.com/exercism/java/issues/2685)

This [solution](https://exercism.org/mentoring/automation/ef0f7c0053ec476c86f7144833e6f049/edit?source%5Bcriteria%5D=secrets&source%5Bpage%5D=1&source%5Btrack_slug%5D=java) could be a great example to see if we want to ask the operator `~` to be used 100% or be flexible and only ask  for the `&` one

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
