### PR TITLE
Fixing ``need-for-speed`` inconsistencies in the documentation/hints

### DIFF
--- a/exercises/concept/need-for-speed/.docs/hints.md
+++ b/exercises/concept/need-for-speed/.docs/hints.md
@@ -28,11 +28,10 @@
 
 ## 6. Check if a remote control car can finish a race
 
-- Solving this is probably best done by [repeatedly driving the car][while].
+- Try applying a formula that compares the distance and speed against the battery and battery drain.
 - Remember that the car has a method to retrieve the distance it has driven.
 - Consider what to do when the battery has been drained before reaching the finish line.
 
 [constructor-syntax]: https://docs.oracle.com/javase/tutorial/java/javaOO/constructors.html
 [instance-constructors]: https://docs.oracle.com/javase/tutorial/java/javaOO/objectcreation.html
-[while]: https://docs.oracle.com/javase/tutorial/java/nutsandbolts/while.html
 [fields]: https://docs.oracle.com/javase/tutorial/java/javaOO/variables.html

--- a/exercises/concept/need-for-speed/.docs/instructions.md
+++ b/exercises/concept/need-for-speed/.docs/instructions.md
@@ -70,7 +70,7 @@ car.distanceDriven();
 
 ## 6. Check if a remote control car can finish a race
 
-To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `RaceTrack.tryFinishTrack()` method that takes a `NeedForSpeed` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`. To see if the car can finish the race, you should try to drive the car until either you reach the end of the track or the battery drains:
+To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `RaceTrack.tryFinishTrack()` method that takes a `NeedForSpeed` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`:
 
 ```java
 int speed = 5;
@@ -88,3 +88,4 @@ race.tryFinishTrack(car);
 
 car.distanceDriven()
 // => 100
+```


### PR DESCRIPTION
# pull request

closes [#2737](https://github.com/exercism/java/issues/2737)

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
