### PR TITLE
Changing String format for String concatenation

### DIFF
--- a/exercises/concept/booking-up-for-beauty/.meta/src/reference/java/AppointmentScheduler.java
+++ b/exercises/concept/booking-up-for-beauty/.meta/src/reference/java/AppointmentScheduler.java
@@ -23,7 +23,7 @@ class AppointmentScheduler {
 
     public String getDescription(LocalDateTime appointmentDate) {
         var formatter = DateTimeFormatter.ofPattern("EEEE, MMMM d, yyyy, 'at' h:mm a", Locale.ENGLISH);
-        return String.format("You have an appointment on %s.", formatter.format(appointmentDate));
+        return "You have an appointment on " + formatter.format(appointmentDate) + ".";
     }
 
     public LocalDate getAnniversaryDate() {

--- a/exercises/concept/calculator-conundrum/.meta/src/reference/java/CalculatorConundrum.java
+++ b/exercises/concept/calculator-conundrum/.meta/src/reference/java/CalculatorConundrum.java
@@ -19,9 +19,9 @@ public class CalculatorConundrum {
                     throw new IllegalOperationException("Division by zero is not allowed", e);
                 }
             }
-            default -> throw new IllegalOperationException(String.format("Operation '%s' does not exist", operation));
+            default -> throw new IllegalOperationException("Operation '" + operation + "' does not exist");
         }
 
-        return String.format("%d %s %d = %s", operand1, operation, operand2, result);
+        return String.valueOf(operand1) + " " + String.valueOf(operation) + " " + operand2 + " = " +  result;
     }
 }

--- a/exercises/concept/calculator-conundrum/src/test/java/CalculatorConundrumTest.java
+++ b/exercises/concept/calculator-conundrum/src/test/java/CalculatorConundrumTest.java
@@ -53,7 +53,7 @@ public class CalculatorConundrumTest {
     @DisplayName("The calculate method throws IllegalOperationException when passing invalid operation")
     public void throwExceptionForUnknownOperation() {
         String invalidOperation = "**";
-        String expectedMessage = String.format("Operation '%s' does not exist", invalidOperation);
+        String expectedMessage = "Operation '" + invalidOperation + "' does not exist";
         assertThatExceptionOfType(IllegalOperationException.class)
                 .isThrownBy(() -> new CalculatorConundrum().calculate(3, 78, invalidOperation))
                 .withMessage(expectedMessage);

--- a/exercises/concept/captains-log/.meta/src/reference/java/CaptainsLog.java
+++ b/exercises/concept/captains-log/.meta/src/reference/java/CaptainsLog.java
@@ -18,7 +18,9 @@ class CaptainsLog {
     String randomShipRegistryNumber() {
         var start = 1000;
         var end = 10000;
-        return String.format("NCC-%d", start + random.nextInt(end - start));
+
+
+        return "NCC-" + String.valueOf(start + random.nextInt(end - start));
     }
 
     double randomStardate() {

--- a/exercises/concept/logs-logs-logs/.meta/src/reference/java/LogLine.java
+++ b/exercises/concept/logs-logs-logs/.meta/src/reference/java/LogLine.java
@@ -21,6 +21,6 @@ public class LogLine {
     }
 
     public String getOutputForShortLog() {
-        return String.format("%d:%s", this.level.getEncodedLevel(), this.message);
+        return String.valueOf(this.level.getEncodedLevel()) + ":" + this.message;
     }
 }


### PR DESCRIPTION
# pull request

As we are generally giving feedback on preferring string concatenation over string.format it makes sense to me that all our reference resolutions (at least for concept exercises) comply with that. Changing the practice ones seemed like a bit overkill, because normally we should give more freedom in those cases to students

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
