### PR TITLE
Fixing the sorting order example in the instructions.md for the remote-controlcompetition exercise

### DIFF
--- a/exercises/concept/remote-control-competition/.docs/instructions.md
+++ b/exercises/concept/remote-control-competition/.docs/instructions.md
@@ -65,6 +65,6 @@ List<ProductionRemoteControlCar> unsortedCars = new ArrayList<>();
 unsortedCars.add(prc1);
 unsortedCars.add(prc2);
 List<ProductionRemoteControlCar> rankings = TestTrack.getRankedCars(unsortedCars);
-// => rankings.get(0) == prc2
-// => rankings.get(1) == prc1
+// => rankings.get(0) == prc1
+// => rankings.get(1) == prc2
 ```

--- a/exercises/concept/remote-control-competition/.docs/instructions.md
+++ b/exercises/concept/remote-control-competition/.docs/instructions.md
@@ -59,12 +59,12 @@ Implement the static `TestTrack.getRankedCars()` to return the cars passed in, s
 ```java
 ProductionRemoteControlCar prc1 = new ProductionRemoteControlCar();
 ProductionRemoteControlCar prc2 = new ProductionRemoteControlCar();
-prc1.setNumberOfVictories(3);
-prc2.setNumberOfVictories(2);
+prc1.setNumberOfVictories(2);
+prc2.setNumberOfVictories(3);
 List<ProductionRemoteControlCar> unsortedCars = new ArrayList<>();
 unsortedCars.add(prc1);
 unsortedCars.add(prc2);
 List<ProductionRemoteControlCar> rankings = TestTrack.getRankedCars(unsortedCars);
-// => rankings.get(0) == prc1
-// => rankings.get(1) == prc2
+// => rankings.get(0) == prc2
+// => rankings.get(1) == prc1
 ```


### PR DESCRIPTION
# pull request

The instructions mentioned that the TestTrack.getRankedCars() returns the cars in descending order but the example returns the cars in ascending order. This PR is for fixing it.



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
