### PR TITLE
Adding analyzer feedback for `cars-assemble` concept exercise

### DIFF
--- a/exercises/concept/cars-assemble/.meta/design.md
+++ b/exercises/concept/cars-assemble/.meta/design.md
@@ -25,3 +25,17 @@ This exercise's prerequisites Concepts are:
 
 - `basics`: know how to define methods.
 - `booleans`: know how to use boolean operators.
+
+## Analyzer
+
+This exercise could benefit from the following rules in the [analyzer]:
+
+- `actionable`: If the student did not reuse the implementation of the `productionRatePerHour` method in the `workingItemsPerMinute` method, instruct them to do so.
+- `informative`: If the solution is hardcoding the value `221`, inform the student that it could be great to extrapolate this value to a `private final` field to make a more readable code.
+- `informative`: If the solution has `if/else-if` statements in the `productionRatePerHour` method, inform the student that it could be great to create a helper method to calculate the succes rate.
+- `informative`: If the solution is using `if/else-if` logic that contain a return statements, inform the students that with separate if blocks you will achieve the same making the code more clear.
+
+If the solution does not receive any of the above feedback, it must be exemplar.
+Leave a `celebratory` comment to celebrate the success!
+
+[analyzer]: https://github.com/exercism/java-analyzer

--- a/exercises/concept/cars-assemble/.meta/design.md
+++ b/exercises/concept/cars-assemble/.meta/design.md
@@ -31,7 +31,7 @@ This exercise's prerequisites Concepts are:
 This exercise could benefit from the following rules in the [analyzer]:
 
 - `actionable`: If the student did not reuse the implementation of the `productionRatePerHour` method in the `workingItemsPerMinute` method, instruct them to do so.
-- `informative`: If the solution is hardcoding the value `221`, inform the student that it could be great to extrapolate this value to a `private final` field to make a more readable code.
+- `informative`: If the solution is repeatedly hard-coding the value `221`, inform the student that they could store this value in a field to make the code easier to maintain.
 - `informative`: If the solution has `if/else-if` statements in the `productionRatePerHour` method, inform the student that creating a helper method to calculate the succes rate might make their code easier to understand.
 - `informative`: If the solution is using `if/else-if` logic that contains return statements, inform the students that the `else` keywords are redundant and that their code can become more clear by omitting them.
 

--- a/exercises/concept/cars-assemble/.meta/design.md
+++ b/exercises/concept/cars-assemble/.meta/design.md
@@ -33,7 +33,7 @@ This exercise could benefit from the following rules in the [analyzer]:
 - `actionable`: If the student did not reuse the implementation of the `productionRatePerHour` method in the `workingItemsPerMinute` method, instruct them to do so.
 - `informative`: If the solution is hardcoding the value `221`, inform the student that it could be great to extrapolate this value to a `private final` field to make a more readable code.
 - `informative`: If the solution has `if/else-if` statements in the `productionRatePerHour` method, inform the student that it could be great to create a helper method to calculate the succes rate.
-- `informative`: If the solution is using `if/else-if` logic that contain a return statements, inform the students that with separate if blocks you will achieve the same making the code more clear.
+- `informative`: If the solution is using `if/else-if` logic that contains return statements, inform the students that the `else` keywords are redundant and that their code can become more clear by omitting them.
 
 If the solution does not receive any of the above feedback, it must be exemplar.
 Leave a `celebratory` comment to celebrate the success!

--- a/exercises/concept/cars-assemble/.meta/design.md
+++ b/exercises/concept/cars-assemble/.meta/design.md
@@ -32,7 +32,7 @@ This exercise could benefit from the following rules in the [analyzer]:
 
 - `actionable`: If the student did not reuse the implementation of the `productionRatePerHour` method in the `workingItemsPerMinute` method, instruct them to do so.
 - `informative`: If the solution is hardcoding the value `221`, inform the student that it could be great to extrapolate this value to a `private final` field to make a more readable code.
-- `informative`: If the solution has `if/else-if` statements in the `productionRatePerHour` method, inform the student that it could be great to create a helper method to calculate the succes rate.
+- `informative`: If the solution has `if/else-if` statements in the `productionRatePerHour` method, inform the student that creating a helper method to calculate the succes rate might make their code easier to understand.
 - `informative`: If the solution is using `if/else-if` logic that contains return statements, inform the students that the `else` keywords are redundant and that their code can become more clear by omitting them.
 
 If the solution does not receive any of the above feedback, it must be exemplar.

--- a/exercises/concept/cars-assemble/.meta/src/reference/java/CarsAssemble.java
+++ b/exercises/concept/cars-assemble/.meta/src/reference/java/CarsAssemble.java
@@ -4,15 +4,11 @@ public class CarsAssemble {
     private final int defaultProductionRate = 221;
 
     public double productionRatePerHour(int speed) {
-        return productionRatePerHourForSpeed(speed) * successRate(speed);
+        return defaultProductionRate * speed * successRate(speed);
     }
 
     public int workingItemsPerMinute(int speed) {
         return (int) (productionRatePerHour(speed) / 60);
-    }
-
-    private int productionRatePerHourForSpeed(int speed) {
-        return defaultProductionRate * speed;
     }
 
     private double successRate(int speed) {


### PR DESCRIPTION
# pull request

closes [#2675](https://github.com/exercism/java/issues/2675)

I also updated the reference resolution, because an extra helper method seemed kinda overkill for me.

This are some motivations I found on the automation tab of the java track to make this analyzer comments:
- [example](https://exercism.org/mentoring/automation/bd9c25896aa348c6939e38da62e7d984/edit?source%5Bcriteria%5D=cars%2C+ass&source%5Bpage%5D=1&source%5Btrack_slug%5D=java)
- Also I mentored this exercise a couple of times, so in order to guide to the reference resolution could be great to give them prioir to students

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
