### PR TITLE
Remove hardcoded year 2023 in the anniversary date task description for Booking Up For Beauty Exercise

### DIFF
--- a/exercises/concept/booking-up-for-beauty/.docs/instructions.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/instructions.md
@@ -49,5 +49,5 @@ Implement the `AppointmentScheduler.getAnniversaryDate()` method that returns th
 ```java
 AppointmentScheduler scheduler = new AppointmentScheduler();
 scheduler.getAnniversaryDate()
-// => LocalDate.of(2023, 9, 15)
+// => LocalDate.of(<current year>, 9, 15)
 ```


### PR DESCRIPTION

# pull request

<!-- Your content goes here: -->

The task description for getting the anniversary date had the year 2023 hardcoded. I see even some accepted solutions had hardcoded the year. So I changed the description to make it clear that the task expects the current year.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
