### PR TITLE
dnd-character: Add test case for ability with lowest number occurring twice

### DIFF
--- a/exercises/practice/dnd-character/src/test/java/DnDCharacterTest.java
+++ b/exercises/practice/dnd-character/src/test/java/DnDCharacterTest.java
@@ -148,6 +148,12 @@ public class DnDCharacterTest {
 
     @Disabled("Remove to run test")
     @Test
+    public void testAbilityCalculationsWithTwoLowestNumbers() {
+        assertThat(dndCharacter.ability(List.of(3, 5, 3, 4))).isEqualTo(12);
+    }
+
+    @Disabled("Remove to run test")
+    @Test
     public void testAbilityCalculationDoesNotChangeInputScores() {
         List<Integer> scores = List.of(1, 2, 3, 4);
         dndCharacter.ability(scores);


### PR DESCRIPTION
# pull request

During a mentoring session, I noticed a solution that passed all the existing tests, but would have failed to meet the following example from the instructions. I wonder if it be worth adding a test for it?

> 3, 5, 3, 4: You discard the 3 and sum 5 + 3 + 4 = 12, which you assign to wisdom.


Note, I have put the PR here instead of the [problem specifications](https://github.com/exercism/problem-specifications/blob/main/exercises/dnd-character/canonical-data.json) because I noticed the Java track already has some tests around the `ability` method and the only `ability` test in the spec seems more vague. I think the `ability` tests we have might be Java specific? 

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
