### PR TITLE
gotta-snatch-em-all: change task to use symmetric set difference

### DIFF
--- a/exercises/concept/gotta-snatch-em-all/.docs/instructions.md
+++ b/exercises/concept/gotta-snatch-em-all/.docs/instructions.md
@@ -42,8 +42,8 @@ collection.contains("Scientuna");
 
 You really want your friends to join your Blorkemon™️ madness, so it's time to start trading!
 
-Not every trade is worth doing, or can be done at all.
-You cannot trade a card you don't have, and you shouldn't trade a card for one that you already have.
+When trading with friends not every trade is worth doing, or can be done at all.
+You should only trade if both you and your friend have a card the other does not have.
 
 Implement the `canTrade` method, that takes your current collection and the collection of one of your friends.
 It should return a `boolean` indicating whether a trade is possible, following the rules above.

--- a/exercises/concept/gotta-snatch-em-all/.meta/src/reference/java/GottaSnatchEmAll.java
+++ b/exercises/concept/gotta-snatch-em-all/.meta/src/reference/java/GottaSnatchEmAll.java
@@ -13,9 +13,11 @@ class GottaSnatchEmAll {
     }
 
     static boolean canTrade(Set<String> myCollection, Set<String> theirCollection) {
-        Set<String> cardsWorthTradingFor = new HashSet<>(theirCollection);
-        cardsWorthTradingFor.removeAll(myCollection);
-        return !myCollection.isEmpty() && !cardsWorthTradingFor.isEmpty();
+        Set<String> myUniqueCards = new HashSet<>(myCollection);
+        Set<String> theirUniqueCards = new HashSet<>(theirCollection);
+        myUniqueCards.removeAll(theirCollection);
+        theirUniqueCards.removeAll(myCollection);
+        return !myUniqueCards.isEmpty() && !theirUniqueCards.isEmpty();
     }
 
     static Set<String> commonCards(List<Set<String>> collections) {

--- a/exercises/concept/gotta-snatch-em-all/src/test/java/GottaSnatchEmAllTest.java
+++ b/exercises/concept/gotta-snatch-em-all/src/test/java/GottaSnatchEmAllTest.java
@@ -136,11 +136,11 @@ class GottaSnatchEmAllTest {
 
     @Test
     @Tag("task:3")
-    @DisplayName("canTrade returns true when my collection is a non-empty subset of their collection")
+    @DisplayName("canTrade returns false when my collection is a non-empty subset of their collection")
     void testCanTradeMyCollectionSubsetOfTheirCollection() {
         Set<String> myCollection = new HashSet<>(Set.of("Gyros", "Garilord"));
         Set<String> theirCollection = new HashSet<>(Set.of("Garilord", "Veevee", "Gyros"));
-        assertThat(GottaSnatchEmAll.canTrade(myCollection, theirCollection)).isTrue();
+        assertThat(GottaSnatchEmAll.canTrade(myCollection, theirCollection)).isFalse();
     }
 
     @Test


### PR DESCRIPTION
Following the discussion in [this forum topic](https://forum.exercism.org/t/need-help-in-clarifying-gotta-snatch-them-all-exercise/10640/1), this PR updates the third task in the `gotta-snatch-em-all` exercise to remove some ambiguity.


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
