### PR TITLE
Rename tryFinishTrack to canFinishRace for better expectations

### DIFF
--- a/exercises/concept/need-for-speed/.docs/instructions.md
+++ b/exercises/concept/need-for-speed/.docs/instructions.md
@@ -70,7 +70,7 @@ car.distanceDriven();
 
 ## 6. Check if a remote control car can finish a race
 
-To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `RaceTrack.tryFinishTrack()` method that takes a `NeedForSpeed` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`:
+To finish a race, a car has to be able to drive the race's distance. This means not draining its battery before having crossed the finish line. Implement the `RaceTrack.canFinishRace()` method that takes a `NeedForSpeed` instance as its parameter and returns `true` if the car can finish the race; otherwise, return `false`:
 
 ```java
 int speed = 5;
@@ -83,7 +83,7 @@ var race = new RaceTrack(distance);
 car.distanceDriven()
 // => 0
 
-race.tryFinishTrack(car);
+race.canFinishRace(car);
 // => true
 
 car.distanceDriven()

--- a/exercises/concept/need-for-speed/.meta/design.md
+++ b/exercises/concept/need-for-speed/.meta/design.md
@@ -26,7 +26,7 @@
 
 This exercise could benefit from the following rules in the [analyzer]:
 
-- `actionable`: If the student used a loop in the `tryFinishTrack()` method, encourage it to explore a different approach.
+- `actionable`: If the student used a loop in the `canFinishRace()` method, encourage it to explore a different approach.
 - `actionable`: If the student used a conditional statement like `if/else` or ternary expressions in the `batteryDrained` method, encourage it to explore a different approach.
 
 If the solution does not receive any of the above feedback, it must be exemplar.

--- a/exercises/concept/need-for-speed/.meta/src/reference/java/NeedForSpeed.java
+++ b/exercises/concept/need-for-speed/.meta/src/reference/java/NeedForSpeed.java
@@ -48,7 +48,7 @@ class RaceTrack {
         this.distance = distance;
     }
 
-    public boolean tryFinishTrack(NeedForSpeed car) {
+    public boolean canFinishRace(NeedForSpeed car) {
         return ((double) distance / car.getSpeed()) <= (car.getCurrentBattery() / car.getBatteryDrain());
     }
 }

--- a/exercises/concept/need-for-speed/src/main/java/NeedForSpeed.java
+++ b/exercises/concept/need-for-speed/src/main/java/NeedForSpeed.java
@@ -25,7 +25,7 @@ class RaceTrack {
         throw new UnsupportedOperationException("Please implement the RaceTrack constructor");
     }
 
-    public boolean tryFinishTrack(NeedForSpeed car) {
-        throw new UnsupportedOperationException("Please implement the RaceTrack.tryFinishTrack() method");
+    public boolean canFinishRace(NeedForSpeed car) {
+        throw new UnsupportedOperationException("Please implement the RaceTrack.canFinishRace() method");
     }
 }

--- a/exercises/concept/need-for-speed/src/test/java/NeedForSpeedTest.java
+++ b/exercises/concept/need-for-speed/src/test/java/NeedForSpeedTest.java
@@ -200,7 +200,7 @@ public class NeedForSpeedTest {
 
     @Test
     @Tag("task:6")
-    @DisplayName("The  method returns false when car cannot finish a race")
+    @DisplayName("The canFinishRace method returns false when car cannot finish a race")
     public void car_can_finish_with_car_that_cannot_finish() {
         int speed = 1;
         int batteryDrain = 20;

--- a/exercises/concept/need-for-speed/src/test/java/NeedForSpeedTest.java
+++ b/exercises/concept/need-for-speed/src/test/java/NeedForSpeedTest.java
@@ -158,7 +158,7 @@ public class NeedForSpeedTest {
 
     @Test
     @Tag("task:6")
-    @DisplayName("The tryFinishCar method returns true when car can finish a race")
+    @DisplayName("The canFinishRace method returns true when car can finish a race")
     public void car_can_finish_with_car_that_can_easily_finish() {
         int speed = 10;
         int batteryDrain = 2;
@@ -167,12 +167,12 @@ public class NeedForSpeedTest {
         int distance = 100;
         var race = new RaceTrack(distance);
 
-        assertThat(race.tryFinishTrack(car)).isTrue();
+        assertThat(race.canFinishRace(car)).isTrue();
     }
 
     @Test
     @Tag("task:6")
-    @DisplayName("The tryFinishCar method returns true when car can just finish a race")
+    @DisplayName("The canFinishRace method returns true when car can just finish a race")
     public void car_can_finish_with_car_that_can_just_finish() {
         int speed = 2;
         int batteryDrain = 10;
@@ -181,12 +181,12 @@ public class NeedForSpeedTest {
         int distance = 20;
         var race = new RaceTrack(distance);
 
-        assertThat(race.tryFinishTrack(car)).isTrue();
+        assertThat(race.canFinishRace(car)).isTrue();
     }
 
     @Test
     @Tag("task:6")
-    @DisplayName("The tryFinishCar method returns false when car just cannot finish a race")
+    @DisplayName("The canFinishRace method returns false when car just cannot finish a race")
     public void car_can_finish_with_car_that_just_cannot_finish() {
         int speed = 3;
         int batteryDrain = 20;
@@ -195,12 +195,12 @@ public class NeedForSpeedTest {
         int distance = 16;
         var race = new RaceTrack(distance);
 
-        assertThat(race.tryFinishTrack(car)).isFalse();
+        assertThat(race.canFinishRace(car)).isFalse();
     }
 
     @Test
     @Tag("task:6")
-    @DisplayName("The tryFinishCar method returns false when car cannot finish a race")
+    @DisplayName("The  method returns false when car cannot finish a race")
     public void car_can_finish_with_car_that_cannot_finish() {
         int speed = 1;
         int batteryDrain = 20;
@@ -209,7 +209,7 @@ public class NeedForSpeedTest {
         int distance = 678;
         var race = new RaceTrack(distance);
 
-        assertThat(race.tryFinishTrack(car)).isFalse();
+        assertThat(race.canFinishRace(car)).isFalse();
     }
 }
 


### PR DESCRIPTION
# pull request

Renamed the `tryFinishTrack` in `NeedForSpeed` to be `canFinishRace` to match the expectation of the instructions for the final task.

Resolves https://github.com/exercism/java-analyzer/issues/184.

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
