### PR TITLE
Fix links for Scrabble Score dig deeper page

### DIFF
--- a/exercises/practice/scrabble-score/.approaches/introduction.md
+++ b/exercises/practice/scrabble-score/.approaches/introduction.md
@@ -152,7 +152,7 @@ For more information, check the [`HashMap` with `reduce()` approach][approach-ma
 Since benchmarking with the [Java Microbenchmark Harness][jmh] is currently outside the scope of this document,
 the choice between the approaches can be made by perceived readability.
 
-[approach-if-statements]: https://exercism.org/tracks/java/exercises/scrabble=score/approaches/if-statements
-[approach-switch-statement]: https://exercism.org/tracks/java/exercises/scrabble=score/approaches/switch-statement
-[approach-map-reduce]: https://exercism.org/tracks/java/exercises/scrabble=score/approaches/map-reduce
+[approach-if-statements]: https://exercism.org/tracks/java/exercises/scrabble-score/approaches/if-statements
+[approach-switch-statement]: https://exercism.org/tracks/java/exercises/scrabble-score/approaches/switch-statement
+[approach-map-reduce]: https://exercism.org/tracks/java/exercises/scrabble-score/approaches/map-reduce
 [jmh]: https://github.com/openjdk/jmh


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->

First pull request on this repository, so forgive me if I did anything wrong.

While I was looking at the Dig Deeper section of Scrabble Score, I saw that the links to each approach were broken because "scrabble-score" was instead written as "scrabble=score". They should now link to the correct pages.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
