### PR TITLE
Remove collection from array description

### DIFF
--- a/concepts/arrays/about.md
+++ b/concepts/arrays/about.md
@@ -1,7 +1,7 @@
 # About Arrays
 
-In Java, data structures that can hold zero or more elements are known as _collections_.
-An **array** is a collection that has a fixed size and whose elements must all be of the same type.
+In Java, arrays are a way to store multiple values of the same type in a single structure.
+Unlike other data structures, arrays have a fixed size once created.
 Elements can be assigned to an array or retrieved from it using an index.
 Java arrays use zero-based indexing: the first element's index is 0, the second element's index is 1, etc.
 

--- a/concepts/arrays/introduction.md
+++ b/concepts/arrays/introduction.md
@@ -1,7 +1,7 @@
 # Introduction to Arrays
 
-In Java, data structures that can hold zero or more elements are known as _collections_.
-An **array** is a collection that has a fixed size and whose elements must all be of the same type.
+In Java, arrays are a way to store multiple values of the same type in a single structure.
+Unlike other data structures, arrays have a fixed size once created.
 Elements can be assigned to an array or retrieved from it using an index.
 Java arrays use zero-based indexing: the first element's index is 0, the second element's index is 1, etc.
 

--- a/exercises/concept/bird-watcher/.docs/introduction.md
+++ b/exercises/concept/bird-watcher/.docs/introduction.md
@@ -2,8 +2,8 @@
 
 ## Arrays
 
-In Java, data structures that can hold zero or more elements are known as _collections_.
-An **array** is a collection that has a fixed size and whose elements must all be of the same type.
+In Java, arrays are a way to store multiple values of the same type in a single structure.
+Unlike other data structures, arrays have a fixed size once created.
 Elements can be assigned to an array or retrieved from it using an index.
 Java arrays use zero-based indexing: the first element's index is 0, the second element's index is 1, etc.
 


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->

Updated the description of Java arrays to avoid confusion with the term "collection" as used in the Java Collections Framework. Previously, the text referred to arrays as collections, which is inaccurate in Java's formal terminology.

Native Java arrays are not part of the Collections Framework, as they do not implement the `Collection` interface or its subtypes, such as `List`, `Set`, or `Map`. They are simply fixed-size objects that hold elements of the same type.

I have rephrased the description to make it more accessible for those who are new to Java, avoiding excessive technical jargon while still preventing misunderstandings and aligning the explanation with Java's official definitions.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
