### PR TITLE
Remove multiply and divide methods accepting double from ComplexNumber

### DIFF
--- a/exercises/practice/complex-numbers/.meta/src/reference/java/ComplexNumber.java
+++ b/exercises/practice/complex-numbers/.meta/src/reference/java/ComplexNumber.java
@@ -1,7 +1,6 @@
 final class ComplexNumber {
 
     private final double real;
-
     private final double imaginary;
 
     ComplexNumber(double real, double imaginary) {
@@ -32,7 +31,10 @@ final class ComplexNumber {
     }
 
     ComplexNumber divide(ComplexNumber other) {
-        return this.multiply(other.conjugate()).divide(Math.pow(other.abs(), 2));
+        double divisor = Math.pow(other.real, 2) + Math.pow(other.imaginary, 2);
+        return new ComplexNumber(
+            (real * other.real + imaginary * other.imaginary) / divisor,
+            (real * other.imaginary - imaginary * other.real) / divisor);
     }
 
     double abs() {
@@ -45,13 +47,5 @@ final class ComplexNumber {
 
     ComplexNumber exponentialOf() {
         return new ComplexNumber(Math.cos(imaginary), Math.sin(imaginary)).multiply(Math.exp(real));
-    }
-
-    private ComplexNumber divide(double factor) {
-        return new ComplexNumber(real / factor, imaginary / factor);
-    }
-
-    private ComplexNumber multiply(double factor) {
-        return new ComplexNumber(factor * real, factor * imaginary);
     }
 }

--- a/exercises/practice/complex-numbers/src/main/java/ComplexNumber.java
+++ b/exercises/practice/complex-numbers/src/main/java/ComplexNumber.java
@@ -28,15 +28,7 @@ class ComplexNumber {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
     }
 
-    ComplexNumber multiply(double factor) {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
-    }
-
     ComplexNumber divide(ComplexNumber other) {
-        throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
-    }
-
-    ComplexNumber divide(double divisor) {
         throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
     }
 


### PR DESCRIPTION
# pull request

## Description
This pull request removes the `multiply` and `divide` methods that accept a double parameter from the `ComplexNumber` class in both the reference solution and the `main.java` file. These methods were deemed unnecessary since the primary focus of the exercise is to operate on complex numbers, and the existing tests do not validate these double overloads.

## Changes Made:
- Removed `multiply(double factor)` and `divide(double divisor)` methods from the `ComplexNumber` class.
- Updated the reference solution accordingly to ensure consistency.

## Rationale
The double overloads for multiplication and division were not accompanied by corresponding test cases in the canonical data, which could lead to situations where these methods are not adequately tested. By removing these methods, we streamline the class and enhance clarity, ensuring that the exercise focuses on complex number operations as intended.

## Next Steps
Please review the changes and let me know if further modifications are needed.
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
