### PR TITLE
improve explanation on Java array .length property

### DIFF
--- a/concepts/arrays/about.md
+++ b/concepts/arrays/about.md
@@ -44,7 +44,8 @@ int secondElement = twoInts[1];
 Accessing an index that is outside of the valid indexes for the array results in an `IndexOutOfBoundsException`.
 
 Arrays can be manipulated by either calling an array instance's methods or properties, or by using the static methods defined in the `Arrays` class (typically only used in generic code).
-Java has a built-in `length` property that returns the length of an array, which can be accessed like this:
+The `length` property holds the length of an array.
+It can be accessed like this:
 
 ```java
 int arrayLength = someArray.length;

--- a/concepts/arrays/about.md
+++ b/concepts/arrays/about.md
@@ -44,7 +44,7 @@ int secondElement = twoInts[1];
 Accessing an index that is outside of the valid indexes for the array results in an `IndexOutOfBoundsException`.
 
 Arrays can be manipulated by either calling an array instance's methods or properties, or by using the static methods defined in the `Arrays` class (typically only used in generic code).
-The most commonly used property for arrays is its length which can be accessed like this:
+Java has a built-in `length` property that returns the length of an array, which can be accessed like this:
 
 ```java
 int arrayLength = someArray.length;

--- a/concepts/arrays/introduction.md
+++ b/concepts/arrays/introduction.md
@@ -44,7 +44,8 @@ int secondElement = twoInts[1];
 Accessing an index that is outside of the valid indexes for the array results in an `IndexOutOfBoundsException`.
 
 Arrays can be manipulated by either calling an array instance's methods or properties, or by using the static methods defined in the `Arrays` class (typically only used in generic code).
-The most commonly used property for arrays is its length which can be accessed like this:
+The `length` property holds the length of an array.
+It can be accessed like this:
 
 ```java
 int arrayLength = someArray.length;

--- a/exercises/concept/bird-watcher/.docs/introduction.md
+++ b/exercises/concept/bird-watcher/.docs/introduction.md
@@ -46,7 +46,8 @@ int secondElement = twoInts[1];
 Accessing an index that is outside of the valid indexes for the array results in an `IndexOutOfBoundsException`.
 
 Arrays can be manipulated by either calling an array instance's methods or properties, or by using the static methods defined in the `Arrays` class (typically only used in generic code).
-The most commonly used property for arrays is its length which can be accessed like this:
+The `length` property holds the length of an array.
+It can be accessed like this:
 
 ```java
 int arrayLength = someArray.length;


### PR DESCRIPTION
# pull request

Hello! I've noticed the sentence "The most commonly used property for arrays is its length" might lead to some misunderstandings, as Java only has a single built-in direct property for arrays. To clarify this, I've made a small adjustment. 

## Changes made:
Replaced 

> "The most commonly used property for arrays is its length which can be accessed like this:"

 with 

> "Java has a built-in `length` property that returns the length of an array, which can be accessed like this:".


Please let me know if you have any questions. Thanks in advance.

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
