### PR TITLE
Fixing reference answer of Salary Calculator for consistancy

### DIFF
--- a/exercises/concept/salary-calculator/.meta/src/reference/java/SalaryCalculator.java
+++ b/exercises/concept/salary-calculator/.meta/src/reference/java/SalaryCalculator.java
@@ -8,11 +8,11 @@ public class SalaryCalculator {
         return productsSold < 20 ? 10 : 13;
     }
 
-    public double bonusForProductsSold (int productsSold) {
+    public double bonusForProductsSold(int productsSold) {
         return productsSold * bonusMultiplier(productsSold);
     }
 
-    public double finalSalary (int daysSkipped, int productsSold) {
+    public double finalSalary(int daysSkipped, int productsSold) {
         double finalSalary = 1000.0 * salaryMultiplier(daysSkipped) + bonusForProductsSold(productsSold);
         return finalSalary > 2000.0 ? 2000.0 : finalSalary;
     } 


### PR DESCRIPTION
# pull request

I understand that this change does not significantly impact the outcome of the exercise, but I’ve noticed a small inconsistency that appears in the guidance tab for mentors reviewing this exercise. While it doesn't affect the functionality, these types of inconsistencies can be misleading for mentors. To address this, I am submitting this PR to adjust just two lines and resolve the inconsistency. Thank you for considering the change!
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
