### PR TITLE
Add text clarifying test executable permissions

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -81,6 +81,20 @@ Good luck! Have fun!
 
    _(Don't worry about the tests failing, at first, this is how you begin each exercise.)_
 
+   If you get the following error:
+
+   ```sh
+   ./gradlew: Permission denied
+   ```
+
+   Then the file is missing the execute permission. To fis this, run:
+
+   ```sh
+   chmod +x ./gradlew
+   ```
+
+   And now you should be able to run the previous command.
+
 4. Solve the exercise. Find and work through the `instructions.append.md` guide ([view on GitHub][hello-world-tutorial]).
 
 Good luck! Have fun!


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->

This PR adds a section on how to add executable permissions to the `gradlew` file, used to run tests.

I find it interesting how no one else seems to be facing this issue, but I always face it on Java when downloading exercises (which I do by using [exercism.el](https://github.com/anonimitoraf/exercism.el)).

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
