### PR TITLE
Fix Pythagorean Triplet Approach URLs  

### DIFF
--- a/exercises/practice/pythagorean-triplet/.approaches/config.json
+++ b/exercises/practice/pythagorean-triplet/.approaches/config.json
@@ -2,6 +2,10 @@
   "introduction": {
     "authors": [
       "bobahop"
+    ],
+    "contributors": [
+      "BNAndras",
+      "jagdish-15"
     ]
   },
   "approaches": [

--- a/exercises/practice/pythagorean-triplet/.approaches/introduction.md
+++ b/exercises/practice/pythagorean-triplet/.approaches/introduction.md
@@ -171,6 +171,6 @@ So if the nested `for` loops approach is fast enough, it may be preferred for re
 [parallel]: https://docs.oracle.com/javase/8/docs/api/java/util/stream/IntStream.html#parallel--
 [flatmap]: https://docs.oracle.com/javase/8/docs/api/java/util/stream/IntStream.html#flatMap-java.util.function.IntFunction-
 [filter]: https://docs.oracle.com/javase/8/docs/api/java/util/stream/IntStream.html#filter-java.util.function.IntPredicate-
-[approach-for-loops]: https://exercism.org/tracks/java/exercises/pythagorean-triplets/approaches/for-loops
-[approach-intstream-parallel-flatmap-filter]: https://exercism.org/tracks/java/exercises/pythagorean-triplets/approaches/if-intstream-parallel-flatmap-filter
+[approach-for-loops]: https://exercism.org/tracks/java/exercises/pythagorean-triplet/approaches/for-loops
+[approach-intstream-parallel-flatmap-filter]: https://exercism.org/tracks/java/exercises/pythagorean-triplet/approaches/intstream-parallel-flatmap-filter
 [jmh]: https://github.com/openjdk/jmh


### PR DESCRIPTION
## Fix Pythagorean Triplet Approach URLs  

This PR corrects the approach URLs for the Pythagorean Triplet exercise, addressing the issue raised by [@BNAndras](https://forum.exercism.org/t/fix-approach-urls-for-pythagorean-triplet/15793) on the Exercism forum.  

**Issue report:** [Fix approach URLs for Pythagorean Triplet](https://forum.exercism.org/t/fix-approach-urls-for-pythagorean-triplet/15793)  

Let me know if any further adjustments are needed!

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
