### PR TITLE
Remove redundant instructions for knapsack exercise

### DIFF
--- a/exercises/practice/knapsack/.docs/instructions.append.md
+++ b/exercises/practice/knapsack/.docs/instructions.append.md
@@ -1,4 +1,0 @@
-# Instructions append
-
-- Use recursion
-- Check if there are any overlapping subproblems whose results can be cached


### PR DESCRIPTION
fixes #2929 

<!-- Your content goes here: -->
Remove instructions.append.md from Knapsack as it no more needs


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
