### PR TITLE
strings - Expand concept by newline and text blocks

### DIFF
--- a/concepts/strings/.meta/config.json
+++ b/concepts/strings/.meta/config.json
@@ -3,5 +3,7 @@
   "authors": [
     "mirkoperillo"
   ],
-  "contributors": []
+  "contributors": [
+    "fapdash"
+  ]
 }

--- a/concepts/strings/about.md
+++ b/concepts/strings/about.md
@@ -22,6 +22,29 @@ String escaped = "c:\\test.txt";
 // => c:\test.txt
 ```
 
+To put a newline character in a string, use the `\n` escape code (`\r\n` on Windows):
+
+```java
+"<html>\n    <body>\n        <h1>Hello, World!</h1>\n    </body>\n</html>\n"
+```
+
+For code that should work on different operating systems Java offers [`System.lineSeparator()`][system-line-separator], which returns the system-dependent line separator string.
+
+To comfortable work with texts that contain a lot of newlines you can use [Text Blocks](text-blocks).
+These multi-line strings are delimited by triple double quote (`"`) characters.
+
+
+```java
+String multilineHtml = """
+<html>
+    <body>
+        <h1>Hello, World!</h1>
+    </body>
+</html>
+""";
+// => "<html>\n    <body>\n        <h1>Hello, World!</h1>\n    </body>\n</html>\n"
+```
+
 Finally, there are many ways to concatenate a string.
 The simplest one is the `+` operator:
 
@@ -35,15 +58,26 @@ For any string formatting more complex than simple concatenation, `String.format
 
 ```java
 String name = "Jane";
-String.format("Hello %s!",name);
+String.format("Hello %s!", name);
 // => "Hello Jane!"
 ```
 
-Other possibilities are:
+The conversion `%n` in a format string inserts a system-dependent line separator.
+
+```java
+String name = "Jane";
+String.format("Hello,%n%s!", name);
+// => "Hello,\nJane!" (Linux, macOS)
+// => "Hello,\r\nJane!" (Windows)
+```
+
+Other possibilities to build more complex strings are:
 
 - use [`StringBuilder` class][string-builder]
 - use [`String.concat` method][string-concat]
 
 [string-class]: https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html
+[text-blocks]: https://openjdk.org/projects/amber/guides/text-blocks-guide
 [string-builder]: https://docs.oracle.com/javase/tutorial/java/data/buffers.html
 [string-concat]: https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#concat-java.lang.String-
+[system-line-separator]: https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/System.html#lineSeparator()


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->

- Add multi-line strings / text blocks (Java 15)
- Add explanation of newlines / end of line chars, so students can understand the motivation behind text blocks

---

Noticed that the String concept was lacking text blocks.
While there are quite some details and intricacies to text blocks, they're not relevant for the level of detail the syllabus is aiming for, therefore it doesn't make sense to have them as an extra concept imo.
I added infos about newlines so students can appreciate the motivation behind text blocks.

Looking forward to your feedback. :)

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
