### PR TITLE
adding workflow files

### DIFF
--- a/.github/auto-sync/PR_BODY.md
+++ b/.github/auto-sync/PR_BODY.md
@@ -1,0 +1,8 @@
+This PR was generated automatically by a scheduled workflow.
+
+It includes updates from `configlet sync` for:
+- 📄 Documentation
+- 🧭 Metadata
+- 🗂️ Filepaths
+
+Please review and merge if everything looks good!

--- a/.github/workflows/configlet-sync.yml
+++ b/.github/workflows/configlet-sync.yml
@@ -1,0 +1,46 @@
+name: Configlet Auto Sync
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 1,15 * *'
+
+jobs:
+  configlet-auto-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Fetch configlet
+        run: ./bin/fetch-configlet
+
+      - name: Run configlet sync for files
+        run: ./bin/configlet sync --docs --metadata --filepaths -u -y
+
+      - name: Create pull request if changes
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "🤖 Auto-sync docs, metadata, and filepaths"
+          title: "🤖 Configlet sync: docs, metadata, and filepaths"
+          body-path: .github/auto-sync/PR_BODY.md
+          branch: configlet-auto-sync
+          delete-branch: true
+
+      - name: Run configlet sync for test and capture output
+        id: sync_test
+        run: |
+          ./bin/configlet sync --test | tee .github/auto-sync/sync-test-output.txt
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          cat .github/auto-sync/sync-test-output.txt >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Create issue if tests are not synced
+        if: ${{ !contains(steps.sync_test.outputs.output, 'Every exercise has up-to-date tests!') }}
+        uses: peter-evans/create-issue-from-file@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "🚨 configlet sync --test found unsynced tests"
+          content-filepath: .github/auto-sync/sync-test-output.txt


### PR DESCRIPTION
# Pull Request

Hi @k_goh,

This PR adds the sync automation workflow we discussed. I've tested the syncing and PR creation for filepaths, metadata, and docs on my fork successfully. However, I wasn’t able to fully test the test-sync part that raises an issue, since creating issues from a fork repo isn’t allowed.

The workflow is scheduled to run automatically on the 1st and 15th of every month at 00:00 UTC. I’ve also included a workflow_dispatch trigger so you can manually run it on the main repo to verify that the issue creation for unsynced tests works as expected, as I currently can't trigger the workflow from my side on the main repo.

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
