### PR TITLE
Fix lint issues

### DIFF
--- a/POLICIES.md
+++ b/POLICIES.md
@@ -51,7 +51,7 @@ References: [[1](https://github.com/exercism/java/issues/177#issuecomment-261291
 >   throw new UnsupportedOperationException("Delete this statement and write your own implementation.");
 >   ```
 >
-> - Exercises of difficulty 5 or higher: copy the StubTemplate.java file (provided [here](https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java)) and rename it to fit the exercise. For example, for the exercise linked-list the file could be named LinkedList.java. Then either (1) add hints to the hints.md file (which gets merged into the README.md for the exercise) or (2) provide stubs as above for exercises that demand complicated method signatures.
+> - Exercises of difficulty 5 or higher: copy the StubTemplate.java file (provided in [this template file](https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java)) and rename it to fit the exercise. For example, for the exercise linked-list the file could be named LinkedList.java. Then either (1) add hints to the hints.md file (which gets merged into the README.md for the exercise) or (2) provide stubs as above for exercises that demand complicated method signatures.
 
 References: [[1](https://github.com/exercism/java/issues/178)], [[2](https://github.com/exercism/java/pull/683#discussion_r125506930)], [[3](https://github.com/exercism/java/issues/977)], [[4](https://github.com/exercism/java/issues/1721)]
 
@@ -108,7 +108,7 @@ References: [[1](https://github.com/exercism/java/issues/365#issuecomment-292533
 
 ### Good first issues
 
-> Aim to keep 10-20 small and straightforward issues open at any given time. Identify any such issues by applying the "good first issue" label. You can view the current list of these issues [here](https://github.com/exercism/java/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+> Aim to keep 10-20 small and straightforward issues open at any given time. Identify any such issues by applying the "good first issue" label. You can view the current list of labeled issues [on GitHub](https://github.com/exercism/java/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
 
 References: [[1](https://github.com/exercism/java/issues/220#issue-196447088)], [[2](https://github.com/exercism/java/issues/1669)]
 

--- a/concepts/inheritance/about.md
+++ b/concepts/inheritance/about.md
@@ -18,7 +18,7 @@ There are four access modifiers:
 - `protected`
 - default (No keyword required)
 
-You can read more about them [here][access-modifiers]
+You can read more about them [in this article][access-modifiers]
 
 ## Inheritance vs Composition
 

--- a/concepts/switch-statement/about.md
+++ b/concepts/switch-statement/about.md
@@ -145,7 +145,7 @@ Starting with Java 14 (available as a preview before in Java 12 and 13) it is po
    However if you use the new `->` notation it must be followed by either: a single statement/expression, a `throw` statement or a `{}` block.
    No more confusion!
 
-You can find more information on enhanced switch [here][switch1], [here][switch2] and on the [oracle documentation][oracle-doc].
+You can find more information on enhanced switch in [this article][switch1] and [this one][switch2], along with the official [Oracle documentation][oracle-doc].
 
 In addition, a feature called `Guarded Patterns` was added in Java 21, which allows you to do checks in the case label itself.
 

--- a/concepts/switch-statement/about.md
+++ b/concepts/switch-statement/about.md
@@ -160,7 +160,7 @@ return switch (day) {
 };
 ```
 
-You can find more information on the switch expression on Java 21 [here][switch-on-Java-21]
+You can find more information on the switch expression on Java 21 in [this blog][switch-on-Java-21]
 
 [yield-keyword]: https://www.codejava.net/java-core/the-java-language/yield-keyword-in-java
 [switch1]: https://www.vojtechruzicka.com/java-enhanced-switch/

--- a/exercises/concept/log-levels/.docs/hints.md
+++ b/exercises/concept/log-levels/.docs/hints.md
@@ -7,12 +7,12 @@
 ## 1. Get message from a log line
 
 - Different options to search for text in a string are explored in [this tutorial][tutorial-search-text-in-string].
-- How to split strings can be seen [here][tutorial-split-strings]
+- How to split strings can be seen in [this tutorial][tutorial-split-strings]
 - Removing white space is [built-in][tutorial-trim-white-space].
 
 ## 2. Get log level from a log line
 
-- Changing a `String`'s casing is explored [here][tutorial-changing-case-upper] and [here][tutorial-changing-case-lower].
+- Changing a `String`'s casing is explored in [this][tutorial-changing-case-upper] and [this][tutorial-changing-case-lower] totorial.
 
 ## 3. Reformat a log line
 

--- a/exercises/concept/log-levels/.docs/hints.md
+++ b/exercises/concept/log-levels/.docs/hints.md
@@ -12,7 +12,7 @@
 
 ## 2. Get log level from a log line
 
-- Changing a `String`'s casing is explored in [this][tutorial-changing-case-upper] and [this][tutorial-changing-case-lower] totorial.
+- Changing a `String`'s casing is explored in [this changing to upper case][tutorial-changing-case-upper] and [this changing to lower case][tutorial-changing-case-lower] tutorial.
 
 ## 3. Reformat a log line
 

--- a/exercises/concept/remote-control-competition/.docs/hints.md
+++ b/exercises/concept/remote-control-competition/.docs/hints.md
@@ -15,7 +15,7 @@
 ## 3. Allow the production cars to be ranked
 
 - See [this discussion][sort] of sorting.
-- See [here][comparable] for default comparison of objects.
+- See [this][comparable] for default comparison of objects.
 
 [interfaces]: https://docs.oracle.com/javase/tutorial/java/concepts/interface.html
 [sort]: https://docs.oracle.com/javase/7/docs/api/java/util/Collections.html

--- a/exercises/concept/remote-control-competition/.docs/hints.md
+++ b/exercises/concept/remote-control-competition/.docs/hints.md
@@ -15,7 +15,7 @@
 ## 3. Allow the production cars to be ranked
 
 - See [this discussion][sort] of sorting.
-- See [this][comparable] for default comparison of objects.
+- See [Comparable's Javadocs][comparable] for default comparison of objects.
 
 [interfaces]: https://docs.oracle.com/javase/tutorial/java/concepts/interface.html
 [sort]: https://docs.oracle.com/javase/7/docs/api/java/util/Collections.html

--- a/exercises/concept/salary-calculator/.docs/hints.md
+++ b/exercises/concept/salary-calculator/.docs/hints.md
@@ -2,7 +2,7 @@
 
 ## General
 
-- Refer to examples [here][ternary-operator-first] and [here][ternary-operator-second] for guidance on using _ternary operators_.
+- Refer to examples in [this][ternary-operator-first] and [this][ternary-operator-second] article for guidance on using _ternary operators_.
 
 ## 1. Determine the salary multiplier
 

--- a/exercises/concept/salary-calculator/.docs/hints.md
+++ b/exercises/concept/salary-calculator/.docs/hints.md
@@ -2,7 +2,7 @@
 
 ## General
 
-- Refer to examples in [this][ternary-operator-first] and [this][ternary-operator-second] article for guidance on using _ternary operators_.
+- Refer to examples in [this article][ternary-operator-first] and [this one][ternary-operator-second] for guidance on using _ternary operators_.
 
 ## 1. Determine the salary multiplier
 

--- a/exercises/concept/wizards-and-warriors/.docs/hints.md
+++ b/exercises/concept/wizards-and-warriors/.docs/hints.md
@@ -13,7 +13,7 @@ The whole inheritance concept has a lot to do with the concepts around [overridi
 ## 2. Describe a Warrior
 
 - In Java, the `toString()` method is actually present inside the `Object` class (which is a superclass to all the classes in Java).
-  You can read more about it [here][object-class-java].
+  You can read more about it at the official [Oracle documentation][object-class-java].
 - To override this method inside your implementation class, you should have a method with same name i.e. `toString()` and same return type i.e. `String`.
 - The `toString()` method must be `public`.
 
@@ -34,7 +34,7 @@ The whole inheritance concept has a lot to do with the concepts around [overridi
 ## 6. Describe a Wizard
 
 - In Java, the `toString()` method is actually present inside the `Object` class (which is a superclass to all the classes in Java).
-  You can read more about it [here][object-class-java].
+  You can read more about it at the official [Oracle documentation][object-class-java].
 - To override this method inside your implementation class, you should have a method with same name i.e. `toString()` and same return type i.e. `String`.
 - The `toString()` method must be `public`.
 

--- a/exercises/practice/dot-dsl/.docs/instructions.md
+++ b/exercises/practice/dot-dsl/.docs/instructions.md
@@ -22,7 +22,7 @@ Write a Domain Specific Language similar to the Graphviz dot language.
 Our DSL is similar to the Graphviz dot language in that our DSL will be used to create graph data structures.
 However, unlike the DOT Language, our DSL will be an internal DSL for use only in our language.
 
-More information about the difference between internal and external DSLs can be found [here][fowler-dsl].
+More information about the difference between internal and external DSLs can be found in[this article][fowler-dsl].
 
 [dsl]: https://en.wikipedia.org/wiki/Domain-specific_language
 [dot-language]: https://en.wikipedia.org/wiki/DOT_(graph_description_language)

--- a/exercises/practice/dot-dsl/.docs/instructions.md
+++ b/exercises/practice/dot-dsl/.docs/instructions.md
@@ -22,7 +22,7 @@ Write a Domain Specific Language similar to the Graphviz dot language.
 Our DSL is similar to the Graphviz dot language in that our DSL will be used to create graph data structures.
 However, unlike the DOT Language, our DSL will be an internal DSL for use only in our language.
 
-More information about the difference between internal and external DSLs can be found in[this article][fowler-dsl].
+More information about the difference between internal and external DSLs can be found [here][fowler-dsl].
 
 [dsl]: https://en.wikipedia.org/wiki/Domain-specific_language
 [dot-language]: https://en.wikipedia.org/wiki/DOT_(graph_description_language)

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -112,13 +112,13 @@ Seeing both kinds can be instructive and interesting.
 
 Mentors review submitted solutions for the track they've chosen to mentor to help users learn as much as possible.
 
-To read more about mentoring, go to the following [link][Mentoring].
+To read more about mentoring, go to the [Exercism docs][Mentoring].
 
 ### Contribute to Exercism
 
 The entire of Exercism is Open Source and is a labor of love for over 100 maintainers and many more contributors.
 
-A starting point to jumping in and becoming a contributor can be found [here][Contributing].
+A starting point to jumping in and becoming a contributor can be found in the [Exercism contributing guide][Contributing].
 
 [Tutorial]: #tutorial
 [Introduction]: #introduction

--- a/reference/contributing-to-practice-exercises.md
+++ b/reference/contributing-to-practice-exercises.md
@@ -19,7 +19,7 @@ This can just be a Pull Request with an empty commit that states which new exerc
 The Java specific details you need to know about adding an exercise are:
 
 - Please add an entry to the `exercises` array in `config.json`.
-  You can find details about what should be in that entry [here][docs-building-config-json].
+  You can find details about what should be in that entry at the [Exercism docs][docs-building-config-json].
   You can also look at other entries in `config.json` as examples and try to mimic them.
 
 - Please add an entry for your exercise to `settings.gradle`.


### PR DESCRIPTION
# Pull Request

This PR updates 18 instances of generic link text across 10 files to resolve markdown linting errors introduced by recent [markdownlint](https://github.com/DavidAnson/markdownlint/blob/v0.38.0/doc/md059.md) rule upgrades (via Dependabot).
 
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
