### PR TITLE
Fix typo in datetime concept

### DIFF
--- a/concepts/datetime/about.md
+++ b/concepts/datetime/about.md
@@ -47,7 +47,7 @@ These methods return a _new_ `LocalDate` instance and do not update the existing
 ```java
 LocalDate date = LocalDate.of(2007, 12, 3);
 
-date.addDays(3);
+date.plusDays(3);
 // => 2007-12-06
 
 date.addMonths(1);

--- a/concepts/datetime/introduction.md
+++ b/concepts/datetime/introduction.md
@@ -41,7 +41,7 @@ These methods return a _new_ `LocalDate` instance and do not update the existing
 ```java
 LocalDate date = LocalDate.of(2007, 12, 3);
 
-date.addDays(3);
+date.plusDays(3);
 // => 2007-12-06
 ```
 

--- a/exercises/concept/booking-up-for-beauty/.docs/introduction.md
+++ b/exercises/concept/booking-up-for-beauty/.docs/introduction.md
@@ -43,7 +43,7 @@ These methods return a _new_ `LocalDate` instance and do not update the existing
 ```java
 LocalDate date = LocalDate.of(2007, 12, 3);
 
-date.addDays(3);
+date.plusDays(3);
 // => 2007-12-06
 ```
 


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->

Fix invalid method reference in datetime concept

This PR:
- replaces the incorrect `addDays()` method with correct `plusDays()` in `LocalDate` examples
- updates the datetime concept and corresponding exercise docs

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
