### PR TITLE
Add @DisplayName to Test Methods in Practice Exercises #2971

### DIFF
--- a/exercises/practice/swift-scheduling/src/test/java/SwiftSchedulingTest.java
+++ b/exercises/practice/swift-scheduling/src/test/java/SwiftSchedulingTest.java
@@ -128,7 +128,9 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("2M before the second month of this year translates to the first workday of the second month of this year")
+    @DisplayName(
+        "2M before the second month of this year translates to the first workday of the second month of this year"
+    )
     void test2MInJanuary() {
         LocalDateTime meetingStart = LocalDateTime.parse("2007-01-02T14:15:00");
         LocalDateTime expected = LocalDateTime.parse("2007-02-01T08:00:00");

--- a/exercises/practice/swift-scheduling/src/test/java/SwiftSchedulingTest.java
+++ b/exercises/practice/swift-scheduling/src/test/java/SwiftSchedulingTest.java
@@ -8,7 +8,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class SwiftSchedulingTest {
     @Test
-    @DisplayName("NOW at 9 AM")
+    @DisplayName("NOW translates to two hours later")
     void testNowAtNineAm() {
         LocalDateTime meetingStart = LocalDateTime.parse("2012-02-13T09:00:00");
         LocalDateTime expected = LocalDateTime.parse("2012-02-13T11:00:00");
@@ -20,7 +20,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("ASAP before 1 PM")
+    @DisplayName("ASAP before one in the afternoon translates to today at five in the afternoon")
     void testAsapBeforeOnePm() {
         LocalDateTime meetingStart = LocalDateTime.parse("1999-06-03T09:45:00");
         LocalDateTime expected = LocalDateTime.parse("1999-06-03T17:00:00");
@@ -32,7 +32,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("ASAP at 1 PM")
+    @DisplayName("ASAP at one in the afternoon translates to tomorrow at one in the afternoon")
     void testAsapAtOnePm() {
         LocalDateTime meetingStart = LocalDateTime.parse("2008-12-21T13:00:00");
         LocalDateTime expected = LocalDateTime.parse("2008-12-22T13:00:00");
@@ -44,7 +44,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("ASAP after 1 PM")
+    @DisplayName("ASAP after one in the afternoon translates to tomorrow at one in the afternoon")
     void testAsapAfterOnePm() {
         LocalDateTime meetingStart = LocalDateTime.parse("2008-12-21T14:50:00");
         LocalDateTime expected = LocalDateTime.parse("2008-12-22T13:00:00");
@@ -56,7 +56,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("EOW on Monday")
+    @DisplayName("EOW on Monday translates to Friday at five in the afternoon")
     void testEowOnMonday() {
         LocalDateTime meetingStart = LocalDateTime.parse("2025-02-03T16:00:00");
         LocalDateTime expected = LocalDateTime.parse("2025-02-07T17:00:00");
@@ -68,7 +68,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("EOW on Tuesday")
+    @DisplayName("EOW on Tuesday translates to Friday at five in the afternoon")
     void testEowOnTuesday() {
         LocalDateTime meetingStart = LocalDateTime.parse("1997-04-29T10:50:00");
         LocalDateTime expected = LocalDateTime.parse("1997-05-02T17:00:00");
@@ -80,7 +80,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("EOW on Wednesday")
+    @DisplayName("EOW on Wednesday translates to Friday at five in the afternoon")
     void testEowOnWednesday() {
         LocalDateTime meetingStart = LocalDateTime.parse("2005-09-14T11:00:00");
         LocalDateTime expected = LocalDateTime.parse("2005-09-16T17:00:00");
@@ -92,7 +92,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("EOW on Thursday")
+    @DisplayName("EOW on Thursday translates to Sunday at eight in the evening")
     void testEowOnThursday() {
         LocalDateTime meetingStart = LocalDateTime.parse("2011-05-19T08:30:00");
         LocalDateTime expected = LocalDateTime.parse("2011-05-22T20:00:00");
@@ -104,7 +104,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("EOW on Friday")
+    @DisplayName("EOW on Friday translates to Sunday at eight in the evening")
     void testEowOnFriday() {
         LocalDateTime meetingStart = LocalDateTime.parse("2022-08-05T14:00:00");
         LocalDateTime expected = LocalDateTime.parse("2022-08-07T20:00:00");
@@ -116,7 +116,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("EOW in leap year")
+    @DisplayName("EOW translates to leap day")
     void testEowDuringLeapYear() {
         LocalDateTime meetingStart = LocalDateTime.parse("2008-02-25T10:30:00");
         LocalDateTime expected = LocalDateTime.parse("2008-02-29T17:00:00");
@@ -128,7 +128,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("2M in January")
+    @DisplayName("2M before the second month of this year translates to the first workday of the second month of this year")
     void test2MInJanuary() {
         LocalDateTime meetingStart = LocalDateTime.parse("2007-01-02T14:15:00");
         LocalDateTime expected = LocalDateTime.parse("2007-02-01T08:00:00");
@@ -140,7 +140,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("11M in November")
+    @DisplayName("11M in the eleventh month translates to the first workday of the eleventh month of next year")
     void test11MInNovember() {
         LocalDateTime meetingStart = LocalDateTime.parse("2013-11-21T15:30:00");
         LocalDateTime expected = LocalDateTime.parse("2014-11-03T08:00:00");
@@ -152,7 +152,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("4M in November")
+    @DisplayName("4M in the ninth month translates to the first workday of the fourth month of next year")
     void test4MInNovember() {
         LocalDateTime meetingStart = LocalDateTime.parse("2019-11-18T15:15:00");
         LocalDateTime expected = LocalDateTime.parse("2020-04-01T08:00:00");
@@ -164,7 +164,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("Q1 in Q1")
+    @DisplayName("Q1 in the first quarter translates to the last workday of the first quarter of this year")
     void testQ1InQ1() {
         LocalDateTime meetingStart = LocalDateTime.parse("2003-01-01T10:45:00");
         LocalDateTime expected = LocalDateTime.parse("2003-03-31T08:00:00");
@@ -176,7 +176,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("Q4 in Q2")
+    @DisplayName("Q4 in the second quarter translates to the last workday of the fourth quarter of this year")
     void testQ4InQ2() {
         LocalDateTime meetingStart = LocalDateTime.parse("2001-04-09T09:00:00");
         LocalDateTime expected = LocalDateTime.parse("2001-12-31T08:00:00");
@@ -188,7 +188,7 @@ class SwiftSchedulingTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("Q3 in Q4")
+    @DisplayName("Q3 in the fourth quarter translates to the last workday of the third quarter of next year")
     void testQ3InQ4() {
         LocalDateTime meetingStart = LocalDateTime.parse("2022-10-06T11:00:00");
         LocalDateTime expected = LocalDateTime.parse("2023-09-29T08:00:00");


### PR DESCRIPTION
Add @DisplayName annotations to swift-scheduling tests

Replace existing @DisplayName annotations with canonical descriptions from problem-specifications to ensure consistency across tracks.

# pull request
<!-- Your content goes here: -->

## Summary
Replace existing @DisplayName annotations in swift-scheduling tests with canonical descriptions from problem-specifications to ensure consistency across tracks.

## Changes Made
- Updated all 16 test methods with canonical descriptions from `canonical-data.json`
- Maintained existing test logic and functionality
- Only modified @DisplayName annotations for better test output readability

## Example
**Before:**

@DisplayName("NOW at 9 AM")

**After:**
@DisplayName("NOW translates to two hours later")

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
