### PR TITLE
Add new test. resistor with decimal values

### DIFF
--- a/exercises/practice/resistor-color-trio/src/test/java/ResistorColorTrioTest.java
+++ b/exercises/practice/resistor-color-trio/src/test/java/ResistorColorTrioTest.java
@@ -90,4 +90,12 @@ public class ResistorColorTrioTest {
             resistorColorTrio.label(new String[]{"blue", "green", "yellow", "orange"})
         ).isEqualTo("650 kiloohms");
     }
+
+    @Disabled("Remove to run test")
+    @Test
+    public void testOrangeAndOrangeAndRed() {
+        assertThat(
+            resistorColorTrio.label(new String[]{"orange", "orange", "red"})
+        ).isEqualTo("3.3 kiloohms");
+    }
 }


### PR DESCRIPTION
### 📌 Pull Request: Add new test case for "orange, orange, red" resistor combination

**Summary:**

This PR adds a new unit test to the `ResistorColorTrioTest` class to validate the correct label generation for the resistor color combination `{"orange", "orange", "red"}`.

**Details:**

* Added test method: `testOrangeAndOrangeAndRed`
* Expected result: `"3.3 kiloohms"`
* The test is currently annotated with `@Disabled` to maintain consistency with other pre-disabled test cases in this suite.
* This allows contributors or students to manually enable and verify the test once the corresponding functionality is implemented or updated.

**Why this is useful:**

* Improves test coverage for the resistor color combinations.
* Helps validate handling of multiplier values when the third band leads to decimal kiloohm values.

**Next steps:**

* Remove `@Disabled` once the implementation is ready.
* Confirm that the output matches `"3.3 kiloohms"` as per spec.

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
