### PR TITLE
Related to #2971 display names 

### DIFF
--- a/exercises/practice/rectangles/src/test/java/RectangleCounterTest.java
+++ b/exercises/practice/rectangles/src/test/java/RectangleCounterTest.java
@@ -1,5 +1,6 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,6 +15,7 @@ public class RectangleCounterTest {
     }
 
     @Test
+    @DisplayName("no rows")
     public void testInputWithNoRowsContainsNoRectangles() {
         String[] inputGrid = new String[]{};
 
@@ -22,6 +24,7 @@ public class RectangleCounterTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("no columns")
     public void testInputWithNoColumnsContainsNoRectangles() {
         String[] inputGrid = new String[]{""};
 
@@ -30,6 +33,7 @@ public class RectangleCounterTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("no rectangles")
     public void testNonTrivialInputWithNoRectangles() {
         String[] inputGrid = new String[]{" "};
 
@@ -38,6 +42,7 @@ public class RectangleCounterTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("one rectangle")
     public void testInputWithOneRectangle() {
         String[] inputGrid = new String[]{
             "+-+",
@@ -50,6 +55,7 @@ public class RectangleCounterTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("two rectangles without shared parts")
     public void testInputWithTwoRectanglesWithoutSharedEdges() {
         String[] inputGrid = new String[]{
             "  +-+",
@@ -64,6 +70,7 @@ public class RectangleCounterTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("five rectangles with shared parts")
     public void testInputWithFiveRectanglesWithSharedEdges() {
         String[] inputGrid = new String[]{
             "  +-+",
@@ -78,6 +85,7 @@ public class RectangleCounterTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("rectangle of height 1 is counted")
     public void testThatRectangleOfHeightOneIsCounted() {
         String[] inputGrid = new String[]{
             "+--+",
@@ -89,6 +97,7 @@ public class RectangleCounterTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("rectangle of width 1 is counted")
     public void testThatRectangleOfWidthOneIsCounted() {
         String[] inputGrid = new String[]{
             "++",
@@ -101,6 +110,7 @@ public class RectangleCounterTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("1x1 square is counted")
     public void testThatOneByOneSquareIsCounted() {
         String[] inputGrid = new String[]{
             "++",
@@ -112,6 +122,7 @@ public class RectangleCounterTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("only complete rectangles are counted")
     public void testThatIncompleteRectanglesAreNotCounted() {
         String[] inputGrid = new String[]{
             "  +-+",
@@ -126,6 +137,7 @@ public class RectangleCounterTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("rectangles can be of different sizes")
     public void testThatRectanglesOfDifferentSizesAreAllCounted() {
         String[] inputGrid = new String[]{
             "+------+----+",
@@ -140,6 +152,7 @@ public class RectangleCounterTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("corner is required for a rectangle to be complete")
     public void testThatIntersectionsWithoutCornerCharacterDoNotCountAsRectangleCorners() {
         String[] inputGrid = new String[]{
             "+------+----+",
@@ -154,6 +167,7 @@ public class RectangleCounterTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("large input with many rectangles")
     public void testLargeInputWithManyRectangles() {
         String[] inputGrid = new String[]{
             "+---+--+----+",
@@ -171,6 +185,7 @@ public class RectangleCounterTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("rectangles must have four sides")
     public void testRectanglesMustHaveFourSides() {
         String[] inputGrid = new String[]{
             "+-+ +-+",

--- a/exercises/practice/relative-distance/src/test/java/RelativeDistanceTest.java
+++ b/exercises/practice/relative-distance/src/test/java/RelativeDistanceTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 
@@ -12,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RelativeDistanceTest {
 
     @Test
+    @DisplayName("Direct parent-child relation")
     public void testDirectParentChildRelation() {
         Map<String, List<String>> familyTree = new HashMap<>() {
             {
@@ -26,6 +28,7 @@ public class RelativeDistanceTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Sibling relationship")
     public void testSiblingRelationship() {
         Map<String, List<String>> familyTree = new HashMap<>() {
             {
@@ -39,6 +42,7 @@ public class RelativeDistanceTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Two degrees of separation, grandchild")
     public void testTwoDegreesOfSeparationGrandchild() {
         Map<String, List<String>> familyTree = new HashMap<>() {
             {
@@ -53,6 +57,7 @@ public class RelativeDistanceTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Unrelated individuals")
     public void testUnrelatedIndividuals() {
         Map<String, List<String>> familyTree = new HashMap<>() {
             {
@@ -67,6 +72,7 @@ public class RelativeDistanceTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Complex graph, cousins")
     public void testComplexGraphCousins() {
         Map<String, List<String>> familyTree = new HashMap<>() {
             {
@@ -131,6 +137,7 @@ public class RelativeDistanceTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Complex graph, no shortcut, far removed nephew")
     public void testComplexGraphNoShortcutFarRemovedNephew() {
         Map<String, List<String>> familyTree = new HashMap<>() {
             {
@@ -194,6 +201,7 @@ public class RelativeDistanceTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Complex graph, some shortcuts, cross-down and cross-up, cousins several times removed, with unrelated family tree")
     public void testComplexGraphSomeShortcutsCrossDownAndCrossUpCousinsSeveralTimesRemovedWithUnrelatedFamilyTree() {
         Map<String, List<String>> familyTree = new HashMap<>() {
             {

--- a/exercises/practice/relative-distance/src/test/java/RelativeDistanceTest.java
+++ b/exercises/practice/relative-distance/src/test/java/RelativeDistanceTest.java
@@ -201,7 +201,10 @@ public class RelativeDistanceTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("Complex graph, some shortcuts, cross-down and cross-up, cousins several times removed, with unrelated family tree")
+    @DisplayName(
+            "Complex graph, some shortcuts, cross-down and cross-up, " +
+                    "cousins several times removed, with unrelated family tree"
+    )
     public void testComplexGraphSomeShortcutsCrossDownAndCrossUpCousinsSeveralTimesRemovedWithUnrelatedFamilyTree() {
         Map<String, List<String>> familyTree = new HashMap<>() {
             {

--- a/exercises/practice/resistor-color-duo/src/test/java/ResistorColorDuoTest.java
+++ b/exercises/practice/resistor-color-duo/src/test/java/ResistorColorDuoTest.java
@@ -1,7 +1,7 @@
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/exercises/practice/resistor-color-duo/src/test/java/ResistorColorDuoTest.java
+++ b/exercises/practice/resistor-color-duo/src/test/java/ResistorColorDuoTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Disabled;
 
@@ -13,6 +14,7 @@ public class ResistorColorDuoTest {
     }
 
     @Test
+    @DisplayName("Brown and black")
     public void testBrownAndBlack() {
         assertThat(
                 resistorColorDuo.value(new String[]{"brown", "black"})
@@ -21,6 +23,7 @@ public class ResistorColorDuoTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Blue and grey")
     public void testBlueAndGrey() {
         assertThat(
                 resistorColorDuo.value(new String[]{ "blue", "grey" })
@@ -29,6 +32,7 @@ public class ResistorColorDuoTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Yellow and violet")
     public void testYellowAndViolet() {
         assertThat(
                 resistorColorDuo.value(new String[]{ "yellow", "violet" })
@@ -37,6 +41,7 @@ public class ResistorColorDuoTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Orange and orange")
     public void testOrangeAndOrange() {
         assertThat(
                 resistorColorDuo.value(new String[]{ "orange", "orange" })
@@ -45,6 +50,7 @@ public class ResistorColorDuoTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("White and red")
     public void testWhiteAndRed() {
         assertThat(
                 resistorColorDuo.value(new String[]{ "white", "red" })
@@ -53,6 +59,7 @@ public class ResistorColorDuoTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Black and brown, one-digit")
     public void testBlackAndBrownOneDigit() {
         assertThat(
                 resistorColorDuo.value(new String[]{ "black", "brown" })
@@ -61,6 +68,7 @@ public class ResistorColorDuoTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Ignore additional colors")
     public void testIgnoreAdditionalColors() {
         assertThat(
                 resistorColorDuo.value(new String[]{ "green", "brown", "orange" })

--- a/exercises/practice/resistor-color-trio/src/test/java/ResistorColorTrioTest.java
+++ b/exercises/practice/resistor-color-trio/src/test/java/ResistorColorTrioTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Disabled;
 
@@ -13,6 +14,7 @@ public class ResistorColorTrioTest {
     }
 
     @Test
+    @DisplayName("Orange and orange and black")
     public void testOrangeAndOrangeAndBlack() {
         assertThat(
             resistorColorTrio.label(new String[]{"orange", "orange", "black"})
@@ -21,6 +23,7 @@ public class ResistorColorTrioTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Blue and grey and brown")
     public void testBlueAndGreyAndBrown() {
         assertThat(
             resistorColorTrio.label(new String[]{"blue", "grey", "brown"})
@@ -29,6 +32,7 @@ public class ResistorColorTrioTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Red and black and red")
     public void testRedAndBlackAndRed() {
         assertThat(
             resistorColorTrio.label(new String[]{"red", "black", "red"})
@@ -37,6 +41,7 @@ public class ResistorColorTrioTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Green and brown and orange")
     public void testGreenAndBrownAndOrange() {
         assertThat(
             resistorColorTrio.label(new String[]{"green", "brown", "orange"})
@@ -45,6 +50,7 @@ public class ResistorColorTrioTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Yellow and violet and yellow")
     public void testYellowAndVioletAndYellow() {
         assertThat(
             resistorColorTrio.label(new String[]{"yellow", "violet", "yellow"})
@@ -53,6 +59,7 @@ public class ResistorColorTrioTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Blue and violet and blue")
     public void testBlueAndVioletAndBlue() {
         assertThat(
             resistorColorTrio.label(new String[]{"blue", "violet", "blue"})
@@ -61,6 +68,7 @@ public class ResistorColorTrioTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Minimum possible value")
     public void testBlackAndBlackAndBlack() {
         assertThat(
             resistorColorTrio.label(new String[]{"black", "black", "black"})
@@ -69,6 +77,7 @@ public class ResistorColorTrioTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Maximum possible value")
     public void testWhiteAndWhiteAndWhite() {
         assertThat(
             resistorColorTrio.label(new String[]{"white", "white", "white"})
@@ -77,6 +86,7 @@ public class ResistorColorTrioTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("First two colors make an invalid octal number")
     public void testFirstTwoColorsMakeAnInvalidOctalNumber() {
         assertThat(
             resistorColorTrio.label(new String[]{"black", "grey", "black"})
@@ -85,6 +95,7 @@ public class ResistorColorTrioTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Ignore extra colors")
     public void testIgnoreExtraColors() {
         assertThat(
             resistorColorTrio.label(new String[]{"blue", "green", "yellow", "orange"})

--- a/exercises/practice/resistor-color-trio/src/test/java/ResistorColorTrioTest.java
+++ b/exercises/practice/resistor-color-trio/src/test/java/ResistorColorTrioTest.java
@@ -1,7 +1,7 @@
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/exercises/practice/resistor-color/src/test/java/ResistorColorTest.java
+++ b/exercises/practice/resistor-color/src/test/java/ResistorColorTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Disabled;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -13,24 +14,28 @@ public class ResistorColorTest {
     }
 
     @Test
+    @DisplayName("Black")
     public void testBlackColorCode() {
         assertThat(resistorColor.colorCode("black")).isEqualTo(0);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("white")
     public void testWhiteColorCode() {
         assertThat(resistorColor.colorCode("white")).isEqualTo(9);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Orange")
     public void testOrangeColorCode() {
         assertThat(resistorColor.colorCode("orange")).isEqualTo(3);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Colors")
     public void testColors() {
         assertThat(resistorColor.colors()).containsExactly(
                 "black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"

--- a/exercises/practice/resistor-color/src/test/java/ResistorColorTest.java
+++ b/exercises/practice/resistor-color/src/test/java/ResistorColorTest.java
@@ -1,7 +1,7 @@
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.Disabled;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ResistorColorTest {

--- a/exercises/practice/rest-api/src/test/java/RestApiTest.java
+++ b/exercises/practice/rest-api/src/test/java/RestApiTest.java
@@ -1,6 +1,7 @@
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class RestApiTest {
 
     @Test
+    @DisplayName("no users")
     public void noUsers() {
         String expected =
             new JSONObject().put("users", new JSONArray()).toString();
@@ -18,6 +20,7 @@ public class RestApiTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("add user")
     public void addUser() {
         String expected = new JSONObject()
             .put("name", "Adam")
@@ -33,6 +36,7 @@ public class RestApiTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("get single user")
     public void getSingleUser() {
         String expected = new JSONObject()
             .put(
@@ -56,6 +60,7 @@ public class RestApiTest {
     }
 
     @Test
+    @DisplayName("both users have 0 balance")
     public void bothUsersHave0Balance() {
         String expected =
             new JSONObject()
@@ -94,6 +99,7 @@ public class RestApiTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("borrower has negative balance")
     public void borrowerHasNegativeBalance() {
         String expected =
             new JSONObject()
@@ -135,6 +141,7 @@ public class RestApiTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("lender has negative balance")
     public void lenderHasNegativeBalance() {
         String expected =
             new JSONObject()
@@ -178,6 +185,7 @@ public class RestApiTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("lender owes borrower")
     public void lenderOwesBorrower() {
         String expected =
             new JSONObject()
@@ -216,6 +224,7 @@ public class RestApiTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("lender owes borrower less than new loan")
     public void lenderOwesBorrowerLessThanNewLoan() {
         String expected =
             new JSONObject()
@@ -254,6 +263,7 @@ public class RestApiTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("lender owes borrower same as new loan")
     public void lenderOwesBorrowerSameAsNewLoan() {
         String expected =
             new JSONObject()

--- a/exercises/practice/reverse-string/src/test/java/ReverseStringTest.java
+++ b/exercises/practice/reverse-string/src/test/java/ReverseStringTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -6,36 +7,42 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ReverseStringTest {
 
     @Test
+    @DisplayName("an empty string")
     public void testAnEmptyString() {
         assertThat(new ReverseString().reverse("")).isEqualTo("");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("a word")
     public void testAWord() {
         assertThat(new ReverseString().reverse("robot")).isEqualTo("tobor");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("a capitalized word")
     public void testACapitalizedWord() {
         assertThat(new ReverseString().reverse("Ramen")).isEqualTo("nemaR");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("a sentence with punctuation")
     public void testASentenceWithPunctuation() {
         assertThat(new ReverseString().reverse("I'm hungry!")).isEqualTo("!yrgnuh m'I");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("a palindrome")
     public void testAPalindrome() {
         assertThat(new ReverseString().reverse("racecar")).isEqualTo("racecar");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("an even-sized word")
     public void testAnEvenSizedWord() {
         assertThat(new ReverseString().reverse("drawer")).isEqualTo("reward");
     }


### PR DESCRIPTION
# pull request

## Description
Add @DisplayName annotations to test methods based on canonical data

## Changes
Added DisplayName annotations to the following exercises:
- rectangles
- relative-distance
- resistor-color-duo
- resistor-color-trio
- resistor-color
- rest-api
- reverse-string

## Testing
All tests pass successfully (verified with ./gradlew test)

## Related Issue
Addresses #2971 (DisplayName annotations initiative)


<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
