### PR TITLE
Add displayname annotations

### DIFF
--- a/exercises/practice/pov/src/test/java/PovTest.java
+++ b/exercises/practice/pov/src/test/java/PovTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -9,6 +10,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 public class PovTest {
 
     @Test
+    @DisplayName("Results in the same tree if the input tree is a singleton")
     public void testFromPovGivenSingletonTree() {
         Tree tree = Tree.of("x");
         Tree expected = Tree.of("x");
@@ -17,6 +19,7 @@ public class PovTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can reroot a tree with a parent and one sibling")
     public void testFromPovGivenTreeWithParentAndOneSibling() {
         Tree tree = Tree.of("parent",
                 List.of(Tree.of("x"),
@@ -30,6 +33,7 @@ public class PovTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can reroot a tree with a parent and many siblings")
     public void testFromPovGivenTreeWithParentAndManySibling() {
         Tree tree = Tree.of("parent",
                 List.of(Tree.of("x"),
@@ -48,6 +52,7 @@ public class PovTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("an reroot a tree with new root deeply nested in the tree")
     public void testFromPovGivenTreeWithNewRootDeeplyNested() {
         Tree tree = Tree.of("level-0",
                 List.of(Tree.of("level-1",
@@ -66,6 +71,7 @@ public class PovTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Moves children of the new root to same level as former parent")
     public void testFromPovGivenMovesChildrenOfNewRootToSameLevelAsFormerParent() {
         Tree tree = Tree.of("parent",
                 List.of(Tree.of("x",
@@ -82,6 +88,7 @@ public class PovTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can reroot a complex tree with cousins")
     public void testFromPovGivenComplexTreeWithCousins() {
         Tree tree = Tree.of("grandparent",
                 List.of(Tree.of("parent",
@@ -110,6 +117,7 @@ public class PovTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Errors if target does not exist in a singleton tree")
     public void testFromPovGivenNonExistentTargetInSingletonTree() {
         Tree tree = Tree.of("x");
         assertThatExceptionOfType(UnsupportedOperationException.class)
@@ -119,6 +127,7 @@ public class PovTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Errors if target does not exist in a larger tree")
     public void testFromPovGivenNonExistentTargetInLargeTree() {
         Tree tree = Tree.of("parent",
                 List.of(Tree.of("x",
@@ -134,6 +143,7 @@ public class PovTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can find path to parent")
     public void testPathToCanFindPathToParent() {
         Tree tree = Tree.of("parent",
                 List.of(Tree.of("x"),
@@ -158,6 +168,7 @@ public class PovTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can find path to cousin")
     public void testPathToCanFindPathToCousin() {
         Tree tree = Tree.of("grandparent",
                 List.of(Tree.of("parent",
@@ -176,6 +187,7 @@ public class PovTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can find path not involving root")
     public void testPathToCanFindPathNotEnvolvingRoot() {
         Tree tree = Tree.of("grandparent",
                 List.of(Tree.of("parent",
@@ -189,6 +201,7 @@ public class PovTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can find path from nodes other than x")
     public void testPathToCanFindPathFromNodesOtherThanX() {
         Tree tree = Tree.of("parent",
                 List.of(Tree.of("a"),
@@ -202,6 +215,7 @@ public class PovTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Errors if destination does not exist")
     public void testPathWhenDestinationDoesNotExist() {
         Tree tree = Tree.of("parent",
                 List.of(Tree.of("x",
@@ -217,6 +231,7 @@ public class PovTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Errors if source does not exist")
     public void testPathWhenSourceDoesNotExist() {
         Tree tree = Tree.of("parent",
                 List.of(Tree.of("x",

--- a/exercises/practice/prime-factors/src/test/java/PrimeFactorsCalculatorTest.java
+++ b/exercises/practice/prime-factors/src/test/java/PrimeFactorsCalculatorTest.java
@@ -1,5 +1,6 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,72 +15,84 @@ public class PrimeFactorsCalculatorTest {
     }
 
     @Test
+    @DisplayName("no factors")
     public void testNoFactors() {
         assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(1L)).isEmpty();
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("prime number")
     public void testPrimeNumber() {
         assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(2L)).containsExactly(2L);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("another prime number")
     public void testAnotherPrimeNumber() {
         assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(3L)).containsExactly(3L);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("square of a prime")
     public void testSquareOfAPrime() {
         assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(9L)).containsExactly(3L, 3L);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("product of first prime")
     public void testProductOfFirstPrime() {
         assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(4L)).containsExactly(2L, 2L);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("cube of a prime")
     public void testCubeOfAPrime() {
         assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(8L)).containsExactly(2L, 2L, 2L);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("product of second prime")
     public void testProductOfSecondPrime() {
         assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(625L)).containsExactly(5L, 5L, 5L, 5L);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("product of third prime")
     public void testProductOfThirdPrime() {
         assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(27L)).containsExactly(3L, 3L, 3L);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("product of first and second prime")
     public void testProductOfFirstAndSecondPrime() {
         assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(6L)).containsExactly(2L, 3L);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("product of primes and non-primes")
     public void testProductOfPrimesAndNonPrimes() {
         assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(12L)).containsExactly(2L, 2L, 3L);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("product of primes")
     public void testProductOfPrimes() {
         assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(901255L)).containsExactly(5L, 17L, 23L, 461L);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("factors include a large prime")
     public void testFactorsIncludingALargePrime() {
         assertThat(primeFactorsCalculator.calculatePrimeFactorsOf(93819012551L)).containsExactly(11L, 9539L, 894119L);
     }

--- a/exercises/practice/protein-translation/src/test/java/ProteinTranslatorTest.java
+++ b/exercises/practice/protein-translation/src/test/java/ProteinTranslatorTest.java
@@ -1,5 +1,6 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,126 +16,147 @@ public class ProteinTranslatorTest {
     }
 
     @Test
+    @DisplayName("Empty RNA sequence results in no proteins")
     public void testEmptyRnaSequenceResultInNoproteins() {
         assertThat(proteinTranslator.translate("")).isEmpty();
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Methionine RNA sequence")
     public void testMethionineRnaSequence() {
         assertThat(proteinTranslator.translate("AUG")).containsExactly("Methionine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Phenylalanine RNA sequence 1")
     public void testPhenylalanineRnaSequence1() {
         assertThat(proteinTranslator.translate("UUU")).containsExactly("Phenylalanine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Phenylalanine RNA sequence 2")
     public void testPhenylalanineRnaSequence2() {
         assertThat(proteinTranslator.translate("UUC")).containsExactly("Phenylalanine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Leucine RNA sequence 1")
     public void testLeucineRnaSequence1() {
         assertThat(proteinTranslator.translate("UUA")).containsExactly("Leucine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Leucine RNA sequence 2")
     public void testLeucineRnaSequence2() {
         assertThat(proteinTranslator.translate("UUG")).containsExactly("Leucine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Serine RNA sequence 1")
     public void testSerineRnaSequence1() {
         assertThat(proteinTranslator.translate("UCU")).containsExactly("Serine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Serine RNA sequence 2")
     public void testSerineRnaSequence2() {
         assertThat(proteinTranslator.translate("UCC")).containsExactly("Serine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Serine RNA sequence 3")
     public void testSerineRnaSequence3() {
         assertThat(proteinTranslator.translate("UCA")).containsExactly("Serine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Serine RNA sequence 4")
     public void testSerineRnaSequence4() {
         assertThat(proteinTranslator.translate("UCG")).containsExactly("Serine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Tyrosine RNA sequence 1")
     public void testTyrosineRnaSequence1() {
         assertThat(proteinTranslator.translate("UAU")).containsExactly("Tyrosine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Tyrosine RNA sequence 2")
     public void testTyrosineRnaSequence2() {
         assertThat(proteinTranslator.translate("UAC")).containsExactly("Tyrosine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Cysteine RNA sequence 1")
     public void testCysteineRnaSequence1() {
         assertThat(proteinTranslator.translate("UGU")).containsExactly("Cysteine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Cysteine RNA sequence 2")
     public void testCysteineRnaSequence2() {
         assertThat(proteinTranslator.translate("UGC")).containsExactly("Cysteine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Tryptophan RNA sequence")
     public void testTryptophanRnaSequence1() {
         assertThat(proteinTranslator.translate("UGG")).containsExactly("Tryptophan");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("STOP codon RNA sequence 1")
     public void testStopRnaSequence1() {
         assertThat(proteinTranslator.translate("UAA")).isEmpty();
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("STOP codon RNA sequence 2")
     public void testStopRnaSequence2() {
         assertThat(proteinTranslator.translate("UAG")).isEmpty();
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("STOP codon RNA sequence 3")
     public void testStopRnaSequence3() {
         assertThat(proteinTranslator.translate("UGA")).isEmpty();
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Sequence of two protein codons translates into proteins")
     public void testSequenceOfTwoProteinCodonsTranslatesIntoProteins() {
         assertThat(proteinTranslator.translate("UUUUUU")).containsExactly("Phenylalanine", "Phenylalanine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Sequence of two different protein codons translates into proteins")
     public void testSequenceOfTwoDifferentProteinCodonsTranslatesIntoProteins() {
         assertThat(proteinTranslator.translate("UUAUUG")).containsExactly("Leucine", "Leucine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Translate RNA strand into correct protein list")
     public void testTranslationOfRnaToProteinList() {
         assertThat(proteinTranslator.translate("AUGUUUUGG"))
                 .containsExactly("Methionine", "Phenylalanine", "Tryptophan");
@@ -142,30 +164,35 @@ public class ProteinTranslatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Translation stops if STOP codon at beginning of sequence")
     public void testTranslationStopsIfStopCodonAtBeginning() {
         assertThat(proteinTranslator.translate("UAGUGG")).isEmpty();
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Translation stops if STOP codon at end of two-codon sequence")
     public void testTranslationStopsIfStopCodonAtEnd1() {
         assertThat(proteinTranslator.translate("UGGUAG")).containsExactly("Tryptophan");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Translation stops if STOP codon at end of three-codon sequence")
     public void testTranslationStopsIfStopCodonAtEnd2() {
         assertThat(proteinTranslator.translate("AUGUUUUAA")).containsExactly("Methionine", "Phenylalanine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Translation stops if STOP codon in middle of three-codon sequence")
     public void testTranslationStopsIfStopCodonInMiddle1() {
         assertThat(proteinTranslator.translate("UGGUAGUGG")).containsExactly("Tryptophan");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Translation stops if STOP codon in middle of six-codon sequence")
     public void testTranslationStopsIfStopCodonInMiddle2() {
         assertThat(proteinTranslator.translate("UGGUGUUAUUAAUGGUUU"))
                 .containsExactly("Tryptophan", "Cysteine", "Tyrosine");
@@ -173,6 +200,7 @@ public class ProteinTranslatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Sequence of two non-STOP codons does not translate to a STOP codon")
     public void testSequenceOfTwoNonStopCodonsDoNotTranslateToAStopCodon() {
         assertThat(proteinTranslator.translate("AUGAUG"))
                 .containsExactly("Methionine", "Methionine");
@@ -180,6 +208,7 @@ public class ProteinTranslatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Non-existing codon can't translate")
     public void testNonExistingCodonCantTranslate() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> proteinTranslator.translate("AAA"))
@@ -188,6 +217,7 @@ public class ProteinTranslatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Unknown amino acids, not part of a codon, can't translate")
     public void testUnknownAminoAcidsNotPartOfACodonCantTranslate() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> proteinTranslator.translate("XYZ"))
@@ -196,6 +226,7 @@ public class ProteinTranslatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Incomplete RNA sequence can't translate")
     public void testIncompleteRnaSequenceCantTranslate() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> proteinTranslator.translate("AUGU"))
@@ -204,6 +235,7 @@ public class ProteinTranslatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Incomplete RNA sequence can translate if valid until a STOP codon")
     public void testIncompleteRnaSequenceCanTranslateIfValidUntilAStopCodon() {
         assertThat(proteinTranslator.translate("UUCUUCUAAUGGU")).containsExactly("Phenylalanine", "Phenylalanine");
     }

--- a/exercises/practice/proverb/src/test/java/ProverbTest.java
+++ b/exercises/practice/proverb/src/test/java/ProverbTest.java
@@ -1,11 +1,13 @@
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class ProverbTest {
 
     @Test
+    @DisplayName("zero pieces")
     public void zeroWordsAreGiven() {
         String[] words  = new String[0];
 
@@ -14,6 +16,7 @@ public class ProverbTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("one piece")
     public void singlePieceOfProverb() {
         String[] words  = new String[]{"nail"};
 
@@ -23,6 +26,7 @@ public class ProverbTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("two pieces")
     public void twoPiecesOfProverb() {
         String[] words  = new String[]{"nail", "shoe"};
 
@@ -34,6 +38,7 @@ public class ProverbTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("three pieces")
     public void shortChainOfConsequences() {
         String[] words  = new String[]{"nail", "shoe", "horse"};
 
@@ -46,6 +51,7 @@ public class ProverbTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("full proverb")
     public void fullProverb() {
         String[] words  = new String[]{"nail", "shoe", "horse", "rider", "message", "battle", "kingdom"};
 
@@ -62,6 +68,7 @@ public class ProverbTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("four pieces modernized")
     public void fourPiecesModernizedProverb() {
         String[] words  = new String[]{"pin", "gun", "soldier", "battle"};
 

--- a/exercises/practice/pythagorean-triplet/src/test/java/PythagoreanTripletTest.java
+++ b/exercises/practice/pythagorean-triplet/src/test/java/PythagoreanTripletTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -10,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class PythagoreanTripletTest {
 
     @Test
+    @DisplayName("triplets whose sum is 12")
     public void tripletsWhoseSumIs12() {
         List<PythagoreanTriplet> actual
                 = PythagoreanTriplet
@@ -23,6 +25,7 @@ public class PythagoreanTripletTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("triplets whose sum is 108")
     public void tripletsWhoseSumIs108() {
         List<PythagoreanTriplet> actual
                 = PythagoreanTriplet
@@ -36,6 +39,7 @@ public class PythagoreanTripletTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("triplets whose sum is 1000")
     public void tripletsWhoseSumIs1000() {
         List<PythagoreanTriplet> actual
                 = PythagoreanTriplet
@@ -50,6 +54,7 @@ public class PythagoreanTripletTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("no matching triplets for 1001")
     public void tripletsWhoseSumIs1001() {
         List<PythagoreanTriplet> actual
                 = PythagoreanTriplet
@@ -62,6 +67,7 @@ public class PythagoreanTripletTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("returns all matching triplets")
     public void tripletsWhoseSumIs90() {
         List<PythagoreanTriplet> actual
                 = PythagoreanTriplet
@@ -77,6 +83,7 @@ public class PythagoreanTripletTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("several matching triplets")
     public void tripletsWhoseSumIs840() {
         List<PythagoreanTriplet> actual
                 = PythagoreanTriplet
@@ -117,6 +124,7 @@ public class PythagoreanTripletTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("triplets for large number")
     public void tripletsWhoseSumIs30000() {
         List<PythagoreanTriplet> actual
                 = PythagoreanTriplet

--- a/exercises/practice/queen-attack/src/test/java/QueenAttackCalculatorTest.java
+++ b/exercises/practice/queen-attack/src/test/java/QueenAttackCalculatorTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,12 +9,14 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOf
 public class QueenAttackCalculatorTest {
 
     @Test
+    @DisplayName("queen with a valid position")
     public void testCreateQueenWithAValidPosition() {
         new Queen(2, 2);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("queen must have positive row")
     public void testCreateQueenMustHavePositiveRow() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new Queen(-2, 2))
@@ -22,6 +25,7 @@ public class QueenAttackCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("queen must have row on board")
     public void testCreateQueenMustHaveRowOnBoard() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new Queen(8, 4))
@@ -30,6 +34,7 @@ public class QueenAttackCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("queen must have positive column")
     public void testCreateQueenMustHavePositiveColumn() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new Queen(2, -2))
@@ -38,6 +43,7 @@ public class QueenAttackCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("queen must have column on board")
     public void testCreateQueenMustHaveColumnOnBoard() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new Queen(4, 8))
@@ -46,6 +52,7 @@ public class QueenAttackCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("cannot attack")
     public void testQueensCannotAttack() {
         QueenAttackCalculator calculator
                 = new QueenAttackCalculator(new Queen(2, 4), new Queen(6, 6));
@@ -55,6 +62,7 @@ public class QueenAttackCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("can attack on same row")
     public void testQueensCanAttackOnTheSameRow() {
         QueenAttackCalculator calculator
                 = new QueenAttackCalculator(new Queen(2, 4), new Queen(2, 6));
@@ -64,6 +72,7 @@ public class QueenAttackCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("can attack on same column")
     public void testQueensCanAttackOnTheSameColumn() {
         QueenAttackCalculator calculator
                 = new QueenAttackCalculator(new Queen(4, 5), new Queen(2, 5));
@@ -73,6 +82,7 @@ public class QueenAttackCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("can attack on first diagonal")
     public void testQueensCanAttackOnFirstDiagonal() {
         QueenAttackCalculator calculator
                 = new QueenAttackCalculator(new Queen(2, 2), new Queen(0, 4));
@@ -82,6 +92,7 @@ public class QueenAttackCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("can attack on second diagonal")
     public void testQueensCanAttackOnSecondDiagonal() {
         QueenAttackCalculator calculator
                 = new QueenAttackCalculator(new Queen(2, 2), new Queen(3, 1));
@@ -91,6 +102,7 @@ public class QueenAttackCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("can attack on third diagonal")
     public void testQueensCanAttackOnThirdDiagonal() {
         QueenAttackCalculator calculator
                 = new QueenAttackCalculator(new Queen(2, 2), new Queen(1, 1));
@@ -100,6 +112,7 @@ public class QueenAttackCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("can attack on fourth diagonal")
     public void testQueensCanAttackOnFourthDiagonal() {
         QueenAttackCalculator calculator
                 = new QueenAttackCalculator(new Queen(1, 7), new Queen(0, 6));
@@ -109,6 +122,8 @@ public class QueenAttackCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("cannot attack if falling diagonals are only the same " +
+            "when reflected across the longest falling diagonal")
     public void testQueenCannotAttackIfFallingDiagonalsAreOnlyTheSameWhenReflectedAcrossTheLongestFallingDiagonal() {
         QueenAttackCalculator calculator
                 = new QueenAttackCalculator(new Queen(4, 1), new Queen(2, 5));

--- a/exercises/practice/rail-fence-cipher/src/test/java/RailFenceCipherTest.java
+++ b/exercises/practice/rail-fence-cipher/src/test/java/RailFenceCipherTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,6 +9,7 @@ public class RailFenceCipherTest {
     private RailFenceCipher railFenceCipher;
 
     @Test
+    @DisplayName("encode with two rails")
     public void encodeWithTwoRails() {
         railFenceCipher = new RailFenceCipher(2);
         assertThat(railFenceCipher.getEncryptedData("XOXOXOXOXOXOXOXOXO"))
@@ -16,6 +18,7 @@ public class RailFenceCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("encode with three rails")
     public void encodeWithThreeRails() {
         railFenceCipher = new RailFenceCipher(3);
         assertThat(railFenceCipher.getEncryptedData("WEAREDISCOVEREDFLEEATONCE"))
@@ -24,6 +27,7 @@ public class RailFenceCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("encode with ending in the middle")
     public void encodeWithEndingInTheMiddle() {
         railFenceCipher = new RailFenceCipher(4);
         assertThat(railFenceCipher.getEncryptedData("EXERCISES"))
@@ -32,6 +36,7 @@ public class RailFenceCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("decode with three rails")
     public void decodeWithThreeRails() {
         railFenceCipher = new RailFenceCipher(3);
         assertThat(railFenceCipher.getDecryptedData("TEITELHDVLSNHDTISEIIEA"))
@@ -40,6 +45,7 @@ public class RailFenceCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("decode with five rails")
     public void decodeWithFiveRails() {
         railFenceCipher = new RailFenceCipher(5);
         assertThat(railFenceCipher.getDecryptedData("EIEXMSMESAORIWSCE"))
@@ -48,6 +54,7 @@ public class RailFenceCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("decode with six rails")
     public void decodeWithSixRails() {
         railFenceCipher = new RailFenceCipher(6);
         assertThat(railFenceCipher.getDecryptedData("133714114238148966225439541018335470986172518171757571896261"))

--- a/exercises/practice/raindrops/src/test/java/RaindropConverterTest.java
+++ b/exercises/practice/raindrops/src/test/java/RaindropConverterTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,108 +9,126 @@ public class RaindropConverterTest {
     private RaindropConverter raindropConverter = new RaindropConverter();
 
     @Test
+    @DisplayName("the sound for 1 is 1")
     public void soundFor1Is1() {
         assertThat(raindropConverter.convert(1)).isEqualTo("1");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 3 is Pling")
     public void soundFor3IsPling() {
         assertThat(raindropConverter.convert(3)).isEqualTo("Pling");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 5 is Plang")
     public void soundFor5IsPlang() {
         assertThat(raindropConverter.convert(5)).isEqualTo("Plang");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 7 is Plong")
     public void soundFor7IsPlong() {
         assertThat(raindropConverter.convert(7)).isEqualTo("Plong");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 6 is Pling as it has a factor 3")
     public void soundFor6IsPlingAsItHasFactor3() {
         assertThat(raindropConverter.convert(6)).isEqualTo("Pling");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base")
     public void noSoundFor2Cubed() {
         assertThat(raindropConverter.convert(8)).isEqualTo("8");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 9 is Pling as it has a factor 3")
     public void soundFor9IsPlingAsItHasFactor3() {
         assertThat(raindropConverter.convert(9)).isEqualTo("Pling");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 10 is Plang as it has a factor 5")
     public void soundFor10IsPlangAsItHasFactor5() {
         assertThat(raindropConverter.convert(10)).isEqualTo("Plang");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 14 is Plong as it has a factor of 7")
     public void soundFor14IsPlongAsItHasFactor7() {
         assertThat(raindropConverter.convert(14)).isEqualTo("Plong");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 15 is PlingPlang as it has factors 3 and 5")
     public void soundFor15IsPlingPlangAsItHasFactors3And5() {
         assertThat(raindropConverter.convert(15)).isEqualTo("PlingPlang");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 21 is PlingPlong as it has factors 3 and 7")
     public void soundFor21IsPlingPlongAsItHasFactors3And7() {
         assertThat(raindropConverter.convert(21)).isEqualTo("PlingPlong");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 25 is Plang as it has a factor 5")
     public void soundFor25IsPlangAsItHasFactor5() {
         assertThat(raindropConverter.convert(25)).isEqualTo("Plang");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 27 is Pling as it has a factor 3")
     public void soundFor27IsPlingAsItHasFactor3() {
         assertThat(raindropConverter.convert(27)).isEqualTo("Pling");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 35 is PlangPlong as it has factors 5 and 7")
     public void soundFor35IsPlangPlongAsItHasFactors5And7() {
         assertThat(raindropConverter.convert(35)).isEqualTo("PlangPlong");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 49 is Plong as it has a factor 7")
     public void soundFor49IsPlongAsItHasFactor7() {
         assertThat(raindropConverter.convert(49)).isEqualTo("Plong");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 52 is 52")
     public void noSoundFor52() {
         assertThat(raindropConverter.convert(52)).isEqualTo("52");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7")
     public void soundFor105IsPlingPlangPlongAsItHasFactors3And5And7() {
         assertThat(raindropConverter.convert(105)).isEqualTo("PlingPlangPlong");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("the sound for 3125 is Plang as it has a factor 5")
     public void soundFor3125IsPlangAsItHasFactor5() {
         assertThat(raindropConverter.convert(3125)).isEqualTo("Plang");
     }

--- a/exercises/practice/rational-numbers/src/test/java/RationalTest.java
+++ b/exercises/practice/rational-numbers/src/test/java/RationalTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,6 +18,7 @@ public class RationalTest {
     // Tests
 
     @Test
+    @DisplayName("Add two positive rational numbers")
     public void testAddTwoPositiveRationalNumbers() {
         Rational expected = new Rational(7, 6);
         Rational actual = new Rational(1, 2).add(new Rational(2, 3));
@@ -25,6 +27,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Add a positive rational number and a negative rational number")
     public void testAddAPositiveRationalNumberAndANegativeRationalNumber() {
         Rational expected = new Rational(-1, 6);
         Rational actual = new Rational(1, 2).add(new Rational(-2, 3));
@@ -33,6 +36,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Add two negative rational numbers")
     public void testAddTwoNegativeRationalNumbers() {
         Rational expected = new Rational(-7, 6);
         Rational actual = new Rational(-1, 2).add(new Rational(-2, 3));
@@ -41,6 +45,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Add a rational number to its additive inverse")
     public void testAddARationalNumberToItsAdditiveInverse() {
         Rational expected = new Rational(0, 1);
         Rational actual = new Rational(1, 2).add(new Rational(-1, 2));
@@ -49,6 +54,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Subtract two positive rational numbers")
     public void testSubtractTwoPositiveRationalNumbers() {
         Rational expected = new Rational(-1, 6);
         Rational actual = new Rational(1, 2).subtract(new Rational(2, 3));
@@ -57,6 +63,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Subtract a positive rational number and a negative rational number")
     public void testSubtractAPositiveRationalNumberAndANegativeRationalNumber() {
         Rational expected = new Rational(7, 6);
         Rational actual = new Rational(1, 2).subtract(new Rational(-2, 3));
@@ -65,6 +72,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Subtract two negative rational numbers")
     public void testSubtractTwoNegativeRationalNumbers() {
         Rational expected = new Rational(1, 6);
         Rational actual = new Rational(-1, 2).subtract(new Rational(-2, 3));
@@ -73,6 +81,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Subtract a rational number from itself")
     public void testSubtractARationalNumberFromItself() {
         Rational expected = new Rational(0, 1);
         Rational actual = new Rational(1, 2).subtract(new Rational(1, 2));
@@ -81,6 +90,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Multiply two positive rational numbers")
     public void testMultiplyTwoPositiveRationalNumbers() {
         Rational expected = new Rational(1, 3);
         Rational actual = new Rational(1, 2).multiply(new Rational(2, 3));
@@ -89,6 +99,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Multiply a negative rational number by a positive rational number")
     public void testMultiplyANegativeRationalNumberByAPositiveRationalNumber() {
         Rational expected = new Rational(-1, 3);
         Rational actual = new Rational(-1, 2).multiply(new Rational(2, 3));
@@ -97,6 +108,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Multiply two negative rational numbers")
     public void testMultiplyTwoNegativeRationalNumbers() {
         Rational expected = new Rational(1, 3);
         Rational actual = new Rational(-1, 2).multiply(new Rational(-2, 3));
@@ -105,6 +117,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Multiply a rational number by its reciprocal")
     public void testMultiplyARationalNumberByItsReciprocal() {
         Rational expected = new Rational(1, 1);
         Rational actual = new Rational(1, 2).multiply(new Rational(2, 1));
@@ -113,6 +126,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Multiply a rational number by 1")
     public void testMultiplyARationalNumberByOne() {
         Rational expected = new Rational(1, 2);
         Rational actual = new Rational(1, 2).multiply(new Rational(1, 1));
@@ -121,6 +135,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Multiply a rational number by 0")
     public void testMultiplyARationalNumberByZero() {
         Rational expected = new Rational(0, 1);
         Rational actual = new Rational(1, 2).multiply(new Rational(0, 1));
@@ -129,6 +144,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Divide two positive rational numbers")
     public void testDivideTwoPositiveRationalNumbers() {
         Rational expected = new Rational(3, 4);
         Rational actual = new Rational(1, 2).divide(new Rational(2, 3));
@@ -137,6 +153,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Divide a positive rational number by a negative rational number")
     public void testDivideAPositiveRationalNumberByANegativeRationalNumber() {
         Rational expected = new Rational(-3, 4);
         Rational actual = new Rational(1, 2).divide(new Rational(-2, 3));
@@ -145,6 +162,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Divide two negative rational numbers")
     public void testDivideTwoNegativeRationalNumbers() {
         Rational expected = new Rational(3, 4);
         Rational actual = new Rational(-1, 2).divide(new Rational(-2, 3));
@@ -153,6 +171,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Divide a rational number by 1")
     public void testDivideARationalNumberByOne() {
         Rational expected = new Rational(1, 2);
         Rational actual = new Rational(1, 2).divide(new Rational(1, 1));
@@ -161,6 +180,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Absolute value of a positive rational number")
     public void testAbsoluteValueOfAPositiveRationalNumber() {
         Rational expected = new Rational(1, 2);
         Rational actual = new Rational(1, 2).abs();
@@ -169,6 +189,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Absolute value of a positive rational number with negative numerator and denominator")
     public void testAbsoluteValueOfAPositiveRationalNumberWithNegativeNumeratorAndDenominator() {
         Rational expected = new Rational(1, 2);
         Rational actual = new Rational(-1, -2).abs();
@@ -177,6 +198,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Absolute value of a negative rational number")
     public void testAbsoluteValueOfANegativeRationalNumber() {
         Rational expected = new Rational(1, 2);
         Rational actual = new Rational(-1, 2).abs();
@@ -185,6 +207,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("\"Absolute value of a negative rational number with negative denominator")
     public void testAbsoluteValueOfANegativeRationalNumberWithNegativeDenominator() {
         Rational expected = new Rational(1, 2);
         Rational actual = new Rational(1, -2).abs();
@@ -193,6 +216,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Absolute value of zero")
     public void testAbsoluteValueOfZero() {
         Rational expected = new Rational(0, 1);
         Rational actual = new Rational(0, 1).abs();
@@ -201,6 +225,7 @@ public class RationalTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Absolute value of a rational number is reduced to lowest terms")
     public void testAbsoluteValueOfARationalNumberIsReducedToLowestTerms() {
         Rational expected = new Rational(1, 2);
         Rational actual = new Rational(2, 4).abs();
@@ -209,6 +234,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Raise a positive rational number to a positive integer power")
     public void testRaiseAPositiveRationalNumberToAPositiveIntegerPower() {
         Rational expected = new Rational(1, 8);
         Rational actual = new Rational(1, 2).pow(3);
@@ -217,6 +243,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Raise a negative rational number to a positive integer power")
     public void testRaiseANegativeRationalNumberToAPositiveIntegerPower() {
         Rational expected = new Rational(-1, 8);
         Rational actual = new Rational(-1, 2).pow(3);
@@ -225,6 +252,7 @@ public class RationalTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Raise a positive rational number to a negative integer power")
     public void testRaiseAPositiveRationalNumberToANegativeIntegerPower() {
         Rational expected = new Rational(25, 9);
         Rational actual = new Rational(3, 5).pow(-2);
@@ -233,6 +261,7 @@ public class RationalTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("\"Raise a negative rational number to an even negative integer power")
     public void testRaiseANegativeRationalNumberToAnEvenNegativeIntegerPower() {
         Rational expected = new Rational(25, 9);
         Rational actual = new Rational(-3, 5).pow(-2);
@@ -241,6 +270,7 @@ public class RationalTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Raise a negative rational number to an odd negative integer power")
     public void testRaiseANegativeRationalNumberToAnOddNegativeIntegerPower() {
         Rational expected = new Rational(-125, 27);
         Rational actual = new Rational(-3, 5).pow(-3);
@@ -249,6 +279,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Raise zero to an integer power")
     public void testRaiseZeroToAnIntegerPower() {
         Rational expected = new Rational(0, 1);
         Rational actual = new Rational(0, 1).pow(5);
@@ -257,6 +288,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Raise one to an integer power")
     public void testRaiseOneToAnIntegerPower() {
         Rational expected = new Rational(1, 1);
         Rational actual = new Rational(1, 1).pow(4);
@@ -265,6 +297,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Raise a positive rational number to the power of zero")
     public void testRaiseAPositiveRationalNumberToThePowerOfZero() {
         Rational expected = new Rational(1, 1);
         Rational actual = new Rational(-1, 2).pow(0);
@@ -273,6 +306,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Raise a real number to a positive rational number")
     public void testRaiseARealNumberToAPositiveRationalNumber() {
         double expected = 16.0;
         double actual = new Rational(4, 3).exp(8.0);
@@ -281,6 +315,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Raise a real number to a negative rational number")
     public void testRaiseARealNumberToANegativeRationalNumber() {
         double expected = 1.0 / 3;
         double actual = new Rational(-1, 2).exp(9);
@@ -289,6 +324,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Reduce a positive rational number to lowest terms")
     public void testReduceAPositiveRationalNumberToLowestTerms() {
         Rational expected = new Rational(1, 2);
         Rational actual = new Rational(2, 4);
@@ -297,6 +333,7 @@ public class RationalTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Reduce places the minus sign on the numerator")
     public void testReducePlacesTheMinusSignOnTheNumerator() {
         Rational expected = new Rational(-3, 4);
         Rational actual = new Rational(3, -4);
@@ -305,6 +342,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Reduce a negative rational number to lowest terms")
     public void testReduceANegativeRationalNumberToLowestTerms() {
         Rational expected = new Rational(-2, 3);
         Rational actual = new Rational(-4, 6);
@@ -313,6 +351,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Reduce a rational number with a negative denominator to lowest terms")
     public void testReduceARationalNumberWithANegativeDenominatorToLowestTerms() {
         Rational expected = new Rational(-1, 3);
         Rational actual = new Rational(3, -9);
@@ -321,6 +360,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Reduce zero to lowest terms")
     public void testReduceZeroToLowestTerms() {
         Rational expected = new Rational(0, 1);
         Rational actual = new Rational(0, 6);
@@ -329,6 +369,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Reduce an integer to lowest terms")
     public void testReduceAnIntegerToLowestTerms() {
         Rational expected = new Rational(-2, 1);
         Rational actual = new Rational(-14, 7);
@@ -337,6 +378,7 @@ public class RationalTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Reduce one to lowest terms")
     public void testReduceOneToLowestTerms() {
         Rational expected = new Rational(1, 1);
         Rational actual = new Rational(13, 13);

--- a/exercises/practice/react/src/test/java/ReactTest.java
+++ b/exercises/practice/react/src/test/java/ReactTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -10,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ReactTest {
 
     @Test
+    @DisplayName("input cells have a value")
     public void testInputCellHasValue() {
         var input = React.inputCell(10);
 
@@ -18,6 +20,7 @@ public class ReactTest {
 
     @Disabled("Remove to run")
     @Test
+    @DisplayName("an input cell's value can be set")
     public void testInputCellValueCanBeSet() {
         var input = React.inputCell(4);
         input.setValue(20);
@@ -27,6 +30,7 @@ public class ReactTest {
 
     @Disabled("Remove to run")
     @Test
+    @DisplayName("compute cells calculate initial value")
     public void testComputeCellCalculateInitialValue() {
         var input = React.inputCell(1);
         var output = React.computeCell(list -> list.get(0) + 1, List.of(input));
@@ -36,6 +40,7 @@ public class ReactTest {
 
     @Disabled("Remove to run")
     @Test
+    @DisplayName("compute cells take inputs in the right order")
     public void testComputeCellsInTheRightOrder() {
         var first = React.inputCell(1);
         var second = React.inputCell(2);
@@ -46,6 +51,7 @@ public class ReactTest {
 
     @Disabled("Remove to run")
     @Test
+    @DisplayName("compute cells update value when dependencies are changed")
     public void testComputeCellsUpdateValueWhenDependenciesAreChanged() {
         var input = React.inputCell(1);
         var output = React.computeCell(list -> list.get(0) + 1, List.of(input));
@@ -56,6 +62,7 @@ public class ReactTest {
 
     @Disabled("Remove to run")
     @Test
+    @DisplayName("compute cells can depend on other compute cells")
     public void testComputeCellsCanDependOnOtherComputeCells() {
         var input = React.inputCell(1);
         var timesTwo = React.computeCell(list -> list.get(0) * 2, List.of(input));
@@ -70,6 +77,7 @@ public class ReactTest {
 
     @Disabled("Remove to run")
     @Test
+    @DisplayName("compute cells fire callbacks")
     public void testComputeCellsFireCallbacks() {
         var input = React.inputCell(1);
         var output = React.computeCell(list -> list.get(0) + 1, List.of(input));
@@ -83,6 +91,7 @@ public class ReactTest {
 
     @Disabled("Remove to run")
     @Test
+    @DisplayName("callback cells only fire on change")
     public void testCallbacksOnlyFireOnChange() {
         var input = React.inputCell(1);
         var output = React.computeCell(list -> list.get(0) < 3 ? 111 : 222, List.of(input));
@@ -99,6 +108,7 @@ public class ReactTest {
 
     @Disabled("Remove to run")
     @Test
+    @DisplayName("callbacks do not report already reported values")
     public void testCallbacksDoNotReportAlreadyReportedValues() {
         var input = React.inputCell(1);
         var output = React.computeCell(list -> list.get(0) + 1, List.of(input));
@@ -116,6 +126,7 @@ public class ReactTest {
 
     @Disabled("Remove to run")
     @Test
+    @DisplayName("callbacks can fire from multiple cells")
     public void testCallbacksCanFireFromMultipleCells() {
         var input = React.inputCell(1);
         var plusOne = React.computeCell(list -> list.get(0) + 1, List.of(input));
@@ -134,6 +145,7 @@ public class ReactTest {
 
     @Disabled("Remove to run")
     @Test
+    @DisplayName("callbacks can be added and removed")
     public void testCallbacksCanBeAddedAndRemoved() {
         var input = React.inputCell(11);
         var output = React.computeCell(list -> list.get(0) + 1, List.of(input));
@@ -166,6 +178,7 @@ public class ReactTest {
 
     @Disabled("Remove to run")
     @Test
+    @DisplayName("removing a callback multiple times doesn't interfere with other callbacks")
     public void testRemovingACallbackMultipleTimesDoesntInterfereWithOtherCallbacks() {
         var input = React.inputCell(1);
         var output = React.computeCell(list -> list.get(0) + 1, List.of(input));
@@ -189,6 +202,7 @@ public class ReactTest {
 
     @Disabled("Remove to run")
     @Test
+    @DisplayName("callbacks should only be called once even if multiple dependencies change")
     public void testCallbacksShouldOnlyBeCalledOnceEvenIfMultipleDependenciesChange() {
         var input = React.inputCell(1);
         var plusOne = React.computeCell(list -> list.get(0) + 1, List.of(input));
@@ -205,6 +219,7 @@ public class ReactTest {
 
     @Disabled("Remove to run")
     @Test
+    @DisplayName("callbacks should not be called if dependencies change but output value doesn't change")
     public void testCallbacksShouldNotBeCalledIfDependenciesChangeButOutputValueDoesntChange() {
         var input = React.inputCell(1);
         var plusOne = React.computeCell(list -> list.get(0) + 1, List.of(input));


### PR DESCRIPTION
# pull request

This PR adds @DisplayName annotations to the test methods for the following practice exercises:
pov
prime-factors
protein-translation
proverb
pythagorean-triplet
queen-attack
rail-fence-cipher
raindrops
rational-numbers
react

Descriptions were taken from the corresponding canonical-data.json files in the problem-specifications repo.


Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
