### PR TITLE
Add displayname annotations #2971

### DIFF
--- a/exercises/practice/saddle-points/src/test/java/MatrixTest.java
+++ b/exercises/practice/saddle-points/src/test/java/MatrixTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -12,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MatrixTest {
 
     @Test
+    @DisplayName("Can identify single saddle point")
     public void testCanIdentifySingleSaddlePoint() {
         Matrix matrix = new Matrix(Arrays.asList(
             Arrays.asList(9, 8, 7),
@@ -26,6 +28,7 @@ public class MatrixTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can identify that empty matrix has no saddle points")
     public void testCanIdentifyThatEmptyMatrixHasNoSaddlePoints() {
         Matrix matrix = new Matrix(new ArrayList<>());
 
@@ -36,6 +39,7 @@ public class MatrixTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can identify lack of saddle points when there are none")
     public void testCanIdentifyLackOfSaddlePointsWhenThereAreNone() {
         Matrix matrix = new Matrix(Arrays.asList(
             Arrays.asList(1, 2, 3),
@@ -50,6 +54,7 @@ public class MatrixTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can identify multiple saddle points in a column")
     public void testCanIdentifyMultipleSaddlePointsInAColumn() {
         Matrix matrix = new Matrix(Arrays.asList(
             Arrays.asList(4, 5, 4),
@@ -68,6 +73,7 @@ public class MatrixTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can identify multiple saddle points in a Row")
     public void testCanIdentifyMultipleSaddlePointsInARow() {
         Matrix matrix = new Matrix(Arrays.asList(
                 Arrays.asList(6, 7, 8),
@@ -86,6 +92,7 @@ public class MatrixTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can identify saddle point in bottom right corner")
     public void testCanIdentifySaddlePointInBottomRightCorner() {
         Matrix matrix = new Matrix(Arrays.asList(
             Arrays.asList(8, 7, 9),
@@ -100,6 +107,7 @@ public class MatrixTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can identify saddle points in a non square matrix")
     public void testCanIdentifySaddlePointsInANonSquareMatrix() {
         Matrix matrix = new Matrix(Arrays.asList(
                 Arrays.asList(3, 1, 3),
@@ -116,6 +124,7 @@ public class MatrixTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can identify that saddle points in a single column matrix are those with the minimum value")
     public void testCanIdentifyThatSaddlePointsInASingleColumnMatrixAreThoseWithMinimumValue() {
         Matrix matrix = new Matrix(Arrays.asList(
                 Collections.singletonList(2),
@@ -134,6 +143,7 @@ public class MatrixTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can identify that saddle points in a single row matrix are those with the maximum value")
     public void testCanIdentifyThatSaddlePointsInASingleRowMatrixAreThoseWithMaximumValue() {
         Matrix matrix = new Matrix(Arrays.asList(
                 Arrays.asList(2, 5, 3, 5)

--- a/exercises/practice/satellite/src/test/java/SatelliteTest.java
+++ b/exercises/practice/satellite/src/test/java/SatelliteTest.java
@@ -3,12 +3,14 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.List;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class SatelliteTest {
     Satellite satellite = new Satellite();
 
     @Test
+    @DisplayName("Empty tree")
     public void emptyTree() {
         List<Character> preorder = List.of();
         List<Character> inorder = List.of();
@@ -22,6 +24,7 @@ public class SatelliteTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Tree with one item")
     public void treeWithOneItem() {
         List<Character> preorder = List.of('a');
         List<Character> inorder = List.of('a');
@@ -35,6 +38,7 @@ public class SatelliteTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Tree with many items")
     public void treeWithManyItems() {
         List<Character> preorder = List.of('a', 'i', 'x', 'f', 'r');
         List<Character> inorder = List.of('i', 'a', 'f', 'x', 'r');
@@ -48,6 +52,7 @@ public class SatelliteTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Reject traversals of different length")
     public void rejectTraversalsOfDifferentLengths() {
         List<Character> preorder = List.of('a', 'b');
         List<Character> inorder = List.of('b', 'a', 'r');
@@ -60,6 +65,7 @@ public class SatelliteTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Reject inconsistent traversals of same length")
     public void rejectInconsistentTraversalsOfSameLength() {
         List<Character> preorder = List.of('x', 'y', 'z');
         List<Character> inorder = List.of('a', 'b', 'c');
@@ -71,6 +77,7 @@ public class SatelliteTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Reject traversals with repeated items")
     public void rejectTraversalsWithRepeatedItems() {
         List<Character> preorder = List.of('a', 'b', 'a');
         List<Character> inorder = List.of('b', 'a', 'a');

--- a/exercises/practice/say/src/test/java/SayTest.java
+++ b/exercises/practice/say/src/test/java/SayTest.java
@@ -1,5 +1,6 @@
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -8,102 +9,120 @@ public class SayTest {
     private Say say = new Say();
 
     @Test
+    @DisplayName("zero")
     public void zero() {
         assertThat(say.say(0)).isEqualTo("zero");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("one")
     public void one() {
         assertThat(say.say(1)).isEqualTo("one");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("fourteen")
     public void fourteen() {
         assertThat(say.say(14)).isEqualTo("fourteen");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("twenty")
     public void twenty() {
         assertThat(say.say(20)).isEqualTo("twenty");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("twenty-two")
     public void twentyTwo() {
         assertThat(say.say(22)).isEqualTo("twenty-two");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("thirty")
     public void thirty() {
         assertThat(say.say(30)).isEqualTo("thirty");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("ninety-nine")
     public void ninetyNine() {
         assertThat(say.say(99)).isEqualTo("ninety-nine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("one hundred")
     public void oneHundred() {
         assertThat(say.say(100)).isEqualTo("one hundred");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("one hundred twenty-three")
     public void oneHundredTwentyThree() {
         assertThat(say.say(123)).isEqualTo("one hundred twenty-three");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("two hundred")
     public void twoHundred() {
         assertThat(say.say(200)).isEqualTo("two hundred");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("nine hundred ninety-nine")
     public void nineHundredNinetyNine() {
         assertThat(say.say(999)).isEqualTo("nine hundred ninety-nine");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("one thousand")
     public void oneThousand() {
         assertThat(say.say(1_000)).isEqualTo("one thousand");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("one thousand two hundred thirty-four")
     public void oneThousandTwoHundredThirtyFour() {
         assertThat(say.say(1_234)).isEqualTo("one thousand two hundred thirty-four");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("one million")
     public void oneMillion() {
         assertThat(say.say(1_000_000)).isEqualTo("one million");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("one million two thousand three hundred forty-five")
     public void oneMillionTwoThousandThreeHundredFortyFive() {
         assertThat(say.say(1_002_345)).isEqualTo("one million two thousand three hundred forty-five");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("one billion")
     public void oneBillion() {
         assertThat(say.say(1_000_000_000)).isEqualTo("one billion");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("nine hundred eighty-seven billion six hundred " +
+            "fifty-four\nmillion three hundred twenty-one thousand one hundred twenty-three")
     public void nineHundredEightySevenBillionSixHundredFiftyFourThreeHundredTwentyOneThousandOneHundredTwentyThree() {
         assertThat(say.say(987_654_321_123L))
                 .isEqualTo("nine hundred eighty-seven billion six hundred fifty-four million" +
@@ -112,6 +131,7 @@ public class SayTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("numbers below zero are out of range")
     public void illegalNegativeNumber() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> say.say(-1));
@@ -119,6 +139,7 @@ public class SayTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("numbers above 999,999,999,999 are out of range")
     public void illegalTooBigNumber() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> say.say(1_000_000_000_000L));

--- a/exercises/practice/say/src/test/java/SayTest.java
+++ b/exercises/practice/say/src/test/java/SayTest.java
@@ -121,8 +121,7 @@ public class SayTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("nine hundred eighty-seven billion six hundred " +
-            "fifty-four\nmillion three hundred twenty-one thousand one hundred twenty-three")
+    @DisplayName("a big number")
     public void nineHundredEightySevenBillionSixHundredFiftyFourThreeHundredTwentyOneThousandOneHundredTwentyThree() {
         assertThat(say.say(987_654_321_123L))
                 .isEqualTo("nine hundred eighty-seven billion six hundred fifty-four million" +

--- a/exercises/practice/scrabble-score/src/test/java/ScrabbleScoreTest.java
+++ b/exercises/practice/scrabble-score/src/test/java/ScrabbleScoreTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -6,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ScrabbleScoreTest {
 
     @Test
+    @DisplayName("lowercase letter")
     public void testALowerCaseLetter() {
         Scrabble scrabble = new Scrabble("a");
         assertThat(scrabble.getScore()).isEqualTo(1);
@@ -13,6 +15,7 @@ public class ScrabbleScoreTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("uppercase letter")
     public void testAUpperCaseLetter() {
         Scrabble scrabble = new Scrabble("A");
         assertThat(scrabble.getScore()).isEqualTo(1);
@@ -20,6 +23,7 @@ public class ScrabbleScoreTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("valuable letter")
     public void testAValuableLetter() {
         Scrabble scrabble = new Scrabble("f");
         assertThat(scrabble.getScore()).isEqualTo(4);
@@ -27,6 +31,7 @@ public class ScrabbleScoreTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("short word")
     public void testAShortWord() {
         Scrabble scrabble = new Scrabble("at");
         assertThat(scrabble.getScore()).isEqualTo(2);
@@ -34,6 +39,7 @@ public class ScrabbleScoreTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("short, valuable word")
     public void testAShortValuableWord() {
         Scrabble scrabble = new Scrabble("zoo");
         assertThat(scrabble.getScore()).isEqualTo(12);
@@ -41,6 +47,7 @@ public class ScrabbleScoreTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("medium word")
     public void testAMediumWord() {
         Scrabble scrabble = new Scrabble("street");
         assertThat(scrabble.getScore()).isEqualTo(6);
@@ -48,6 +55,7 @@ public class ScrabbleScoreTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("medium, valuable word")
     public void testAMediumValuableWord() {
         Scrabble scrabble = new Scrabble("quirky");
         assertThat(scrabble.getScore()).isEqualTo(22);
@@ -55,6 +63,7 @@ public class ScrabbleScoreTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("long, mixed-case word")
     public void testALongMixCaseWord() {
         Scrabble scrabble = new Scrabble("OxyphenButazone");
         assertThat(scrabble.getScore()).isEqualTo(41);
@@ -62,6 +71,7 @@ public class ScrabbleScoreTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("english-like word")
     public void testAEnglishLikeWord() {
         Scrabble scrabble = new Scrabble("pinata");
         assertThat(scrabble.getScore()).isEqualTo(8);
@@ -69,6 +79,7 @@ public class ScrabbleScoreTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("empty input")
     public void testAnEmptyInput() {
         Scrabble scrabble = new Scrabble("");
         assertThat(scrabble.getScore()).isEqualTo(0);
@@ -76,6 +87,7 @@ public class ScrabbleScoreTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("entire alphabet available")
     public void testEntireAlphabetAvailable() {
         Scrabble scrabble = new Scrabble("abcdefghijklmnopqrstuvwxyz");
         assertThat(scrabble.getScore()).isEqualTo(87);

--- a/exercises/practice/secret-handshake/src/test/java/HandshakeCalculatorTest.java
+++ b/exercises/practice/secret-handshake/src/test/java/HandshakeCalculatorTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -8,30 +9,35 @@ public class HandshakeCalculatorTest {
     private final HandshakeCalculator handshakeCalculator = new HandshakeCalculator();
 
     @Test
+    @DisplayName("wink for 1")
     public void testThatInput1YieldsAWink() {
         assertThat(handshakeCalculator.calculateHandshake(1)).containsExactly(Signal.WINK);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("double blink for 10")
     public void testThatInput2YieldsADoubleBlink() {
         assertThat(handshakeCalculator.calculateHandshake(2)).containsExactly(Signal.DOUBLE_BLINK);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("close your eyes for 100")
     public void testThatInput4YieldsACloseYourEyes() {
         assertThat(handshakeCalculator.calculateHandshake(4)).containsExactly(Signal.CLOSE_YOUR_EYES);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("jump for 1000")
     public void testThatInput8YieldsAJump() {
         assertThat(handshakeCalculator.calculateHandshake(8)).containsExactly(Signal.JUMP);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("combine two actions")
     public void testAnInputThatYieldsTwoActions() {
         assertThat(handshakeCalculator.calculateHandshake(3))
                 .containsExactly(Signal.WINK, Signal.DOUBLE_BLINK);
@@ -39,6 +45,7 @@ public class HandshakeCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("reverse two actions")
     public void testAnInputThatYieldsTwoReversedActions() {
         assertThat(handshakeCalculator.calculateHandshake(19))
                 .containsExactly(Signal.DOUBLE_BLINK, Signal.WINK);
@@ -46,18 +53,21 @@ public class HandshakeCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("reversing one action gives the same action")
     public void testReversingASingleActionYieldsTheSameAction() {
         assertThat(handshakeCalculator.calculateHandshake(24)).containsExactly(Signal.JUMP);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("reversing no actions still gives no actions")
     public void testReversingNoActionsYieldsNoActions() {
         assertThat(handshakeCalculator.calculateHandshake(16)).isEmpty();
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("all possible actions")
     public void testInputThatYieldsAllActions() {
         assertThat(handshakeCalculator.calculateHandshake(15))
                 .containsExactly(Signal.WINK, Signal.DOUBLE_BLINK, Signal.CLOSE_YOUR_EYES, Signal.JUMP);
@@ -65,6 +75,7 @@ public class HandshakeCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("reverse all possible actions")
     public void testInputThatYieldsAllActionsReversed() {
         assertThat(handshakeCalculator.calculateHandshake(31))
                 .containsExactly(Signal.JUMP, Signal.CLOSE_YOUR_EYES, Signal.DOUBLE_BLINK, Signal.WINK);
@@ -72,6 +83,7 @@ public class HandshakeCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("do nothing for zero")
     public void testThatInput0YieldsNoActions() {
         assertThat(handshakeCalculator.calculateHandshake(0)).isEmpty();
     }

--- a/exercises/practice/secret-handshake/src/test/java/HandshakeCalculatorTest.java
+++ b/exercises/practice/secret-handshake/src/test/java/HandshakeCalculatorTest.java
@@ -88,27 +88,6 @@ public class HandshakeCalculatorTest {
         assertThat(handshakeCalculator.calculateHandshake(0)).isEmpty();
     }
 
-    @Disabled("Remove to run test")
-    @Test
-    public void testThatHandlesMoreThanFiveBinaryPlacesWithReversal() {
-        assertThat(handshakeCalculator.calculateHandshake(51))
-                .containsExactly(Signal.DOUBLE_BLINK, Signal.WINK);
-    }
-
-    @Disabled("Remove to run test")
-    @Test
-    public void testThatHandlesMoreThanFiveBinaryPlacesWithoutReversal() {
-        assertThat(handshakeCalculator.calculateHandshake(35))
-                .containsExactly(Signal.WINK, Signal.DOUBLE_BLINK);
-    }
-
-    @Disabled("Remove to run test")
-    @Test
-    public void testInputThatYieldsAllActionsFromMoreThanFiveBinaryPlaces() {
-        assertThat(handshakeCalculator.calculateHandshake(111))
-                .containsExactly(Signal.WINK, Signal.DOUBLE_BLINK, Signal.CLOSE_YOUR_EYES, Signal.JUMP);
-    }
-
     /* The following tests diverge from the canonical test data to test numbers with binary representation with 
      * more than five digits are correctly handled. For more details, check out issue #1965 here:
      * (https://github.com/exercism/java/issues/1965).

--- a/exercises/practice/secret-handshake/src/test/java/HandshakeCalculatorTest.java
+++ b/exercises/practice/secret-handshake/src/test/java/HandshakeCalculatorTest.java
@@ -107,6 +107,32 @@ public class HandshakeCalculatorTest {
     public void testInputThatYieldsAllActionsFromMoreThanFiveBinaryPlaces() {
         assertThat(handshakeCalculator.calculateHandshake(111))
                 .containsExactly(Signal.WINK, Signal.DOUBLE_BLINK, Signal.CLOSE_YOUR_EYES, Signal.JUMP);
+    /* The following tests diverge from the canonical test data to test numbers with binary representation with 
+     * more than five digits are correctly handled. For more details, check out issue #1965 here:
+     * (https://github.com/exercism/java/issues/1965).
+     */
+    @Disabled("Remove to run test")
+    @Test
+    @DisplayName("handles input with more than five bits with reversal")
+    public void testThatHandlesMoreThanFiveBinaryPlacesWithReversal() {
+        assertThat(handshakeCalculator.calculateHandshake(51))
+            .containsExactly(Signal.DOUBLE_BLINK, Signal.WINK);
+    }
+    
+    @Disabled("Remove to run test")
+    @Test
+    @DisplayName("handles input with more than five bits without reversal")
+    public void testThatHandlesMoreThanFiveBinaryPlacesWithoutReversal() {
+        assertThat(handshakeCalculator.calculateHandshake(35))
+            .containsExactly(Signal.WINK, Signal.DOUBLE_BLINK);
+    }
+    
+    @Disabled("Remove to run test")
+    @Test
+    @DisplayName("all actions for input with more than five bits")
+    public void testInputThatYieldsAllActionsFromMoreThanFiveBinaryPlaces() {
+        assertThat(handshakeCalculator.calculateHandshake(111))
+            .containsExactly(Signal.WINK, Signal.DOUBLE_BLINK, Signal.CLOSE_YOUR_EYES, Signal.JUMP);
     }
 
 }

--- a/exercises/practice/secret-handshake/src/test/java/HandshakeCalculatorTest.java
+++ b/exercises/practice/secret-handshake/src/test/java/HandshakeCalculatorTest.java
@@ -97,23 +97,23 @@ public class HandshakeCalculatorTest {
     @DisplayName("handles input with more than five bits with reversal")
     public void testThatHandlesMoreThanFiveBinaryPlacesWithReversal() {
         assertThat(handshakeCalculator.calculateHandshake(51))
-            .containsExactly(Signal.DOUBLE_BLINK, Signal.WINK);
+                .containsExactly(Signal.DOUBLE_BLINK, Signal.WINK);
     }
-    
+
     @Disabled("Remove to run test")
     @Test
     @DisplayName("handles input with more than five bits without reversal")
     public void testThatHandlesMoreThanFiveBinaryPlacesWithoutReversal() {
         assertThat(handshakeCalculator.calculateHandshake(35))
-            .containsExactly(Signal.WINK, Signal.DOUBLE_BLINK);
+                .containsExactly(Signal.WINK, Signal.DOUBLE_BLINK);
     }
-    
+
     @Disabled("Remove to run test")
     @Test
     @DisplayName("all actions for input with more than five bits")
     public void testInputThatYieldsAllActionsFromMoreThanFiveBinaryPlaces() {
         assertThat(handshakeCalculator.calculateHandshake(111))
-            .containsExactly(Signal.WINK, Signal.DOUBLE_BLINK, Signal.CLOSE_YOUR_EYES, Signal.JUMP);
+                .containsExactly(Signal.WINK, Signal.DOUBLE_BLINK, Signal.CLOSE_YOUR_EYES, Signal.JUMP);
     }
 
 }

--- a/exercises/practice/secret-handshake/src/test/java/HandshakeCalculatorTest.java
+++ b/exercises/practice/secret-handshake/src/test/java/HandshakeCalculatorTest.java
@@ -107,6 +107,8 @@ public class HandshakeCalculatorTest {
     public void testInputThatYieldsAllActionsFromMoreThanFiveBinaryPlaces() {
         assertThat(handshakeCalculator.calculateHandshake(111))
                 .containsExactly(Signal.WINK, Signal.DOUBLE_BLINK, Signal.CLOSE_YOUR_EYES, Signal.JUMP);
+    }
+
     /* The following tests diverge from the canonical test data to test numbers with binary representation with 
      * more than five digits are correctly handled. For more details, check out issue #1965 here:
      * (https://github.com/exercism/java/issues/1965).

--- a/exercises/practice/series/src/test/java/SeriesTest.java
+++ b/exercises/practice/series/src/test/java/SeriesTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -11,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 public class SeriesTest {
 
     @Test
+    @DisplayName("slices of one from one")
     public void slicesOfOneFromOne() {
         Series series = new Series("1");
         List<String> expected = Collections.singletonList("1");
@@ -20,6 +22,7 @@ public class SeriesTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("slices of one from two")
     public void slicesOfOneFromTwo() {
         Series series = new Series("12");
         List<String> expected = Arrays.asList("1", "2");
@@ -29,6 +32,7 @@ public class SeriesTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("slices of two")
     public void slicesOfTwo() {
         Series series = new Series("35");
         List<String> expected = Collections.singletonList("35");
@@ -38,6 +42,7 @@ public class SeriesTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("slices of two overlap")
     public void slicesOfTwoOverlap() {
         Series series = new Series("9142");
         List<String> expected = Arrays.asList("91", "14", "42");
@@ -47,6 +52,7 @@ public class SeriesTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("slices can include duplicates")
     public void slicesIncludeDuplicates() {
         Series series = new Series("777777");
         List<String> expected = Arrays.asList(
@@ -61,6 +67,7 @@ public class SeriesTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("slices of a long series")
     public void slicesOfLongSeries() {
         Series series = new Series("918493904243");
         List<String> expected = Arrays.asList(
@@ -79,6 +86,7 @@ public class SeriesTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("slice length is too large")
     public void sliceLengthIsToolarge() {
         Series series = new Series("12345");
 
@@ -89,6 +97,7 @@ public class SeriesTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("slice length is way too large")
     public void sliceLengthIsWayToolarge() {
         Series series = new Series("12345");
 
@@ -99,6 +108,7 @@ public class SeriesTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("slice length cannot be zero")
     public void sliceLengthZero() {
         Series series = new Series("12345");
 
@@ -109,6 +119,7 @@ public class SeriesTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("slice length cannot be negative")
     public void sliceLengthNegative() {
         Series series = new Series("123");
 
@@ -119,6 +130,7 @@ public class SeriesTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("empty series is invalid")
     public void emptySeries() {
 
         assertThatExceptionOfType(IllegalArgumentException.class)

--- a/exercises/practice/sgf-parsing/src/test/java/SgfParsingTest.java
+++ b/exercises/practice/sgf-parsing/src/test/java/SgfParsingTest.java
@@ -5,11 +5,13 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class SgfParsingTest {
 
     @Test
+    @DisplayName("empty input")
     public void emptyInput() {
         String input = "";
         assertThatExceptionOfType(SgfParsingException.class).as("tree missing")
@@ -18,6 +20,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("tree with no nodes")
     public void treeWithNoNodes() {
         String input = "()";
         assertThatExceptionOfType(SgfParsingException.class)
@@ -27,6 +30,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("node without tree")
     public void nodeWithoutTree() {
         String input = ";";
         assertThatExceptionOfType(SgfParsingException.class).as("tree missing")
@@ -35,6 +39,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("node without properties")
     public void nodeWithoutProperties() throws SgfParsingException {
         String input = "(;)";
         SgfNode expected = new SgfNode();
@@ -44,6 +49,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("single node tree")
     public void singleNodeTree() throws SgfParsingException {
         String input = "(;A[B])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("B")));
@@ -53,6 +59,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("multiple properties")
     public void multipleProperties() throws SgfParsingException {
         String input = "(;A[b]C[d])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("b"),
@@ -63,6 +70,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("properties without delimiter")
     public void propertiesWithoutDelimiter() {
         String input = "(;A)";
         assertThatExceptionOfType(SgfParsingException.class).as("properties without delimiter")
@@ -71,6 +79,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("all lowercase property")
     public void allLowercaseProperty() {
         String input = "(;a[b])";
         assertThatExceptionOfType(SgfParsingException.class).as("property must be in uppercase")
@@ -79,6 +88,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("upper and lowercase property")
     public void upperAndLowercaseProperty() {
         String input = "(;Aa[b])";
         assertThatExceptionOfType(SgfParsingException.class).as("property must be in uppercase")
@@ -87,6 +97,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("two nodes")
     public void twoNodes() throws SgfParsingException {
         String input = "(;A[B];B[C])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("B")),
@@ -99,6 +110,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("two child trees")
     public void twoChildTrees() throws SgfParsingException {
         String input = "(;A[B](;B[C])(;C[D]))";
         SgfNode expected = new SgfNode(Map.of("A", List.of("B")),
@@ -112,6 +124,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("multiple property values")
     public void multiplePropertyValues() throws SgfParsingException {
         String input = "(;A[b][c][d])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("b", "c", "d")));
@@ -121,6 +134,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("within property values, whitespace characters such as tab are converted to spaces")
     public void withinPropertyValueWhitespace() throws SgfParsingException {
         String input = "(;A[hello\t\tworld])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("hello  world")));
@@ -130,6 +144,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("within property values, newlines remain as newlines")
     public void withinPropertyValueNewline() throws SgfParsingException {
         String input = "(;A[hello\n\nworld])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("hello\n\nworld")));
@@ -139,6 +154,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("escaped closing bracket within property value becomes just a closing bracket")
     public void escapedClosingBracket() throws SgfParsingException {
         String input = "(;A[\\]])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("]")));
@@ -148,6 +164,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("escaped backslash in property value becomes just a backslash")
     public void escapedBacklash() throws SgfParsingException {
         String input = "(;A[\\\\])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("\\")));
@@ -157,6 +174,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("opening bracket within property value doesn't need to be escaped")
     public void openingBracketNeedNotToBeEscaped() throws SgfParsingException {
         String input = "(;A[x[y\\]z][foo]B[bar];C[baz])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("x[y]z", "foo"),
@@ -170,6 +188,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("semicolon in property value doesn't need to be escaped")
     public void semicolonNeedNotToBeEscaped() throws SgfParsingException {
         String input = "(;A[a;b][foo]B[bar];C[baz])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("a;b", "foo"),
@@ -183,6 +202,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("parentheses in property value don't need to be escaped")
     public void paranthesesNeedNotToBeEscaped() throws SgfParsingException {
         String input = "(;A[x(y)z][foo]B[bar];C[baz])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("x(y)z", "foo"),
@@ -196,6 +216,7 @@ public class SgfParsingTest {
 
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("escaped tab in property value is converted to space")
     public void escapedTab() throws SgfParsingException {
         String input = "(;A[hello\\\tworld])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("hello world")));
@@ -205,6 +226,7 @@ public class SgfParsingTest {
     
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("escaped newline in property value is converted to nothing at all")
     public void escapedNewline() throws SgfParsingException {
         String input = "(;A[hello\\\nworld])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("helloworld")));
@@ -215,6 +237,7 @@ public class SgfParsingTest {
     
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("escaped t and n in property value are just letters, not whitespace")
     public void escapedTAndN() throws SgfParsingException {
         String input = "(;A[\\t = t and \\n = n])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("t = t and n = n")));
@@ -225,6 +248,7 @@ public class SgfParsingTest {
     
     @Test
     @Disabled("Remove to run test")
+    @DisplayName("mixing various kinds of whitespace and escaped characters in property value")
     public void mixOfEscapedCharactersAndWhitespaces() throws SgfParsingException {
         String input = "(;A[\\]b\nc\\\nd\t\te\\\\ \\\n\\]])";
         SgfNode expected = new SgfNode(Map.of("A", List.of("]b\ncd  e\\ ]")));

--- a/exercises/practice/sieve/src/test/java/SieveTest.java
+++ b/exercises/practice/sieve/src/test/java/SieveTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -10,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SieveTest {
 
     @Test
+    @DisplayName("no primes under two")
     public void noPrimesUnder2() {
         Sieve sieve = new Sieve(1);
         List<Integer> expectedOutput = Collections.emptyList();
@@ -19,6 +21,7 @@ public class SieveTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("find first prime")
     public void findFirstPrime() {
         Sieve sieve = new Sieve(2);
         List<Integer> expectedOutput = Collections.singletonList(2);
@@ -28,6 +31,7 @@ public class SieveTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("find primes up to 10")
     public void findPrimesUpTo10() {
         Sieve sieve = new Sieve(10);
         List<Integer> expectedOutput = Arrays.asList(2, 3, 5, 7);
@@ -37,6 +41,7 @@ public class SieveTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("limit is prime")
     public void limitIsPrime() {
         Sieve sieve = new Sieve(13);
         List<Integer> expectedOutput = Arrays.asList(2, 3, 5, 7, 11, 13);
@@ -46,6 +51,7 @@ public class SieveTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("find primes up to 1000")
     public void findPrimesUpTo1000() {
         Sieve sieve = new Sieve(1000);
         List<Integer> expectedOutput = Arrays.asList(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61,

--- a/exercises/practice/simple-cipher/src/test/java/SimpleCipherTest.java
+++ b/exercises/practice/simple-cipher/src/test/java/SimpleCipherTest.java
@@ -37,8 +37,10 @@ public class SimpleCipherTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("Is reversible. I.e., if you apply decode in a encoded result, \n" +
-            "you must see the same plaintext encode parameter as a result of the decode method")
+    @DisplayName(
+            "Is reversible. I.e., if you apply decode in a encoded result, " +
+                    "you must see the same plaintext encode parameter as a result of the decode method"
+    )
     public void randomKeyCipherIsReversible() {
         String plainText = "abcdefghij";
         assertThat(randomKeyCipher.decode(randomKeyCipher.encode(plainText))).isEqualTo(plainText);

--- a/exercises/practice/simple-cipher/src/test/java/SimpleCipherTest.java
+++ b/exercises/practice/simple-cipher/src/test/java/SimpleCipherTest.java
@@ -73,8 +73,10 @@ public class SimpleCipherTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("Is reversible. I.e., if you apply decode in a encoded result, \n" +
-            "you must see the same plaintext encode parameter as a result of the decode method")
+    @DisplayName(
+        "Is reversible. I.e., if you apply decode in a encoded result, " +
+        "you must see the same plaintext encode parameter as a result of the decode method"
+    )
     public void substitutionCipherIsReversibleGivenKey() {
         String plainText = "abcdefghij";
         assertThat(substitutionCipher.decode(substitutionCipher.encode(plainText))).isEqualTo(plainText);

--- a/exercises/practice/simple-cipher/src/test/java/SimpleCipherTest.java
+++ b/exercises/practice/simple-cipher/src/test/java/SimpleCipherTest.java
@@ -1,5 +1,6 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +19,7 @@ public class SimpleCipherTest {
      * problem with shift ciphers, some characters will always output the key verbatim.
      */
     @Test
+    @DisplayName("Can encode")
     public void randomKeyCipherCanEncode() {
         String plainText = "aaaaaaaaaa";
         String cipherText = randomKeyCipher.getKey().substring(0, 10);
@@ -26,6 +28,7 @@ public class SimpleCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can decode")
     public void randomKeyCipherCanDecode() {
         String cipherText = "aaaaaaaaaa";
         assertThat(randomKeyCipher.decode(randomKeyCipher.getKey().substring(0, 10)))
@@ -34,6 +37,8 @@ public class SimpleCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Is reversible. I.e., if you apply decode in a encoded result, \n" +
+            "you must see the same plaintext encode parameter as a result of the decode method")
     public void randomKeyCipherIsReversible() {
         String plainText = "abcdefghij";
         assertThat(randomKeyCipher.decode(randomKeyCipher.encode(plainText))).isEqualTo(plainText);
@@ -41,12 +46,14 @@ public class SimpleCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Key is made only of lowercase letters")
     public void randomKeyCipherKeyIsLowercaseLetters() {
         assertThat(randomKeyCipher.getKey()).matches("^[a-z]+$");
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can encode")
     public void substitutionCipherCanEncode() {
         String plainText = "aaaaaaaaaa";
         String cipherText = "abcdefghij";
@@ -55,6 +62,7 @@ public class SimpleCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can decode")
     public void substitutionCipherCanDecode() {
         String plainText = "abcdefghij";
         String cipherText = "aaaaaaaaaa";
@@ -63,6 +71,8 @@ public class SimpleCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Is reversible. I.e., if you apply decode in a encoded result, \n" +
+            "you must see the same plaintext encode parameter as a result of the decode method")
     public void substitutionCipherIsReversibleGivenKey() {
         String plainText = "abcdefghij";
         assertThat(substitutionCipher.decode(substitutionCipher.encode(plainText))).isEqualTo(plainText);
@@ -70,6 +80,7 @@ public class SimpleCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can double shift encode")
     public void substitutionCipherCanDoubleShiftEncode() {
         String plainText = "iamapandabear";
         String cipherText = "qayaeaagaciai";
@@ -78,6 +89,7 @@ public class SimpleCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can wrap on encode")
     public void substitutionCipherCanWrapEncode() {
         String plainText = "zzzzzzzzzz";
         String cipherText = "zabcdefghi";
@@ -86,6 +98,7 @@ public class SimpleCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can wrap on decode")
     public void substitutionCipherCanWrapDecode() {
         String plainText = "zabcdefghi";
         String cipherText = "zzzzzzzzzz";
@@ -94,6 +107,7 @@ public class SimpleCipherTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Can decode messages longer than the key")
     public void substitutionCipherMessageLongerThanKey() {
         String plainText = "iamapandabear";
         String key = "abc";

--- a/exercises/practice/simple-cipher/src/test/java/SimpleCipherTest.java
+++ b/exercises/practice/simple-cipher/src/test/java/SimpleCipherTest.java
@@ -38,8 +38,8 @@ public class SimpleCipherTest {
     @Disabled("Remove to run test")
     @Test
     @DisplayName(
-            "Is reversible. I.e., if you apply decode in a encoded result, " +
-                    "you must see the same plaintext encode parameter as a result of the decode method"
+        "Is reversible. I.e., if you apply decode in a encoded result, " +
+        "you must see the same plaintext encode parameter as a result of the decode method"
     )
     public void randomKeyCipherIsReversible() {
         String plainText = "abcdefghij";

--- a/exercises/practice/space-age/src/test/java/SpaceAgeTest.java
+++ b/exercises/practice/space-age/src/test/java/SpaceAgeTest.java
@@ -1,4 +1,5 @@
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,6 +10,7 @@ public class SpaceAgeTest {
     private static final double MAXIMUM_DELTA = 1E-02;
 
     @Test
+    @DisplayName("age on Earth")
     public void ageOnEarth() {
         SpaceAge age = new SpaceAge(1000000000);
 
@@ -17,6 +19,7 @@ public class SpaceAgeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("age on Mercury")
     public void ageOnMercury() {
         SpaceAge age = new SpaceAge(2134835688);
 
@@ -25,6 +28,7 @@ public class SpaceAgeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("age on Venus")
     public void ageOnVenus() {
         SpaceAge age = new SpaceAge(189839836);
 
@@ -33,6 +37,7 @@ public class SpaceAgeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("age on Mars")
     public void ageOnMars() {
         SpaceAge age = new SpaceAge(2129871239L);
 
@@ -41,6 +46,7 @@ public class SpaceAgeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("age on Jupiter")
     public void ageOnJupiter() {
         SpaceAge age = new SpaceAge(901876382);
 
@@ -49,6 +55,7 @@ public class SpaceAgeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("age on Saturn")
     public void ageOnSaturn() {
         SpaceAge age = new SpaceAge(2000000000L);
 
@@ -57,6 +64,7 @@ public class SpaceAgeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("age on Uranus")
     public void ageOnUranus() {
         SpaceAge age = new SpaceAge(1210123456L);
 
@@ -65,6 +73,7 @@ public class SpaceAgeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("age on Neptune")
     public void ageOnNeptune() {
         SpaceAge age = new SpaceAge(1821023456L);
 

--- a/exercises/practice/spiral-matrix/src/test/java/SpiralMatrixBuilderTest.java
+++ b/exercises/practice/spiral-matrix/src/test/java/SpiralMatrixBuilderTest.java
@@ -1,5 +1,6 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,12 +15,14 @@ public class SpiralMatrixBuilderTest {
     }
 
     @Test
+    @DisplayName("empty spiral")
     public void testEmptySpiral() {
         assertThat(spiralMatrixBuilder.buildMatrixOfSize(0)).isEmpty();
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("trivial spiral")
     public void testTrivialSpiral() {
         int[][] expected = {
                 {1}
@@ -30,6 +33,7 @@ public class SpiralMatrixBuilderTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("spiral of size 2")
     public void testSpiralOfSize2() {
         int[][] expected = {
                 {1, 2},
@@ -41,6 +45,7 @@ public class SpiralMatrixBuilderTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("spiral of size 3")
     public void testSpiralOfSize3() {
         int[][] expected = {
                 {1, 2, 3},
@@ -53,6 +58,7 @@ public class SpiralMatrixBuilderTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("spiral of size 4")
     public void testSpiralOfSize4() {
         int[][] expected = {
                 { 1,  2,  3,  4},
@@ -66,6 +72,7 @@ public class SpiralMatrixBuilderTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("spiral of size 5")
     public void testSpiralOfSize5() {
         int[][] expected = {
                 { 1,  2,  3,  4,  5},

--- a/exercises/practice/state-of-tic-tac-toe/src/test/java/StateOfTicTacToeTest.java
+++ b/exercises/practice/state-of-tic-tac-toe/src/test/java/StateOfTicTacToeTest.java
@@ -1,5 +1,6 @@
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -14,6 +15,7 @@ public class StateOfTicTacToeTest {
     }
     
     @Test
+    @DisplayName("Finished game where X won via left column victory")
     public void testFinishedGameWhereXWonViaLeftColumnVictory() {
 
         assertThat(
@@ -23,6 +25,7 @@ public class StateOfTicTacToeTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where X won via middle column victory")
     public void testFinishedGameWhereXWonViaMiddleColumnVictory() {
 
         assertThat(
@@ -32,6 +35,7 @@ public class StateOfTicTacToeTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where X won via right column victory")
     public void testFinishedGameWhereXWonViaRightColumnVictory() {
 
         assertThat(
@@ -41,6 +45,7 @@ public class StateOfTicTacToeTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where O won via left column victory")
     public void testFinishedGameWhereOWonViaLeftColumnVictory() {
 
         assertThat(
@@ -50,6 +55,7 @@ public class StateOfTicTacToeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where O won via middle column victory")
     public void testFinishedGameWhereOWonViaMiddleColumnVictory() {
 
         assertThat(
@@ -59,6 +65,7 @@ public class StateOfTicTacToeTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where O won via right column victory")
     public void testFinishedGameWhereOWonViaRightColumnVictory() {
 
         assertThat(
@@ -68,6 +75,7 @@ public class StateOfTicTacToeTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where X won via top row victory")
     public void testFinishedGameWhereXWonViaTopRowVictory() {
 
         assertThat(
@@ -77,6 +85,7 @@ public class StateOfTicTacToeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where X won via middle row victory")
     public void testFinishedGameWhereXWonViaMiddleRowVictory() {
 
         assertThat(
@@ -86,6 +95,7 @@ public class StateOfTicTacToeTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where X won via middle row victory")
     public void testFinishedGameWhereXWonViaBottomRowVictory() {
 
         assertThat(
@@ -95,6 +105,7 @@ public class StateOfTicTacToeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where O won via top row victory")
     public void testFinishedGameWhereOWonViaTopRowVictory() {
 
         assertThat(
@@ -104,6 +115,7 @@ public class StateOfTicTacToeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where O won via middle row victory")
     public void testFinishedGameWhereOWonViaMiddleRowVictory() {
 
         assertThat(
@@ -113,6 +125,7 @@ public class StateOfTicTacToeTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where O won via bottom row victory")
     public void testFinishedGameWhereOWonViaBottomRowVictory() {
 
         assertThat(
@@ -122,6 +135,7 @@ public class StateOfTicTacToeTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where X won via falling diagonal victory")
     public void testFinishedGameWhereXWonViaFallingDiagonalVictory() {
 
         assertThat(
@@ -131,6 +145,7 @@ public class StateOfTicTacToeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where X won via rising diagonal victory")
     public void testFinishedGameWhereXWonViaRisingDiagonalVictory() {
 
         assertThat(
@@ -140,6 +155,7 @@ public class StateOfTicTacToeTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where O won via falling diagonal victory")
     public void testFinishedGameWhereOWonViaFallingDiagonalVictory() {
 
         assertThat(
@@ -149,6 +165,7 @@ public class StateOfTicTacToeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where O won via rising diagonal victory")
     public void testFinishedGameWhereOWonViaRisingDiagonalVictory() {
 
         assertThat(
@@ -158,6 +175,7 @@ public class StateOfTicTacToeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where X won via a row and a column victory")
     public void testFinishedGameWhereXWonViaARowAndAColumnVictory() {
 
         assertThat(
@@ -167,6 +185,7 @@ public class StateOfTicTacToeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Finished game where X won via two diagonal victories")
     public void testFinishedGameWhereXWonViaTwoDiagonalVictories() {
 
         assertThat(
@@ -176,6 +195,7 @@ public class StateOfTicTacToeTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Drawn games")
     public void testDraw() {
 
         assertThat(
@@ -185,6 +205,7 @@ public class StateOfTicTacToeTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Another draw")
     public void testAnotherDraw() {
         
         assertThat(
@@ -194,6 +215,7 @@ public class StateOfTicTacToeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Ongoing game: one move in")
     public void testOngoingGameOneMoveIn() {
 
         assertThat(
@@ -203,6 +225,7 @@ public class StateOfTicTacToeTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Ongoing game: two moves in")
     public void testOngoingGameTwoMovesIn() {
 
         assertThat(
@@ -212,6 +235,7 @@ public class StateOfTicTacToeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Ongoing game: five moves in")
     public void testOngoingGameFiveMovesIn() {
 
         assertThat(
@@ -221,6 +245,7 @@ public class StateOfTicTacToeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Invalid board: X went twice")
     public void testInvalidBoardXWentTwice() {
 
         assertThatExceptionOfType(IllegalArgumentException.class)
@@ -230,6 +255,7 @@ public class StateOfTicTacToeTest {
     
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Invalid board: O started")
     public void testInvalidBoardOStarted() {
 
         assertThatExceptionOfType(IllegalArgumentException.class)
@@ -239,6 +265,7 @@ public class StateOfTicTacToeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Invalid board")
     public void testInvalidBoard() {
 
         assertThatExceptionOfType(IllegalArgumentException.class)
@@ -248,6 +275,7 @@ public class StateOfTicTacToeTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("Invalid board: players kept playing after a win")
     public void testInvalidBoardPlayersKeptPlayingAfterAWin() {
 
         assertThatExceptionOfType(IllegalArgumentException.class)


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->

Add DisplayName annotations to multiple modules

This merge includes the addition of DisplayName annotations to the following exercises:
- state-of-tic-tac-toe
- spiral-matrix
- space-age
- simple-cipher
- sieve
- sgf-parsing
- series
- secret-handshake
- scrabble-score
- say
- satellite
- saddle-points

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
