### PR TITLE
Fix artifact upload to support both `results.txt` and `results.json` in test-changed-exercises

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -68,5 +68,7 @@ jobs:
         uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: test-results
-          path: exercises/**/build/results.txt
+          path: |
+            exercises/**/build/results.txt
+            exercises/**/build/results.json
         if: failure()


### PR DESCRIPTION
# pull request

Follow-up to #3026

When Gradle-related changes are detected, the `test-changed-exercises` script delegates to the `test-with-test-runner` script, which generates a `results.json` file rather than the `results.txt` file produced by `test-changed-exercises`. The `test-changed`  job in the workflow needs to upload whichever test result file is produced.

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
