### PR TITLE
Add @DisplayName to Zipper test methods (Issue #2971)

### DIFF
--- a/exercises/practice/zipper/src/test/java/ZipperTest.java
+++ b/exercises/practice/zipper/src/test/java/ZipperTest.java
@@ -1,6 +1,7 @@
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,12 +22,14 @@ public class ZipperTest {
     }
 
     @Test
+    @DisplayName("data is retained")
     public void testToTree() {
         assertThat(zipper.toTree()).isEqualTo(binaryTree);
     }
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("left, right and value")
     public void testLeftRightAndValue() {
         zipper = binaryTree.getRoot();
         assertThat(zipper.left.right.getValue()).isEqualTo(3);
@@ -34,6 +37,7 @@ public class ZipperTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("dead end")
     public void testDeadEnd() {
         zipper = binaryTree.getRoot();
         assertThat(zipper.left.left).isNull();
@@ -41,6 +45,7 @@ public class ZipperTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("tree from deep focus")
     public void testToTreeFromDeepFocus() {
         zipper = binaryTree.getRoot();
         assertThat(zipper.left.right.toTree()).isEqualTo(binaryTree);
@@ -48,6 +53,7 @@ public class ZipperTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("traversing up from top")
     public void testTraversingUpFromTop() {
         zipper = binaryTree.getRoot();
         assertThat(zipper.up).isNull();
@@ -55,6 +61,7 @@ public class ZipperTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("left, right, and up")
     public void testLeftRightAndUp() {
         zipper = binaryTree.getRoot();
         assertThat(zipper.left.up.right.up.left.right.getValue()).isEqualTo(3);
@@ -62,6 +69,7 @@ public class ZipperTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("test ability to descend multiple levels and return")
     public void testAbilityToReturnAfterMultipleLevelDescend() {
         zipper = binaryTree.getRoot();
         assertThat(zipper.left.right.up.up.getValue()).isEqualTo(1);
@@ -69,6 +77,7 @@ public class ZipperTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("set_value")
     public void testSetValue() {
         zipper = binaryTree.getRoot();
         zipper = zipper.left;
@@ -91,6 +100,7 @@ public class ZipperTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("set_value after traversing up")
     public void testSetValueAfterTraversingUp() {
         zipper = binaryTree.getRoot();
         zipper = zipper.left.right.up;
@@ -113,6 +123,7 @@ public class ZipperTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("set_left with leaf")
     public void testSetLeftWithLeaf() {
         zipper = binaryTree.getRoot();
         zipper = zipper.left;
@@ -138,6 +149,7 @@ public class ZipperTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("set_right with null")
     public void testSetRightWithNull() {
         zipper = binaryTree.getRoot();
         zipper = zipper.left;
@@ -151,6 +163,7 @@ public class ZipperTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("set_right with subtree")
     public void testSetRightWithSubtree() {
         BinaryTree subtree = new BinaryTree(6);
         subtree.getRoot().setLeft(new Zipper(7));
@@ -181,6 +194,7 @@ public class ZipperTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("set_value on deep focus")
     public void testSetValueOnDeepFocus() {
         zipper = binaryTree.getRoot();
         zipper = zipper.left.right;
@@ -203,6 +217,7 @@ public class ZipperTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("different paths to same zipper")
     public void differentPathToSameZipper() {
         Zipper zipper1 = binaryTree.getRoot().left.up.right;
         Zipper zipper2 = binaryTree.getRoot().right;


### PR DESCRIPTION
# pull request

<!-- Your content goes here: -->

I added `@DisplayName` to Zipper test methods based on the `canonical-data.json` for Zipper.

File modified: `exercises/practice/zipper/src/test/java/ZipperTest.java`

Verification: Tests and styles have passed using `./gradlew test` and `./gradlew check`.

Note: `import org.junit.jupiter.api.DisplayName;` was placed alphabetically in the imports.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
