### PR TITLE
Remove erroneous references to an input map

### DIFF
--- a/exercises/concept/international-calling-connoisseur/.docs/instructions.md
+++ b/exercises/concept/international-calling-connoisseur/.docs/instructions.md
@@ -31,7 +31,7 @@ dialingCodes.setDialingCode(679, "Fiji");
 
 ## 3. Lookup a dialing code's country
 
-Implement the `getCountry` method that takes a map of dialing codes and a dialing code and returns the country name with the dialing code.
+Implement the `getCountry` method that takes a dialing code and returns the country name with the dialing code.
 
 ```java
 DialingCodes dialingCodes = new DialingCodes();
@@ -63,7 +63,7 @@ dialingCodes.addNewDialingCode(39, "Vatican City");
 
 Its rare, but mistakes can be made.
 To correct the mistake, we will need to know what dialing code the country is currently mapped to.
-To find which dialing code needs to be corrected, implement the `findDialingCode` method that takes in a map of dialing codes and a country and returns the country's dialing code.
+To find which dialing code needs to be corrected, implement the `findDialingCode` method that takes a country and returns the country's dialing code.
 Return `null` if the country is _not_ in the map.
 
 ```java


### PR DESCRIPTION
Related to https://forum.exercism.org/t/java-an-error-in-international-calling-connoisseur/17249.

The docs contradict the rest of the exercise by referencing a map being passed in for these methods. Please mark this PR as tiny.