### PR TITLE
Add missing JUnit launcher

### DIFF
--- a/exercises/practice/hangman/build.gradle
+++ b/exercises/practice/hangman/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     testImplementation platform("org.junit:junit-bom:5.10.0")
     testImplementation "org.junit.jupiter:junit-jupiter"
     testImplementation "org.assertj:assertj-core:3.25.1"
+
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 test {

--- a/exercises/practice/rest-api/build.gradle
+++ b/exercises/practice/rest-api/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     testImplementation platform("org.junit:junit-bom:5.10.0")
     testImplementation "org.junit.jupiter:junit-jupiter"
     testImplementation "org.assertj:assertj-core:3.25.1"
+
+    testRuntimeOnly "org.junit.platform:junit-platform-launcher"
 }
 
 test {


### PR DESCRIPTION
For some reason, this was missing only from the hangman and rest-api exercises. It is required to run the tests from Gradle.

See https://docs.gradle.org/current/userguide/upgrading_version_8.html#test_framework_implementation_dependencies

Changes are to build file only. Should have no impact on solutions already submitted.

[no important files changed]

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
