### PR TITLE
Update setup JDK to use JDK 21

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
-      - name: Set up JDK 1.17
+      - name: Set up JDK 21
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e
         with:
-          java-version: 17
+          java-version: 21
           distribution: "temurin"
       - name: Check if tests compile cleanly with starter sources
         run: ./gradlew compileStarterTestJava --continue
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
-      - name: Set up JDK 1.17
+      - name: Set up JDK 21
         uses: actions/setup-java@f2beeb24e141e01a676f977032f5a29d81c9e27e
         with:
-          java-version: 17
+          java-version: 21
           distribution: "temurin"
       - name: Run checkstyle
         run: ./gradlew check --exclude-task test --continue


### PR DESCRIPTION
Updates the action to use a newer release. The action does not yet support Java 25.

# pull request

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
