### PR TITLE
Fix unchecked warnings

### DIFF
--- a/exercises/concept/lasagna/src/test/java/utils/Lasagna.java
+++ b/exercises/concept/lasagna/src/test/java/utils/Lasagna.java
@@ -8,18 +8,19 @@ public class Lasagna extends ReflectionProxy {
     }
 
     public int expectedMinutesInOven() {
-        return invokeMethod("expectedMinutesInOven", new Class[]{});
+        return invokeMethod("expectedMinutesInOven", Integer.class, new Class[]{});
     }
 
     public int remainingMinutesInOven(int actualMinutes) {
-        return invokeMethod("remainingMinutesInOven", new Class[]{int.class}, actualMinutes);
+        return invokeMethod("remainingMinutesInOven", Integer.class, new Class[]{int.class}, actualMinutes);
     }
 
     public int preparationTimeInMinutes(int amountLayers) {
-        return invokeMethod("preparationTimeInMinutes", new Class[]{int.class}, amountLayers);
+        return invokeMethod("preparationTimeInMinutes", Integer.class, new Class[]{int.class}, amountLayers);
     }
 
     public int totalTimeInMinutes(int amountLayers, int actualMinutes) {
-        return invokeMethod("totalTimeInMinutes", new Class[]{int.class, int.class}, amountLayers, actualMinutes);
+        return invokeMethod("totalTimeInMinutes", Integer.class, new Class[]{int.class, int.class},
+                amountLayers, actualMinutes);
     }
 }

--- a/exercises/concept/lasagna/src/test/java/utils/ReflectionProxy.java
+++ b/exercises/concept/lasagna/src/test/java/utils/ReflectionProxy.java
@@ -101,12 +101,14 @@ public abstract class ReflectionProxy {
     /**
      * Invokes a method from the target instance
      * @param methodName The name of the method
+     * @param returnType The class representing the expected return type
      * @param parameterTypes The list of parameter types
      * @param parameterValues The list with values for the method parameters
      * @param <T> The result type we expect the method to be
      * @return The value returned by the method
      */
-    protected  <T> T invokeMethod(String methodName, Class<?>[] parameterTypes, Object... parameterValues) {
+    protected <T> T invokeMethod(String methodName, Class<T> returnType, Class<?>[] parameterTypes,
+                                 Object... parameterValues) {
         if (target == null) {
             return null;
         }
@@ -114,13 +116,13 @@ public abstract class ReflectionProxy {
             // getDeclaredMethod is used to get protected/private methods
             Method method = target.getClass().getDeclaredMethod(methodName, parameterTypes);
             method.setAccessible(true);
-            return (T) method.invoke(target, parameterValues);
+            return returnType.cast(method.invoke(target, parameterValues));
         } catch (NoSuchMethodException e) {
             try {
                 // try getting it from parent class, but only public methods will work
                 Method method = target.getClass().getMethod(methodName, parameterTypes);
                 method.setAccessible(true);
-                return (T) method.invoke(target, parameterValues);
+                return returnType.cast(method.invoke(target, parameterValues));
             } catch (Exception ex) {
                 return null;
             }
@@ -381,7 +383,7 @@ public abstract class ReflectionProxy {
      * @return The result of 'toString' from the target instance
      */
     public String toString() {
-        return invokeMethod("toString", new Class[]{ });
+        return invokeMethod("toString", String.class, new Class[]{ });
     }
 
     /**
@@ -390,14 +392,14 @@ public abstract class ReflectionProxy {
      * @param <T> The type we are expecting it to be
      * @return The value of the property (if it exists)
      */
-    protected <T> T getPropertyValue(String propertyName) {
+    protected <T> T getPropertyValue(String propertyName, Class<T> propertyType) {
         if (target == null || !hasProperty(propertyName)) {
             return null;
         }
         try {
             Field field = target.getClass().getDeclaredField(propertyName);
             field.setAccessible(true);
-            return (T) field.get(target);
+            return propertyType.cast(field.get(target));
         } catch (Exception e) {
             return null;
         }

--- a/exercises/concept/wizards-and-warriors-2/src/test/java/GameMasterProxy.java
+++ b/exercises/concept/wizards-and-warriors-2/src/test/java/GameMasterProxy.java
@@ -12,23 +12,25 @@ public class GameMasterProxy extends ReflectionProxy {
     }
 
     public String describe(Character character) {
-        return invokeMethod("describe", new Class[] { Character.class }, character);
+        return invokeMethod("describe", String.class, new Class[] { Character.class }, character);
     }
 
     public String describe(Destination character) {
-        return invokeMethod("describe", new Class[] { Destination.class }, character);
+        return invokeMethod("describe", String.class, new Class[] { Destination.class }, character);
     }
 
     public String describe(TravelMethod character) {
-        return invokeMethod("describe", new Class[] { TravelMethod.class }, character);
+        return invokeMethod("describe", String.class, new Class[] { TravelMethod.class }, character);
     }
 
     public String describe(Character character, Destination destination, TravelMethod travelMethod) {
-        return invokeMethod("describe", new Class[] { Character.class, Destination.class, TravelMethod.class },
+        return invokeMethod("describe", String.class,
+                new Class[] { Character.class, Destination.class, TravelMethod.class },
                 character, destination, travelMethod);
     }
 
     public String describe(Character character, Destination destination) {
-        return invokeMethod("describe", new Class[] { Character.class, Destination.class }, character, destination);
+        return invokeMethod("describe", String.class, new Class[] { Character.class, Destination.class },
+                character, destination);
     }
 }

--- a/exercises/concept/wizards-and-warriors-2/src/test/java/ReflectionProxy.java
+++ b/exercises/concept/wizards-and-warriors-2/src/test/java/ReflectionProxy.java
@@ -117,12 +117,14 @@ public abstract class ReflectionProxy {
      * Invokes a method from the target instance
      *
      * @param methodName      The name of the method
+     * @param returnType      The class representing the expected return type
      * @param parameterTypes  The list of parameter types
      * @param parameterValues The list with values for the method parameters
      * @param <T>             The result type we expect the method to be
      * @return The value returned by the method
      */
-    protected <T> T invokeMethod(String methodName, Class<?>[] parameterTypes, Object... parameterValues) {
+    protected <T> T invokeMethod(String methodName, Class<T> returnType, Class<?>[] parameterTypes,
+                                 Object... parameterValues) {
         if (target == null) {
             throw new UnsupportedOperationException();
         }
@@ -131,12 +133,12 @@ public abstract class ReflectionProxy {
                 // getDeclaredMethod is used to get protected/private methods
                 Method method = target.getClass().getDeclaredMethod(methodName, parameterTypes);
                 method.setAccessible(true);
-                return (T) method.invoke(target, parameterValues);
+                return returnType.cast(method.invoke(target, parameterValues));
             } catch (NoSuchMethodException e) {
                 // try getting it from parent class, but only public methods will work
                 Method method = target.getClass().getMethod(methodName, parameterTypes);
                 method.setAccessible(true);
-                return (T) method.invoke(target, parameterValues);
+                return returnType.cast(method.invoke(target, parameterValues));
             }
         } catch (Exception e) {
             throw new UnsupportedOperationException(e);
@@ -360,7 +362,6 @@ public abstract class ReflectionProxy {
 
     /**
      * Proxy for the 'equals' method
-     *
      * @param obj The ReflexionProxy object you want to compare against
      * @return True if both targets are equal, false otherwise
      */
@@ -379,7 +380,6 @@ public abstract class ReflectionProxy {
 
     /**
      * Proxy for the 'hashCode' method
-     *
      * @return The hashCode from the target class
      */
     public int hashCode() {
@@ -397,28 +397,26 @@ public abstract class ReflectionProxy {
 
     /**
      * Proxy for the 'toString' method from the target class
-     *
      * @return The result of 'toString' from the target instance
      */
     public String toString() {
-        return invokeMethod("toString", new Class[]{});
+        return invokeMethod("toString", String.class, new Class[]{ });
     }
 
     /**
      * Gets a property value from the target instance (if it exists)
-     *
      * @param propertyName The name of the property
-     * @param <T>          The type we are expecting it to be
+     * @param <T> The type we are expecting it to be
      * @return The value of the property (if it exists)
      */
-    protected <T> T getPropertyValue(String propertyName) {
+    protected <T> T getPropertyValue(String propertyName, Class<T> propertyType) {
         if (target == null || !hasProperty(propertyName)) {
             return null;
         }
         try {
             Field field = target.getClass().getDeclaredField(propertyName);
             field.setAccessible(true);
-            return (T) field.get(target);
+            return propertyType.cast(field.get(target));
         } catch (Exception e) {
             return null;
         }
@@ -426,7 +424,6 @@ public abstract class ReflectionProxy {
 
     /**
      * Checks if the target class is abstract
-     *
      * @return True if the target class exists and is abstract, false otherwise
      */
     public boolean isAbstract() {
@@ -439,7 +436,6 @@ public abstract class ReflectionProxy {
 
     /**
      * Checks if the target class extends another
-     *
      * @param className The fully qualified name of the class it should extend
      * @return True if the target class extends the specified one, false otherwise
      */
@@ -458,7 +454,6 @@ public abstract class ReflectionProxy {
 
     /**
      * Checks if the target class is an interface
-     *
      * @return True if the target class exists and is an interface, false otherwise
      */
     public boolean isInterface() {
@@ -471,8 +466,7 @@ public abstract class ReflectionProxy {
 
     /**
      * Checks if a method is abstract
-     *
-     * @param name           The name of the method
+     * @param name The name of the method
      * @param parameterTypes The list of method parameter types
      * @return True if the method exists and is abstract, false otherwise
      */
@@ -491,8 +485,7 @@ public abstract class ReflectionProxy {
 
     /**
      * Checks if a method is protected
-     *
-     * @param name           The name of the method
+     * @param name The name of the method
      * @param parameterTypes The list of method parameter types
      * @return True if the method exists and is protected, false otherwise
      */
@@ -511,3 +504,4 @@ public abstract class ReflectionProxy {
 
     //endregion
 }
+

--- a/exercises/concept/wizards-and-warriors/src/test/java/ReflectionProxy.java
+++ b/exercises/concept/wizards-and-warriors/src/test/java/ReflectionProxy.java
@@ -99,12 +99,14 @@ public abstract class ReflectionProxy {
     /**
      * Invokes a method from the target instance
      * @param methodName The name of the method
+     * @param returnType The class representing the expected return type
      * @param parameterTypes The list of parameter types
      * @param parameterValues The list with values for the method parameters
      * @param <T> The result type we expect the method to be
      * @return The value returned by the method
      */
-    protected  <T> T invokeMethod(String methodName, Class<?>[] parameterTypes, Object... parameterValues) {
+    protected <T> T invokeMethod(String methodName, Class<T> returnType, Class<?>[] parameterTypes,
+                                 Object... parameterValues) {
         if (target == null) {
             return null;
         }
@@ -112,13 +114,13 @@ public abstract class ReflectionProxy {
             // getDeclaredMethod is used to get protected/private methods
             Method method = target.getClass().getDeclaredMethod(methodName, parameterTypes);
             method.setAccessible(true);
-            return (T) method.invoke(target, parameterValues);
+            return returnType.cast(method.invoke(target, parameterValues));
         } catch (NoSuchMethodException e) {
             try {
                 // try getting it from parent class, but only public methods will work
                 Method method = target.getClass().getMethod(methodName, parameterTypes);
                 method.setAccessible(true);
-                return (T) method.invoke(target, parameterValues);
+                return returnType.cast(method.invoke(target, parameterValues));
             } catch (Exception ex) {
                 return null;
             }
@@ -379,23 +381,24 @@ public abstract class ReflectionProxy {
      * @return The result of 'toString' from the target instance
      */
     public String toString() {
-        return invokeMethod("toString", new Class[]{ });
+        return invokeMethod("toString", String.class, new Class[]{ });
     }
 
     /**
      * Gets a property value from the target instance (if it exists)
      * @param propertyName The name of the property
+     * @param propertyType The class representing the property's type
      * @param <T> The type we are expecting it to be
      * @return The value of the property (if it exists)
      */
-    protected <T> T getPropertyValue(String propertyName) {
+    protected <T> T getPropertyValue(String propertyName, Class<T> propertyType) {
         if (target == null || !hasProperty(propertyName)) {
             return null;
         }
         try {
             Field field = target.getClass().getDeclaredField(propertyName);
             field.setAccessible(true);
-            return (T) field.get(target);
+            return propertyType.cast(field.get(target));
         } catch (Exception e) {
             return null;
         }

--- a/exercises/concept/wizards-and-warriors/src/test/java/WarriorProxy.java
+++ b/exercises/concept/wizards-and-warriors/src/test/java/WarriorProxy.java
@@ -6,14 +6,14 @@ class WarriorProxy extends ReflectionProxy {
     }
     
     public String toString() {
-        return invokeMethod("toString", new Class[0]);
+        return invokeMethod("toString", String.class, new Class[0]);
     }
 
     boolean isVulnerable() {
-        return invokeMethod("isVulnerable", new Class[0]);
+        return invokeMethod("isVulnerable", Boolean.class, new Class[0]);
     }
 
     int getDamagePoints(Fighter target) {
-        return invokeMethod("getDamagePoints", new Class[]{Fighter.class}, target);
+        return invokeMethod("getDamagePoints", Integer.class, new Class[]{Fighter.class}, target);
     }
 }

--- a/exercises/concept/wizards-and-warriors/src/test/java/WizardProxy.java
+++ b/exercises/concept/wizards-and-warriors/src/test/java/WizardProxy.java
@@ -6,18 +6,18 @@ class WizardProxy extends ReflectionProxy {
     }
 
     public String toString() {
-        return invokeMethod("toString", new Class[0]);
+        return invokeMethod("toString", String.class, new Class[0]);
     }
 
     boolean isVulnerable() {
-        return invokeMethod("isVulnerable", new Class[0]);
+        return invokeMethod("isVulnerable", Boolean.class, new Class[0]);
     }
 
     int getDamagePoints(Fighter target) {
-        return invokeMethod("getDamagePoints", new Class[]{Fighter.class}, target);
+        return invokeMethod("getDamagePoints", Integer.class, new Class[]{Fighter.class}, target);
     }
 
     void prepareSpell() {
-        invokeMethod("prepareSpell", new Class[0]);
+        invokeMethod("prepareSpell", Void.class, new Class[0]);
     }
 }


### PR DESCRIPTION
This change fixes "unchecked or unsafe operations" from the build.

Example of warning:

```
Note: /home/runner/work/java/java/exercises/concept/lasagna/src/test/java/utils/ReflectionProxy.java uses unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
```

See https://github.com/exercism/java/actions/runs/21096072319/job/60673664241#step:4:129

Changes do not effect outcome of tests.

[no important files changed]

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
