### PR TITLE
Fix deprecated Gradle features warning

### DIFF
--- a/exercises/build.gradle
+++ b/exercises/build.gradle
@@ -78,8 +78,8 @@ subprojects {
 
     // configuration of the linter
     checkstyle {
-      toolVersion '10.7.0'
-      configFile file("$rootDir/checkstyle.xml")
+      toolVersion = '10.7.0'
+      configFile = file("$rootDir/checkstyle.xml")
       sourceSets = [project.sourceSets.main, project.sourceSets.test]
     }
 


### PR DESCRIPTION
This change fixes the following warning from the CI builds:

  > Deprecated Gradle features were used in this build, making it incompatible with Gradle 10.

When warnings was turned on, Gradle was reporting:

  > Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated.`:81`
  > This is scheduled to be removed in Gradle 10.
  >
  > Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated.`:82`
  > This is scheduled to be removed in Gradle 10.

Example from CI: https://github.com/exercism/java/actions/runs/21563114872/job/62130171648#step:4:1426

# pull request

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
