### PR TITLE
Update Need for Speed drained battery instructions for clarity

### DIFF
--- a/exercises/concept/need-for-speed/.docs/instructions.md
+++ b/exercises/concept/need-for-speed/.docs/instructions.md
@@ -45,7 +45,7 @@ car.distanceDriven();
 
 ## 4. Check for a drained battery
 
-Update the `NeedForSpeed.drive()` method to drain the battery based on the car's battery drain. Also, implement the `NeedForSpeed.batteryDrained()` method that indicates if the battery is drained:
+Update the `NeedForSpeed.drive()` method to drain the battery based on the car's battery drain. Also, implement the `NeedForSpeed.batteryDrained()` method that indicates if the battery is too drained to drive:
 
 ```java
 int speed = 5;


### PR DESCRIPTION
The tests check that if battery level is 99/100 but battery drain would be 100, that the car is technically 'drained'. This PR updates the instructions to reflect this to avoid ambiguity. A greater change would be change the wording to not describe it as drained (i.e. `batteryDrained` -> `batteryEnough`) but that's more of a subjective change, so this  PR keeps to a smaller scope.

<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
