### PR TITLE
Remove tests accidentally added by resync

### DIFF
--- a/exercises/practice/largest-series-product/.meta/tests.toml
+++ b/exercises/practice/largest-series-product/.meta/tests.toml
@@ -58,6 +58,7 @@ include = false
 
 [6cf66098-a6af-4223-aab1-26aeeefc7402]
 description = "rejects empty string and nonzero span"
+include = false
 reimplements = "6d96c691-4374-4404-80ee-2ea8f3613dd4"
 
 [7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74]
@@ -69,4 +70,5 @@ include = false
 
 [c859f34a-9bfe-4897-9c2f-6d7f8598e7f0]
 description = "rejects negative span"
+include = false
 reimplements = "5fe3c0e5-a945-49f2-b584-f0814b4dd1ef"

--- a/exercises/practice/largest-series-product/src/test/java/LargestSeriesProductCalculatorTest.java
+++ b/exercises/practice/largest-series-product/src/test/java/LargestSeriesProductCalculatorTest.java
@@ -129,33 +129,11 @@ public class LargestSeriesProductCalculatorTest {
 
     @Disabled("Remove to run test")
     @Test
-    @DisplayName("rejects empty string and nonzero span")
-    public void testEmptyStringAndNonZeroSpanIsRejected() {
-        LargestSeriesProductCalculator calculator = new LargestSeriesProductCalculator("");
-
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> calculator.calculateLargestProductForSeriesLength(1))
-                .withMessage("Series length must be less than or equal to the length of the string to search.");
-    }
-
-    @Disabled("Remove to run test")
-    @Test
     @DisplayName("rejects invalid character in digits")
     public void testStringToSearchContainingNonDigitCharacterIsRejected() {
         assertThatExceptionOfType(IllegalArgumentException.class)
                 .isThrownBy(() -> new LargestSeriesProductCalculator("1234a5"))
                 .withMessage("String to search may only contain digits.");
-    }
-
-    @Disabled("Remove to run test")
-    @Test
-    @DisplayName("rejects negative span")
-    public void testNegativeSeriesLengthIsRejected() {
-        LargestSeriesProductCalculator calculator = new LargestSeriesProductCalculator("12345");
-
-        assertThatExceptionOfType(IllegalArgumentException.class)
-                .isThrownBy(() -> calculator.calculateLargestProductForSeriesLength(-1))
-                .withMessage("Series length must be non-negative.");
     }
 
     @Disabled("Remove to run test")
@@ -169,5 +147,4 @@ public class LargestSeriesProductCalculatorTest {
 
         assertThat(actualProduct).isEqualTo(expectedProduct);
     }
-
 }


### PR DESCRIPTION
According to the tests.toml, the removed tests reimplement tests that were once excluded. It is likely that there were accidentally added back when the tests were updated to sync back up with the problem specs.

Fixes #3107

<!-- Your content goes here: -->



<!-- DO NOT EDIT BELOW THIS LINE! -->
---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
