### PR TITLE
fix: config.json exercise status fields and game-of-life prerequisite bug

### DIFF
--- a/config.json
+++ b/config.json
@@ -95,7 +95,7 @@
           "if-else-statements",
           "switch-statement"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "squeaky-clean",
@@ -233,7 +233,8 @@
           "strings",
           "switch-statement",
           "constructors"
-        ]
+        ],
+        "status": "active"
       },
       {
         "slug": "tim-from-marketing",
@@ -245,7 +246,8 @@
         "prerequisites": [
           "if-else-statements",
           "strings"
-        ]
+        ],
+        "status": "active"
       },
       {
         "slug": "captains-log",
@@ -258,7 +260,8 @@
           "arrays",
           "numbers",
           "strings"
-        ]
+        ],
+        "status": "active"
       },
       {
         "slug": "booking-up-for-beauty",
@@ -270,7 +273,8 @@
         "prerequisites": [
           "numbers",
           "strings"
-        ]
+        ],
+        "status": "active"
       },
       {
         "slug": "wizards-and-warriors-2",
@@ -295,7 +299,8 @@
         ],
         "prerequisites": [
           "numbers"
-        ]
+        ],
+        "status": "active"
       },
       {
         "slug": "gotta-snatch-em-all",
@@ -308,7 +313,7 @@
           "lists",
           "generic-types"
         ],
-        "status": "beta"
+        "status": "active"
       },
       {
         "slug": "international-calling-connoisseur",
@@ -321,7 +326,8 @@
           "classes",
           "foreach-loops",
           "generic-types"
-        ]
+        ],
+        "status": "active"
       }
     ],
     "practice": [
@@ -981,7 +987,7 @@
         "practices": [],
         "prerequisites": [
           "arrays",
-          "if-statements"
+          "if-else-statements"
         ],
         "difficulty": 5
       },


### PR DESCRIPTION
A few config housekeeping items that have been sitting around.

**Missing status fields**

Six concept exercises had no `status` field at all in `config.json`: `logs-logs-logs`, `tim-from-marketing`, `captains-log`, `booking-up-for-beauty`, `secrets`, and `international-calling-connoisseur`. They all have complete implementations and tests, so each gets `"status": "active"`.

**Beta promotions**

`calculator-conundrum` and `gotta-snatch-em-all` are still marked `beta` but both have been in the track for a long time with no open issues. Promoting both to `active`.

**Bug: wrong prerequisite slug**

`game-of-life` lists `"if-statements"` as a prerequisite but that slug doesn't exist — the correct one is `"if-else-statements"`. One character difference but it silently breaks any tooling that validates prerequisite references.
