### PR TITLE
improve: expand strings intro and rewrite inheritance concept docs

### DIFF
--- a/concepts/inheritance/about.md
+++ b/concepts/inheritance/about.md
@@ -27,13 +27,13 @@ These concepts are very similar and are often confused.
 - Inheritance means that the child has an IS-A relationship with the parent class.
 
 ```java
-interface Animal() {
-    public void bark();
+interface Animal {
+    void makeSound();
 }
 
 class Dog implements Animal {
-    public void bark() {
-        System.out.println("Bark");
+    public void makeSound() {
+        System.out.println("Woof!");
     }
 }
 ```

--- a/concepts/inheritance/introduction.md
+++ b/concepts/inheritance/introduction.md
@@ -1,58 +1,88 @@
 # Introduction
 
-Inheritance is a core concept in OOP (Object-Oriented Programming).
-It represents an IS-A relationship.
-It literally means in programming as it means in english, inheriting features from parent (in programming features is normally functions and variables).
-
-Consider a class, `Animal` as shown,
+Inheritance lets one class build on top of another, reusing its fields and methods without rewriting them.
+The class being extended is called the **parent** (or superclass); the class doing the extending is the **child** (or subclass).
+The relationship is described as IS-A: a `Dog` IS-A `Animal`.
 
 ```java
-//Creating an Animal class with bark() as a member function.
 public class Animal {
-
-    public void bark() {
-        System.out.println("This is an animal");
+    public void makeSound() {
+        System.out.println("...");
     }
-
 }
 ```
 
-`Animal` is a parent class, because the properties this class has can be extended to all the animals in general.
-
-Consider an animal named `Lion`, having a class like,
+Use the `extends` keyword to inherit from a class:
 
 ```java
-//Lion class is a child class of Animal.
-public class Lion extends Animal {
+public class Dog extends Animal {
 
     @Override
-    public void bark() {
-        System.out.println("Lion here!!");
+    public void makeSound() {
+        System.out.println("Woof!");
     }
-
 }
 ```
 
 ~~~~exercism/note
-The `Override` annotation is used to indicate that a method in a subclass is overriding a method of its superclass.
-It's not strictly necessary but it's a best practice to use it.
+The `@Override` annotation tells the compiler that you intend to replace a parent method.
+It's not required, but it's considered good practice — the compiler will warn you if the method name doesn't actually match anything in the parent.
 ~~~~
 
-Now whenever we do,
+Because `Dog` extends `Animal`, a `Dog` instance can be stored in an `Animal` variable.
+The actual type at runtime decides which method runs — this is called **polymorphism**:
 
 ```java
-Animal animal = new Lion(); //creating instance of Animal, of type Lion
-animal.bark();
+Animal animal = new Dog();
+animal.makeSound(); // prints "Woof!", not "..."
 ```
 
-Note: Initialising the `Animal` class with `Lion`.
-The output will look like
+## The `super` keyword
+
+Inside a child class, `super` refers to the parent.
+You can use it to call the parent's constructor or a method you've overridden:
 
 ```java
-Lion here!!
+public class Dog extends Animal {
+    private String name;
+
+    public Dog(String name) {
+        super(); // calls Animal's constructor
+        this.name = name;
+    }
+
+    @Override
+    public void makeSound() {
+        super.makeSound(); // calls Animal's version first
+        System.out.println(name + " says: Woof!");
+    }
+}
 ```
 
-According to OOP, there are many types of inheritance, but Java supports only some of them (Multi-level and Hierarchical).
-To read more about it, please read [this][java-inheritance].
+## Abstract classes
 
-[java-inheritance]: https://www.javatpoint.com/inheritance-in-java#:~:text=On%20the%20basis%20of%20class,will%20learn%20about%20interfaces%20later.
+If it doesn't make sense to instantiate the parent directly, mark it `abstract`.
+An abstract class can declare methods without providing a body — each subclass is then required to implement them:
+
+```java
+public abstract class Shape {
+    public abstract double area(); // subclasses must implement this
+}
+
+public class Circle extends Shape {
+    private double radius;
+
+    public Circle(double radius) {
+        this.radius = radius;
+    }
+
+    @Override
+    public double area() {
+        return Math.PI * radius * radius;
+    }
+}
+```
+
+To read more about inheritance in Java, see the [official documentation][java-inheritance].
+
+[java-inheritance]: https://docs.oracle.com/javase/tutorial/java/IandI/subclasses.html

--- a/concepts/strings/introduction.md
+++ b/concepts/strings/introduction.md
@@ -7,7 +7,64 @@ Double quotes are used to define a `String` instance:
 String fruit = "Apple";
 ```
 
-Strings are manipulated by calling the string's methods.
-Once a string has been constructed, its value can never change.
-Any methods that appear to modify a string will actually return a new string.
-The `String` class provides some _static_ methods to transform the strings.
+## Common string operations
+
+Strings expose a rich set of methods. Here are the ones you'll reach for most often:
+
+```java
+String s = "Hello, World!";
+
+s.length();             // 13
+s.toLowerCase();        // "hello, world!"
+s.toUpperCase();        // "HELLO, WORLD!"
+s.trim();               // removes leading/trailing whitespace
+s.contains("World");    // true
+s.startsWith("Hello");  // true
+s.endsWith("!");        // true
+s.indexOf("World");     // 7
+s.substring(7, 12);     // "World"
+s.replace("World", "Java"); // "Hello, Java!"
+s.split(", ");          // ["Hello", "World!"]
+```
+
+## Strings are immutable
+
+Once a string is created, its value never changes.
+Any method that appears to modify a string actually returns a new one — the original is untouched:
+
+```java
+String original = "hello";
+String upper = original.toUpperCase();
+// original is still "hello", upper is "HELLO"
+```
+
+## Comparing strings
+
+Use `.equals()` to compare string values — never `==`, which only checks if two variables point to the same object:
+
+```java
+String a = "hello";
+String b = "hello";
+a.equals(b);            // true  (correct)
+a.equalsIgnoreCase(b);  // true  (case-insensitive version)
+```
+
+## Building strings dynamically
+
+When you need to construct a string piece by piece (e.g. inside a loop), use `StringBuilder` instead of concatenating with `+`.
+Each `+` on a `String` creates a new object, which gets expensive fast:
+
+```java
+StringBuilder sb = new StringBuilder();
+sb.append("Hello");
+sb.append(", ");
+sb.append("World!");
+String result = sb.toString(); // "Hello, World!"
+```
+
+For simple one-liner formatting, `String.format` is handy:
+
+```java
+String.format("Hello, %s! You are %d years old.", "Alice", 30);
+// "Hello, Alice! You are 30 years old."
+```


### PR DESCRIPTION
Quality improvements to two concept docs that had real problems.

**strings/introduction.md**

The existing file was 13 lines and only mentioned that strings exist and "have methods". Expanded it to cover the most commonly used String methods with examples, explain immutability properly, show why `.equals()` matters over `==`, and introduce `StringBuilder` and `String.format` for building strings dynamically.

**inheritance/introduction.md**

Rewrote this one from scratch. The old version had a few issues:
- Used `bark()` on a parent `Animal` class — semantically odd since lions don't bark
- "It literally means in programming as it means in english" is awkward
- Only linked to javatpoint.com instead of the Oracle docs
- Didn't mention `super` or abstract classes at all

The rewrite uses a proper `makeSound()` method, introduces `super` with a real example, covers abstract classes, and links to the official Java tutorial.

**inheritance/about.md**

Fixed a syntax error in the interface example: `interface Animal()` — interfaces don't have `()` after the name. Changed to `interface Animal` and updated the method signature to `makeSound()` to match the introduction.
