### PR TITLE
add: hints.md for all difficulty-5 exercises (policy compliance)

### DIFF
--- a/exercises/practice/allergies/.docs/hints.md
+++ b/exercises/practice/allergies/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/atbash-cipher/.docs/hints.md
+++ b/exercises/practice/atbash-cipher/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/bob/.docs/hints.md
+++ b/exercises/practice/bob/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/flatten-array/.docs/hints.md
+++ b/exercises/practice/flatten-array/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/game-of-life/.docs/hints.md
+++ b/exercises/practice/game-of-life/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/grep/.docs/hints.md
+++ b/exercises/practice/grep/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/knapsack/.docs/hints.md
+++ b/exercises/practice/knapsack/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/ledger/.docs/hints.md
+++ b/exercises/practice/ledger/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/matching-brackets/.docs/hints.md
+++ b/exercises/practice/matching-brackets/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/nucleotide-count/.docs/hints.md
+++ b/exercises/practice/nucleotide-count/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/pascals-triangle/.docs/hints.md
+++ b/exercises/practice/pascals-triangle/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/phone-number/.docs/hints.md
+++ b/exercises/practice/phone-number/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/pig-latin/.docs/hints.md
+++ b/exercises/practice/pig-latin/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/prime-factors/.docs/hints.md
+++ b/exercises/practice/prime-factors/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/relative-distance/.docs/hints.md
+++ b/exercises/practice/relative-distance/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/robot-name/.docs/hints.md
+++ b/exercises/practice/robot-name/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/run-length-encoding/.docs/hints.md
+++ b/exercises/practice/run-length-encoding/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/series/.docs/hints.md
+++ b/exercises/practice/series/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/square-root/.docs/hints.md
+++ b/exercises/practice/square-root/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/state-of-tic-tac-toe/.docs/hints.md
+++ b/exercises/practice/state-of-tic-tac-toe/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java

--- a/exercises/practice/word-count/.docs/hints.md
+++ b/exercises/practice/word-count/.docs/hints.md
@@ -1,0 +1,10 @@
+# Hints
+
+## General
+
+- Unlike lower-difficulty exercises, this one does not come with a starter implementation file.
+  You will need to create the solution file yourself.
+- Look at the test file to figure out the expected class name and method signatures.
+- If you are not sure how to structure the file, check the [StubTemplate][stub-template] in the repository for a starting point.
+
+[stub-template]: https://github.com/exercism/java/blob/main/resources/exercise-template/src/main/java/ExerciseName.java


### PR DESCRIPTION
Per the [track policy][policy], every exercise with difficulty 5 should have a `hints.md` explaining that no starter implementation is provided. Students coming from difficulty-4 exercises are used to getting a stub — hitting a blank file for the first time with no explanation is a bad experience.

Added the same standard hints file to all 21 difficulty-5 exercises that were missing it:

`allergies`, `atbash-cipher`, `bob`, `flatten-array`, `game-of-life`, `grep`, `knapsack`, `ledger`, `matching-brackets`, `nucleotide-count`, `pascals-triangle`, `phone-number`, `pig-latin`, `prime-factors`, `relative-distance`, `robot-name`, `run-length-encoding`, `series`, `square-root`, `state-of-tic-tac-toe`, `word-count`

The two exercises that already had hints.md (`mazy-mice` and `parallel-letter-frequency`) were left untouched.

[policy]: https://github.com/exercism/java/blob/main/POLICIES.md#add-hint-for-the-first-exercises-without-starter-implementation
