### PR TITLE
add: hints.md for difficulty 1-2 exercises referencing hello-world tutorial

### DIFF
--- a/exercises/practice/armstrong-numbers/.docs/hints.md
+++ b/exercises/practice/armstrong-numbers/.docs/hints.md
@@ -1,0 +1,9 @@
+# Hints
+
+## Getting started
+
+New to the Java track? The Hello World exercise includes a detailed [Tutorial][tutorial]
+that walks you through setting up your environment and submitting your first solution.
+It is worth reading even if you have used Exercism before, since it covers Java-specific tooling.
+
+[tutorial]: https://exercism.org/tracks/java/exercises/hello-world

--- a/exercises/practice/darts/.docs/hints.md
+++ b/exercises/practice/darts/.docs/hints.md
@@ -1,0 +1,9 @@
+# Hints
+
+## Getting started
+
+New to the Java track? The Hello World exercise includes a detailed [Tutorial][tutorial]
+that walks you through setting up your environment and submitting your first solution.
+It is worth reading even if you have used Exercism before, since it covers Java-specific tooling.
+
+[tutorial]: https://exercism.org/tracks/java/exercises/hello-world

--- a/exercises/practice/dnd-character/.docs/hints.md
+++ b/exercises/practice/dnd-character/.docs/hints.md
@@ -1,0 +1,9 @@
+# Hints
+
+## Getting started
+
+New to the Java track? The Hello World exercise includes a detailed [Tutorial][tutorial]
+that walks you through setting up your environment and submitting your first solution.
+It is worth reading even if you have used Exercism before, since it covers Java-specific tooling.
+
+[tutorial]: https://exercism.org/tracks/java/exercises/hello-world

--- a/exercises/practice/dot-dsl/.docs/hints.md
+++ b/exercises/practice/dot-dsl/.docs/hints.md
@@ -1,0 +1,9 @@
+# Hints
+
+## Getting started
+
+New to the Java track? The Hello World exercise includes a detailed [Tutorial][tutorial]
+that walks you through setting up your environment and submitting your first solution.
+It is worth reading even if you have used Exercism before, since it covers Java-specific tooling.
+
+[tutorial]: https://exercism.org/tracks/java/exercises/hello-world

--- a/exercises/practice/grains/.docs/hints.md
+++ b/exercises/practice/grains/.docs/hints.md
@@ -1,0 +1,9 @@
+# Hints
+
+## Getting started
+
+New to the Java track? The Hello World exercise includes a detailed [Tutorial][tutorial]
+that walks you through setting up your environment and submitting your first solution.
+It is worth reading even if you have used Exercism before, since it covers Java-specific tooling.
+
+[tutorial]: https://exercism.org/tracks/java/exercises/hello-world

--- a/exercises/practice/high-scores/.docs/hints.md
+++ b/exercises/practice/high-scores/.docs/hints.md
@@ -1,0 +1,9 @@
+# Hints
+
+## Getting started
+
+New to the Java track? The Hello World exercise includes a detailed [Tutorial][tutorial]
+that walks you through setting up your environment and submitting your first solution.
+It is worth reading even if you have used Exercism before, since it covers Java-specific tooling.
+
+[tutorial]: https://exercism.org/tracks/java/exercises/hello-world

--- a/exercises/practice/leap/.docs/hints.md
+++ b/exercises/practice/leap/.docs/hints.md
@@ -1,0 +1,9 @@
+# Hints
+
+## Getting started
+
+New to the Java track? The Hello World exercise includes a detailed [Tutorial][tutorial]
+that walks you through setting up your environment and submitting your first solution.
+It is worth reading even if you have used Exercism before, since it covers Java-specific tooling.
+
+[tutorial]: https://exercism.org/tracks/java/exercises/hello-world

--- a/exercises/practice/resistor-color-duo/.docs/hints.md
+++ b/exercises/practice/resistor-color-duo/.docs/hints.md
@@ -1,0 +1,9 @@
+# Hints
+
+## Getting started
+
+New to the Java track? The Hello World exercise includes a detailed [Tutorial][tutorial]
+that walks you through setting up your environment and submitting your first solution.
+It is worth reading even if you have used Exercism before, since it covers Java-specific tooling.
+
+[tutorial]: https://exercism.org/tracks/java/exercises/hello-world

--- a/exercises/practice/resistor-color-trio/.docs/hints.md
+++ b/exercises/practice/resistor-color-trio/.docs/hints.md
@@ -1,0 +1,9 @@
+# Hints
+
+## Getting started
+
+New to the Java track? The Hello World exercise includes a detailed [Tutorial][tutorial]
+that walks you through setting up your environment and submitting your first solution.
+It is worth reading even if you have used Exercism before, since it covers Java-specific tooling.
+
+[tutorial]: https://exercism.org/tracks/java/exercises/hello-world

--- a/exercises/practice/resistor-color/.docs/hints.md
+++ b/exercises/practice/resistor-color/.docs/hints.md
@@ -1,0 +1,9 @@
+# Hints
+
+## Getting started
+
+New to the Java track? The Hello World exercise includes a detailed [Tutorial][tutorial]
+that walks you through setting up your environment and submitting your first solution.
+It is worth reading even if you have used Exercism before, since it covers Java-specific tooling.
+
+[tutorial]: https://exercism.org/tracks/java/exercises/hello-world

--- a/exercises/practice/reverse-string/.docs/hints.md
+++ b/exercises/practice/reverse-string/.docs/hints.md
@@ -1,0 +1,9 @@
+# Hints
+
+## Getting started
+
+New to the Java track? The Hello World exercise includes a detailed [Tutorial][tutorial]
+that walks you through setting up your environment and submitting your first solution.
+It is worth reading even if you have used Exercism before, since it covers Java-specific tooling.
+
+[tutorial]: https://exercism.org/tracks/java/exercises/hello-world

--- a/exercises/practice/rna-transcription/.docs/hints.md
+++ b/exercises/practice/rna-transcription/.docs/hints.md
@@ -1,0 +1,9 @@
+# Hints
+
+## Getting started
+
+New to the Java track? The Hello World exercise includes a detailed [Tutorial][tutorial]
+that walks you through setting up your environment and submitting your first solution.
+It is worth reading even if you have used Exercism before, since it covers Java-specific tooling.
+
+[tutorial]: https://exercism.org/tracks/java/exercises/hello-world

--- a/exercises/practice/two-fer/.docs/hints.md
+++ b/exercises/practice/two-fer/.docs/hints.md
@@ -1,0 +1,9 @@
+# Hints
+
+## Getting started
+
+New to the Java track? The Hello World exercise includes a detailed [Tutorial][tutorial]
+that walks you through setting up your environment and submitting your first solution.
+It is worth reading even if you have used Exercism before, since it covers Java-specific tooling.
+
+[tutorial]: https://exercism.org/tracks/java/exercises/hello-world


### PR DESCRIPTION
Per the [track policy][policy], every exercise with difficulty less than 3 should have a `hints.md` pointing students to the Hello World tutorial. The tutorial walks through the full workflow of downloading, solving, and submitting — useful context for anyone just getting started on the track.

Added the hints file to all 13 difficulty 1-2 exercises that were missing it:

`leap`, `reverse-string`, `two-fer`, `armstrong-numbers`, `darts`, `dnd-character`, `dot-dsl`, `grains`, `high-scores`, `resistor-color`, `resistor-color-duo`, `resistor-color-trio`, `rna-transcription`

[policy]: https://github.com/exercism/java/blob/main/POLICIES.md#reference-tutorial-in-the-first-exercises
