### PR TITLE
Add lint-changed task in Java workflow

### DIFF
--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -25,8 +25,9 @@ jobs:
         run: ./gradlew compileStarterTestJava --continue
         working-directory: exercises
 
-  lint:
-    name: Lint Java files using Checkstyle
+  lint-all:
+    name: Lint all Java files using Checkstyle
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -38,6 +39,22 @@ jobs:
       - name: Run checkstyle
         run: ./gradlew check --exclude-task test --continue
         working-directory: exercises
+
+  lint-changed:
+    name: Lint changed Java exercises using Checkstyle
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+      - name: Set up JDK 21
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654
+        with:
+          java-version: 21
+          distribution: "temurin"
+      - name: Lint changed exercises
+        run: bin/lint-changed-exercise
 
   test-all:
     name: Test all exercises using java-test-runner

--- a/bin/lint-changed-exercise
+++ b/bin/lint-changed-exercise
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Determine the base branch of the PR
+BASE_BRANCH=${GITHUB_BASE_REF:-main}
+
+# Fetch full history for proper diff
+git fetch origin "$BASE_BRANCH"
+
+# Compute merge base
+MERGE_BASE=$(git merge-base HEAD origin/"$BASE_BRANCH")
+
+# Get changed files relative to merge base
+changed_files=$(git diff --name-only "$MERGE_BASE" HEAD)
+
+# If any Gradle build file changed, run the full suite and exit
+if echo "$changed_files" | grep -qE '\.(gradle|gradlew|bat)$|settings\.gradle'; then
+  echo "Gradle build files changed, running full lint suite..."
+  cd exercises && ./gradlew check --exclude-task test --continue
+  exit 0
+fi
+
+# Extract unique exercise directories
+changed_exercises=$(echo "$changed_files" | \
+  grep -E '^exercises/(practice|concept)/[^/]+/.+\.java$' | \
+  cut -d/ -f1-3 | sort -u)
+
+if [ -z "$changed_exercises" ]; then
+  echo "No relevant exercises changed, skipping linting."
+  exit 0
+fi
+
+# Print exercises
+echo "Changed exercises detected:"
+echo "$changed_exercises"
+echo "----------------------------------------"
+
+# Run lint checks
+exit_code=0
+for dir in $changed_exercises; do
+  slug=$(basename "$dir")
+
+  echo "========================================"
+  echo "=== Running checkstyle for $slug ==="
+  echo "========================================"
+
+  if [[ $dir == exercises/practice/* ]]; then
+    ./exercises/gradlew -p exercises ":practice:$slug:check" --exclude-task test || exit_code=1
+  elif [[ $dir == exercises/concept/* ]]; then
+    ./exercises/gradlew -p exercises ":concept:$slug:check" --exclude-task test || exit_code=1
+  fi
+done
+
+exit $exit_code


### PR DESCRIPTION
# Pull Request

We previously added `test-changed` to avoid the waiting time required to run tests on all exercises when only a few, or even just one, exercise was changed.

Even though linting took much less time than testing, there was still room to save around one minute per PR using this approach. I've tested it on my fork.

The working is analogous to the `test-changed` task, except this skips the result archive part.

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
