### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/affine-cipher/.docs/instructions.append.md
+++ b/exercises/practice/affine-cipher/.docs/instructions.append.md
@@ -1,4 +1,6 @@
 # Instructions append
 
+## Implementation
+
 Please notice that the `%` operator is not equivalent to the one described in the problem description
 ([see Wikipedia entry for Modulo operation](https://en.wikipedia.org/wiki/Modulo_operation)).

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 The anagrams can be returned in any order.

--- a/exercises/practice/armstrong-numbers/.docs/instructions.append.md
+++ b/exercises/practice/armstrong-numbers/.docs/instructions.append.md
@@ -1,4 +1,6 @@
 # Instructions append
 
+## Implementation
+
 For more help on how to solve this exercise, please refer to the tutorial provided as part of the hello world exercise:
 [instructions.append.md](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)

--- a/exercises/practice/bank-account/.docs/instructions.append.md
+++ b/exercises/practice/bank-account/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 This exercise introduces [concurrency][oracle-docs-concurrency].
 To pass the last test you might find the [`synchronized` keyword or locks][oracle-docs-synchronized] useful.
 

--- a/exercises/practice/clock/.docs/instructions.append.md
+++ b/exercises/practice/clock/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 In order to satisfy the requirement that two clocks are considered equal just when they are set to the same time, you will need to override the [`equals`](https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#equals(java.lang.Object)) and [`hashcode`](https://docs.oracle.com/javase/8/docs/api/java/lang/Object.html#hashCode) methods in your `Clock` class.
 
 For more information on how to override these methods, see [this JavaWorld article](https://web.archive.org/web/20170528222153/http://www.javaworld.com/article/2072762/java-app-dev/object-equality.html).

--- a/exercises/practice/diffie-hellman/.docs/instructions.append.md
+++ b/exercises/practice/diffie-hellman/.docs/instructions.append.md
@@ -1,5 +1,3 @@
-# Instructions append
-
-## Hints
+# Hints
 This exercise requires you to perform calculations on large numbers. To correctly represent large numbers, the
 [BigInteger](https://docs.oracle.com/javase/8/docs/api/java/math/BigInteger.html) class is used.

--- a/exercises/practice/diffie-hellman/.docs/instructions.append.md
+++ b/exercises/practice/diffie-hellman/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 This exercise requires you to perform calculations on large numbers. To correctly represent large numbers, the
 [BigInteger](https://docs.oracle.com/javase/8/docs/api/java/math/BigInteger.html) class is used.

--- a/exercises/practice/dot-dsl/.docs/instructions.append.md
+++ b/exercises/practice/dot-dsl/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 The graph is represented in the DSL by the `Graph` class.
 The implementation for the nodes and edges (represented by the `Node` and `Edge` classes respectively) are provided.
 

--- a/exercises/practice/flatten-array/.docs/instructions.append.md
+++ b/exercises/practice/flatten-array/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 For the Java track, the input will be provided as a `List` instead of an array, and the output should also be a `List`.

--- a/exercises/practice/hamming/.docs/instructions.append.md
+++ b/exercises/practice/hamming/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This is the first exercise with tests that require you to throw an [`Exception`][exception-docs].
 `Exception`s are typically thrown to indicate that a program has encountered an unexpected input or state.

--- a/exercises/practice/hangman/.docs/instructions.append.md
+++ b/exercises/practice/hangman/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 One main aspect of Functional Programming is to have side-effect free functions, not to have to wonder that hidden objects a function has changed.  
 

--- a/exercises/practice/intergalactic-transmission/.docs/instructions.append.md
+++ b/exercises/practice/intergalactic-transmission/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 Although we're dealing with bytes of data, the inputs and outputs are `List<Integer>` (instead of `byte[]`) to avoid the need to cast or convert negative values for bytes 128 to 255.

--- a/exercises/practice/isogram/.docs/instructions.append.md
+++ b/exercises/practice/isogram/.docs/instructions.append.md
@@ -1,1 +1,0 @@
-# Instructions append

--- a/exercises/practice/leap/.docs/instructions.append.md
+++ b/exercises/practice/leap/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 Before you start, make sure you understand how to write code that can pass the test cases.
 For more context, check out this [tutorial].
 

--- a/exercises/practice/linked-list/.docs/instructions.append.md
+++ b/exercises/practice/linked-list/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 This exercise introduces [generics](https://docs.oracle.com/javase/tutorial/java/generics/index.html).
 To make the tests pass you need to construct your class such that it accepts any type of input, e.g. `Integer` or `String`.
 

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Hints
+# Instructions append
+
+## Hints
 
 In Java it's considered best practice to use instance methods over class methods. However, there are conditions in which it is absolutely appropriate for a function to be `static`. Since classes in Java are closed for modification (i.e. you cannot add members to a class outside its definition like you can in other languages like Ruby or JavaScript), you cannot add new behavior to the class directly. What to do if you still want to define behavior for a given type? The idiomatic solution in this case is to write a utility method.
 Collections of these kinds of methods are often referred to as "utility classes". Examples of such classes from within the JRE include [Arrays](https://docs.oracle.com/javase/9/docs/api/java/util/Arrays.html) and [Collections](https://docs.oracle.com/javase/9/docs/api/java/util/Collections.html).

--- a/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
+++ b/exercises/practice/parallel-letter-frequency/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 As a stretch goal, consider if your implementation will work for characters with [diacritics or accents](https://en.wikipedia.org/wiki/Diacritic). For example, such solutions should not consider e and ë the same character. An example text for this case is [Wilhelmus](https://en.wikipedia.org/wiki/Wilhelmus), the Dutch national anthem.

--- a/exercises/practice/reverse-string/.docs/instructions.append.md
+++ b/exercises/practice/reverse-string/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
+## Implementation
+
 For more help on how to solve this exercise, please refer to the tutorial provided as part of the [hello world](https://exercism.org/tracks/java/exercises/hello-world) exercise.

--- a/exercises/practice/rna-transcription/.docs/instructions.append.md
+++ b/exercises/practice/rna-transcription/.docs/instructions.append.md
@@ -1,4 +1,6 @@
 # Instructions append
 
+## Implementation
+
 For more help on how to solve this exercise, please refer to the tutorial provided as part of the hello world exercise:
 [instructions.append.md](https://github.com/exercism/java/blob/main/exercises/practice/hello-world/.docs/instructions.append.md#tutorial)

--- a/exercises/practice/square-root/.docs/instructions.append.md
+++ b/exercises/practice/square-root/.docs/instructions.append.md
@@ -1,4 +1,6 @@
-# Instructions (appended)
+# Instructions append
+
+## Implementation
 
 The goal of this exercise is to practice working with numbers, so stay away
 from `java.lang.Math`!

--- a/exercises/practice/two-fer/.docs/instructions.append.md
+++ b/exercises/practice/two-fer/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 Before you start, make sure you understand how to write code that can pass the test cases.
 For more context, check out this [tutorial].
 


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.