### PR TITLE
swift scheduling: add missing Q2 test case

### DIFF
--- a/exercises/practice/swift-scheduling/.meta/tests.toml
+++ b/exercises/practice/swift-scheduling/.meta/tests.toml
@@ -56,3 +56,6 @@ description = "Q4 in the second quarter translates to the last workday of the fo
 
 [c920886c-44ad-4d34-a156-dc4176186581]
 description = "Q3 in the fourth quarter translates to the last workday of the third quarter of next year"
+
+[7c8f1616-be62-417e-bbd5-a60fa743eccc]
+description = "Q2 starting in the last month of the second quarter translates to the last workday of the second quarter of this year"

--- a/exercises/practice/swift-scheduling/src/test/java/SwiftSchedulingTest.java
+++ b/exercises/practice/swift-scheduling/src/test/java/SwiftSchedulingTest.java
@@ -199,4 +199,18 @@ class SwiftSchedulingTest {
 
         assertThat(actual).isEqualTo(expected);
     }
+
+    @Disabled("Remove to run test")
+    @Test
+    @DisplayName(
+        "Q2 starting in the last month of the second quarter translates to the last workday of the second quarter of this year"
+    )
+    void testQ2InQ2() {
+        LocalDateTime meetingStart = LocalDateTime.parse("2019-06-15T09:50:00");
+        LocalDateTime expected = LocalDateTime.parse("2019-06-28T08:00:00");
+
+        LocalDateTime actual = SwiftScheduling.convertToDeliveryDate(meetingStart, "Q2");
+
+        assertThat(actual).isEqualTo(expected);
+    }
 }


### PR DESCRIPTION
## Summary

Add the missing test case for the swift scheduling exercise from problem specifications. The new test covers a Q2 delivery that starts in the last month of the second quarter and expects the last workday of the second quarter of this year.

## Changes

- Sync the tests toml file with the canonical data using configlet
- Add the corresponding JUnit test to the exercise test suite

## Verification

- Configlet sync reports the exercise has up to date tests
- The exercise test task passes all 17 tests, including the new case

Closes #3158
