### PR TITLE
test(bob): add missing shouting question mark test case

### DIFF
--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -18,6 +18,9 @@ description = "shouting"
 [d6c98afd-df35-4806-b55e-2c457c3ab748]
 description = "shouting gibberish"
 
+[3c954328-86fb-4c71-8961-e18d6a5e2517]
+description = "shouting a statement containing a question mark"
+
 [8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
 description = "asking a question"
 

--- a/exercises/practice/bob/src/test/java/BobTest.java
+++ b/exercises/practice/bob/src/test/java/BobTest.java
@@ -39,6 +39,14 @@ public class BobTest {
 
     @Disabled("Remove to run test")
     @Test
+    @DisplayName("shouting a statement containing a question mark")
+    public void shoutingAStatementContainingQuestionMark() {
+        assertThat(bob.hey("DO LIONS EAT PEOPLE? AHHHHH."))
+                .isEqualTo("Whoa, chill out!");
+    }
+
+    @Disabled("Remove to run test")
+    @Test
     @DisplayName("asking a question")
     public void askingAQuestion() {
         assertThat(bob.hey("Does this cryogenic chamber make me look fat?"))


### PR DESCRIPTION
# Pull Request

Adds the missing test case from problem-specifications for the `bob` exercise.

The new test covers shouting a statement that contains a question mark
(UUID `3c954328-86fb-4c71-8961-e18d6a5e2517`).

Closes https://github.com/exercism/java/issues/3149

---

Reviewer Resources:

[Track Policies](https://github.com/exercism/java/blob/main/POLICIES.md#event-checklist)
